### PR TITLE
A better VisualizerEditor (deprecate buttonCallback)

### DIFF
--- a/Source/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.cpp
+++ b/Source/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.cpp
@@ -211,7 +211,7 @@ void SpikeDisplayEditor::stopRecording()
 
 // }
 
-void SpikeDisplayEditor::buttonCallback(Button* button)
+void SpikeDisplayEditor::buttonEvent(Button* button)
 {
     //std::cout<<"Got event from component:"<<button<<std::endl;
 

--- a/Source/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.h
+++ b/Source/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayEditor.h
@@ -48,7 +48,7 @@ public:
     SpikeDisplayEditor(GenericProcessor*);
     ~SpikeDisplayEditor();
 
-    void buttonCallback(Button* button);
+    void buttonEvent(Button* button);
 
     void startRecording();
     void stopRecording();

--- a/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -48,7 +48,8 @@ Visualizer* LfpDisplayEditor::createNewCanvas()
 
 }
 
-void LfpDisplayEditor::buttonCallback(Button* button)
+// not really being used (yet) ...
+void LfpDisplayEditor::buttonEvent(Button* button)
 {
 
     int gId = button->getRadioGroupId();

--- a/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.h
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.h
@@ -44,7 +44,8 @@ public:
     LfpDisplayEditor(GenericProcessor*, bool useDefaultParameterEditors);
     ~LfpDisplayEditor();
 
-    void buttonCallback(Button* button);
+    // not really being used (yet) ...
+    void buttonEvent(Button* button);
 
     Visualizer* createNewCanvas();
 

--- a/Source/Plugins/LfpDisplayNodeBeta/LfpDisplayEditor.cpp
+++ b/Source/Plugins/LfpDisplayNodeBeta/LfpDisplayEditor.cpp
@@ -50,11 +50,12 @@ Visualizer* LfpDisplayEditor::createNewCanvas()
 
 }
 
-void LfpDisplayEditor::buttonCallback(Button* button)
+// not really being used (yet)...
+void LfpDisplayEditor::buttonEvent(Button* button)
 {
 
     int gId = button->getRadioGroupId();
-
+    std::cout<<"sfwef\n";
     if (gId > 0)
     {
         if (canvas != 0)

--- a/Source/Plugins/LfpDisplayNodeBeta/LfpDisplayEditor.h
+++ b/Source/Plugins/LfpDisplayNodeBeta/LfpDisplayEditor.h
@@ -51,7 +51,8 @@ public:
     LfpDisplayEditor(GenericProcessor*, bool useDefaultParameterEditors);
     ~LfpDisplayEditor();
 
-    void buttonCallback(Button* button);
+    // not really being used (yet) ...
+    void buttonEvent(Button* button);
 
     Visualizer* createNewCanvas();
 

--- a/Source/Plugins/LfpTriggeredAverageNode/LfpTriggeredAverageEditor.cpp
+++ b/Source/Plugins/LfpTriggeredAverageNode/LfpTriggeredAverageEditor.cpp
@@ -47,7 +47,8 @@ Visualizer* LfpTriggeredAverageEditor::createNewCanvas()
 
 }
 
-void LfpTriggeredAverageEditor::buttonCallback(Button* button)
+// not really being used (yet) ...
+void LfpTriggeredAverageEditor::buttonEvent(Button* button)
 {
 
     int gId = button->getRadioGroupId();

--- a/Source/Plugins/LfpTriggeredAverageNode/LfpTriggeredAverageEditor.h
+++ b/Source/Plugins/LfpTriggeredAverageNode/LfpTriggeredAverageEditor.h
@@ -49,7 +49,8 @@ public:
     LfpTriggeredAverageEditor(GenericProcessor*, bool useDefaultParameterEditors);
     ~LfpTriggeredAverageEditor();
 
-    void buttonCallback(Button* button);
+    // not really being used (yet) ...
+    void buttonEvent(Button* button);
 
     Visualizer* createNewCanvas();
 

--- a/Source/Plugins/PCIeRhythm/RHD2000Editor.cpp
+++ b/Source/Plugins/PCIeRhythm/RHD2000Editor.cpp
@@ -858,10 +858,12 @@ void RHD2000Editor::buttonEvent(Button* button)
 	{
 		board->enableBoardLeds(button->getToggleState());
 	}
+    /*
 	else
 	{
 		VisualizerEditor::buttonEvent(button);
 	}
+    */
 
 }
 

--- a/Source/Plugins/SpikeSorter/SpikeSorterEditor.cpp
+++ b/Source/Plugins/SpikeSorter/SpikeSorterEditor.cpp
@@ -229,7 +229,7 @@ void SpikeSorterEditor::sliderEvent(Slider* slider)
 
 void SpikeSorterEditor::buttonEvent(Button* button)
 {
-    VisualizerEditor::buttonEvent(button);
+    //VisualizerEditor::buttonEvent(button);
     SpikeSorter* processor = (SpikeSorter*) getProcessor();
 
     if (electrodeButtons.contains((ElectrodeButton*) button))

--- a/Source/Processors/DataThreads/RhythmNode/RHD2000Editor.cpp
+++ b/Source/Processors/DataThreads/RhythmNode/RHD2000Editor.cpp
@@ -860,10 +860,12 @@ void RHD2000Editor::buttonEvent(Button* button)
 	{
 		board->enableBoardLeds(button->getToggleState());
 	}
+    /*
 	else
 	{
 		VisualizerEditor::buttonEvent(button);
 	}
+    */
 
 }
 

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -121,8 +121,8 @@ VisualizerEditor::~VisualizerEditor()
 
 }
 
-// All addition buttons inside the VisualizerEditor should use this callback instead of buttonEvent()
-void VisualizerEditor::buttonCallback(Button* button) {}
+// All additional buttons inside the VisualizerEditor should use this instead of buttonClicked()
+void VisualizerEditor::buttonEvent(Button* button) {}
 
 void VisualizerEditor::enable()
 {
@@ -161,9 +161,16 @@ void VisualizerEditor::editorWasClicked()
 }
 
 // This method is used to open the visualizer in a tab or window; do not use for sub-classes of VisualizerEditor
-void VisualizerEditor::buttonEvent(Button* button)
+// Use VisualizerEditor::buttonEvent instead
+void VisualizerEditor::buttonClicked(Button* button)
 {
+    // To handle default buttons, like the Channel Selector Drawer.
+    GenericEditor::buttonClicked(button);
 
+    // I think this must also be removed. If the user wants to keep buttons which send parameters to
+    // the canvas, it will be conceptually easier for him to handle everything on his/her own -- in
+    // the buttonEvent method. Implementing this half interface is actually confusing (for a newbie
+    // atleast)
     int gId = button->getRadioGroupId();
 
     if (gId > 0)
@@ -176,7 +183,7 @@ void VisualizerEditor::buttonEvent(Button* button)
     }
     else
     {
-
+        // handling the canvas "SelectorButtons" -- the ones which open the canvas.
         if (canvas == nullptr)
         {
 
@@ -251,8 +258,11 @@ void VisualizerEditor::buttonEvent(Button* button)
 
     }
 
-    buttonCallback(button);
+    // Pass the button event along to subclasses.
+    buttonEvent(button);
 
+    /* This is no longer needed I think, because it is handled in the GenericEditor::buttonClicked method. */
+    /*
     if (button == drawerButton)
     {
         std::cout<<"Drawer button clicked"<<std::endl;
@@ -260,7 +270,7 @@ void VisualizerEditor::buttonEvent(Button* button)
         tabSelector->setBounds(desiredWidth - 20,7,15,10);
 
     }
-
+    */
 }
 
 void VisualizerEditor::saveCustomParameters(XmlElement* xml)

--- a/Source/Processors/Editors/VisualizerEditor.h
+++ b/Source/Processors/Editors/VisualizerEditor.h
@@ -52,26 +52,53 @@ private:
 
 
 /**
-
+  @brief
   Base class for creating editors with visualizers.
-
+  
+  @details
+  Automatically adds buttons (and their handlers) which open the canvas in a window or
+  a tab. Just like any other editor, do not override VisualizerEditor::buttonClicked.
   @see GenericEditor, Visualizer
-
+  
+  If you must add buttons to your editor, handle them by overiding VisualizerEditor::buttonEvent
+  @sa         RHD2000Editor, PCIeRhythm::RHD2000Editor
 */
 
 class PLUGIN_API VisualizerEditor : public GenericEditor
 {
 public:
-    VisualizerEditor(GenericProcessor*, int, bool useDefaultParameterEditors);
-    VisualizerEditor(GenericProcessor*, bool useDefaultParameterEditors);
+    /**
+     * @brief      Prefer this constructor to properly "size" the editor widget.
+     * @details    Unlike other editors, setting GenericEditor::desiredWidth
+     * @code{cpp}
+     *   desiredWidth = <width-that-you-need>;
+     * @endcode
+     * will not work.
+     *
+     * @param      processor                   The processor
+     * @param[in]  desired_width               The desired width
+     * @param[in]  useDefaultParameterEditors  ``true`` if you want a _default_ editor.
+     */
+    VisualizerEditor(GenericProcessor* processor, int desired_width, bool useDefaultParameterEditors);
+
+    VisualizerEditor(GenericProcessor* processor, bool useDefaultParameterEditors);
     ~VisualizerEditor();
 
-	// WARNING: This method is used to open the visualizer in a tab or window; do not use for sub-classes of VisualizerEditor
-    void buttonEvent(Button* button);
+	/**
+     * @brief      This method handles the button evnets which open visualizer in a tab or window.
+     * @warning    Do not override this function unless you call ``VisualizerEditor::buttonClicked``
+     *             somewhere!
+     */
+    void buttonClicked(Button* button);
 	
-	// All addition buttons inside the VisualizerEditor should use this callback instead of buttonEvent()
-	virtual void buttonCallback(Button* button);
+	/**
+     * @brief      All additional buttons that you create _for the editor_ should be handled here.
+     */
+	virtual void buttonEvent(Button* button);
 
+    /**
+     * @brief      Creates a new canvas. This is like a factory method and must be defined in your sub-class.
+     */
     virtual Visualizer* createNewCanvas() = 0;
 
     virtual void enable();

--- a/Source/Processors/PSTH/PeriStimulusTimeHistogramEditor.cpp
+++ b/Source/Processors/PSTH/PeriStimulusTimeHistogramEditor.cpp
@@ -262,7 +262,7 @@ void PeriStimulusTimeHistogramEditor::visualizationMenu()
 
 void PeriStimulusTimeHistogramEditor::buttonEvent(Button* button)
 {
-    VisualizerEditor::buttonEvent(button);
+    //VisualizerEditor::buttonEvent(button);
     if (periStimulusTimeHistogramCanvas == nullptr)
         return;
 


### PR DESCRIPTION
* Added docs for the `VisualizerEditor` class. Override only `buttonEvent` _(as for other non-visual editors)_
* Started fixing other editors, a lot of redundant code can be removed.
* See comments in `VisualEditor.cpp`