### PR TITLE
Fixed: Changing data directory in GUI did not take effect if a record…

### DIFF
--- a/Builds/VisualStudio2013/Plugins/EventBroadcaster/EventBroadcaster.vcxproj
+++ b/Builds/VisualStudio2013/Plugins/EventBroadcaster/EventBroadcaster.vcxproj
@@ -130,7 +130,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>..\..\x64\Debug64\bin;../../../../Resources/windows-libs/ZeroMQ/lib_x64</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\x64\Release64\bin;../../../../Resources/windows-libs/ZeroMQ/lib_x64</AdditionalLibraryDirectories>
       <AdditionalDependencies>libzmq-v120-mt-4_0_4.lib;open-ephys.lib;setupapi.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -113,7 +113,7 @@ void RecordNode::filenameComponentChanged(FilenameComponent* fnc)
 {
 
     dataDirectory = fnc->getCurrentFile();
-
+	newDirectoryNeeded = true;
 
 }
 


### PR DESCRIPTION
…ing had been started (and stopped) before. Only the first directory before the first recording was used. Fixed: EventBroadcaster was linking to Debug version of open-ephys.lib in Release mode