### PR TITLE
[VisualizerEditor] Helpers to override `buttonClicked` added.

### DIFF
--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -149,6 +149,11 @@ void VisualizerEditor::updateVisualizer()
 
 }
 
+void VisualizerEditor::windowClosed()
+{
+
+}
+
 void VisualizerEditor::editorWasClicked()
 {
 
@@ -191,8 +196,8 @@ void VisualizerEditor::buttonClicked(Button* button)
 
         if (dataWindow == nullptr) // have we created a window already?
         {
-            // dataWindow = new DataWindow(windowSelector, tabText);
-            makeNewWindow();
+            // enable windowClosed() callback
+            makeNewWindow(true);
             dataWindow->setContentNonOwned(canvas, false);
             dataWindow->setVisible(true);
             //canvas->refreshState();
@@ -314,9 +319,14 @@ void VisualizerEditor::loadCustomParameters(XmlElement* xml)
     }
 }
 
-void VisualizerEditor::makeNewWindow()
+void VisualizerEditor::makeNewWindow(bool enableCallback)
 {
-    dataWindow = new DataWindow(windowSelector, tabText);
+    if (enableCallback)
+        // used by CyclopsEditor to consistently update windowSelector buttons
+        // even when window is closed.
+        dataWindow = new DataWindow(windowSelector, this, tabText);
+    else
+        dataWindow = new DataWindow(windowSelector, tabText);
 }
 
 Component* VisualizerEditor::getActiveTabContentComponent() const

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -116,6 +116,8 @@ VisualizerEditor::~VisualizerEditor()
     {
         AccessClass::getDataViewport()->destroyTab(tabIndex);
     }
+    if (dataWindow != nullptr)
+        dataWindow->removeListener(this);
 
     deleteAllChildren();
 
@@ -196,10 +198,11 @@ void VisualizerEditor::buttonClicked(Button* button)
 
         if (dataWindow == nullptr) // have we created a window already?
         {
-            // enable windowClosed() callback
-            makeNewWindow(true);
+            makeNewWindow();
             dataWindow->setContentNonOwned(canvas, false);
             dataWindow->setVisible(true);
+            // enable windowClosed() callback
+            dataWindow->addListener(this);
             //canvas->refreshState();
 
         }
@@ -319,14 +322,23 @@ void VisualizerEditor::loadCustomParameters(XmlElement* xml)
     }
 }
 
-void VisualizerEditor::makeNewWindow(bool enableCallback)
+void VisualizerEditor::makeNewWindow()
 {
-    if (enableCallback)
-        // used by CyclopsEditor to consistently update windowSelector buttons
-        // even when window is closed.
-        dataWindow = new DataWindow(windowSelector, this, tabText);
-    else
-        dataWindow = new DataWindow(windowSelector, tabText);
+    dataWindow = new DataWindow(windowSelector, tabText);
+}
+
+void VisualizerEditor::addWindowListener(DataWindow* dw, DataWindow::Listener* newListener) /* static method */
+{
+    if (dw != nullptr && newListener != nullptr){
+        dw->addListener(newListener);
+    }
+}
+
+void VisualizerEditor::removeWindowListener(DataWindow* dw, DataWindow::Listener* oldListener) /* static method */
+{
+    if (dw != nullptr && oldListener != nullptr){
+        dw->removeListener(oldListener);
+    }
 }
 
 Component* VisualizerEditor::getActiveTabContentComponent() const

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -114,7 +114,7 @@ VisualizerEditor::~VisualizerEditor()
 
     if (tabIndex > -1)
     {
-		AccessClass::getDataViewport()->destroyTab(tabIndex);
+        AccessClass::getDataViewport()->destroyTab(tabIndex);
     }
 
     deleteAllChildren();
@@ -155,7 +155,7 @@ void VisualizerEditor::editorWasClicked()
     if (tabIndex > -1)
     {
         std::cout << "Setting tab index to " << tabIndex << std::endl;
-		AccessClass::getDataViewport()->selectTab(tabIndex);
+        AccessClass::getDataViewport()->selectTab(tabIndex);
     }
 
 }
@@ -184,14 +184,15 @@ void VisualizerEditor::buttonClicked(Button* button)
         if (tabSelector->getToggleState() && windowSelector->getToggleState())
         {
             tabSelector->setToggleState(false, dontSendNotification);
-			AccessClass::getDataViewport()->destroyTab(tabIndex);
-            tabIndex = -1;
+            // AccessClass::getDataViewport()->destroyTab(tabIndex);
+            // tabIndex = -1;
+            removeTab(tabIndex);
         }
 
         if (dataWindow == nullptr) // have we created a window already?
         {
-
-            dataWindow = new DataWindow(windowSelector, tabText);
+            // dataWindow = new DataWindow(windowSelector, tabText);
+            makeNewWindow();
             dataWindow->setContentNonOwned(canvas, false);
             dataWindow->setVisible(true);
             //canvas->refreshState();
@@ -228,15 +229,15 @@ void VisualizerEditor::buttonClicked(Button* button)
                 dataWindow->setVisible(false);
             }
 
-			tabIndex = AccessClass::getDataViewport()->addTabToDataViewport(tabText, canvas, this);
-
+            // tabIndex = AccessClass::getDataViewport()->addTabToDataViewport(tabText, canvas, this);
+            addTab(tabText, canvas);
 
         }
         else if (!tabSelector->getToggleState() && tabIndex > -1)
         {
-			AccessClass::getDataViewport()->destroyTab(tabIndex);
-            tabIndex = -1;
-
+            // AccessClass::getDataViewport()->destroyTab(tabIndex);
+            // tabIndex = -1;
+            removeTab(tabIndex);
         }
     }
 
@@ -313,6 +314,32 @@ void VisualizerEditor::loadCustomParameters(XmlElement* xml)
     }
 }
 
+void VisualizerEditor::makeNewWindow()
+{
+    dataWindow = new DataWindow(windowSelector, tabText);
+}
+
+Component* VisualizerEditor::getActiveTabContentComponent() const
+{
+    return AccessClass::getDataViewport()->getCurrentContentComponent();
+}
+
+void VisualizerEditor::setActiveTabId(int tindex)
+{
+    AccessClass::getDataViewport()->selectTab(tindex);
+}
+
+void VisualizerEditor::removeTab(int tindex)
+{
+    AccessClass::getDataViewport()->destroyTab(tindex);
+    tabIndex = -1;
+}
+
+int VisualizerEditor::addTab(String tab_text, Visualizer* vis_canvas)
+{
+    tabIndex = AccessClass::getDataViewport()->addTabToDataViewport(tab_text, vis_canvas, this);
+    return tabIndex;
+}
 
 void VisualizerEditor::saveVisualizerParameters(XmlElement* xml)
 {

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -337,6 +337,7 @@ void VisualizerEditor::removeTab(int tindex)
 
 int VisualizerEditor::addTab(String tab_text, Visualizer* vis_canvas)
 {
+    tabText = tab_text;
     tabIndex = AccessClass::getDataViewport()->addTabToDataViewport(tab_text, vis_canvas, this);
     return tabIndex;
 }

--- a/Source/Processors/Editors/VisualizerEditor.h
+++ b/Source/Processors/Editors/VisualizerEditor.h
@@ -65,6 +65,7 @@ private:
 */
 
 class PLUGIN_API VisualizerEditor : public GenericEditor
+                                  , public DataWindow::Listener
 {
 public:
     /**
@@ -130,15 +131,32 @@ protected: // these should be available to sub-classes if needed.
      * @details    Use this to make a new DataWindow. If needed, you can
      *             transfer ownership of the new object from
      *             VisualizerEditor::dataWindow to _your_ own ScopedPointer.
-     *
-     * @param[in]  enableCallbacks  **When** ``true``, it passes "``this``" to
-     *                              constructor of the DataWindow and
-     *                              VisualizerEditor::windowClosed() is invoked
-     *                              when window is closed. **When** ``false``,
-     *                              ``this`` is not passed and callback does not
-     *                              happen.
+     * @note       This method provides an interface to DataWindow, DataWindow
+     *             methods cannot be defined in derivations (ie, plugins).
      */
-    void makeNewWindow(bool enableCallbacks = false);
+    void makeNewWindow();
+
+    /**
+     * @brief      Adds a closeWindow listener for dw.
+     *
+     * @param      dw           The datawindow
+     * @param      newListener  The new listener
+     * 
+     * @note       This method provides an interface to DataWindow, DataWindow
+     *             methods cannot be defined in derivations (ie, plugins).
+     */
+    static void addWindowListener(DataWindow* dw, DataWindow::Listener* newListener);
+
+    /**
+     * @brief      Removes a closeWindow listener for dw.
+     *
+     * @param      dw           The datawindow
+     * @param      oldListener  The old listener
+     *
+     * @note       This method provides an interface to DataWindow, DataWindow
+     *             methods cannot be defined in derivations (ie, plugins).
+     */
+    static void removeWindowListener(DataWindow* dw, DataWindow::Listener* oldListener);
 
     /**
      * @brief      Use this to efficiently compare or find what is on the

--- a/Source/Processors/Editors/VisualizerEditor.h
+++ b/Source/Processors/Editors/VisualizerEditor.h
@@ -84,17 +84,17 @@ public:
     VisualizerEditor(GenericProcessor* processor, bool useDefaultParameterEditors);
     ~VisualizerEditor();
 
-	/**
+    /**
      * @brief      This method handles the button evnets which open visualizer in a tab or window.
      * @warning    Do not override this function unless you call ``VisualizerEditor::buttonClicked``
      *             somewhere!
      */
     void buttonClicked(Button* button);
-	
-	/**
+    
+    /**
      * @brief      All additional buttons that you create _for the editor_ should be handled here.
      */
-	virtual void buttonEvent(Button* button);
+    virtual void buttonEvent(Button* button);
 
     /**
      * @brief      Creates a new canvas. This is like a factory method and must be defined in your sub-class.
@@ -120,17 +120,60 @@ public:
 
     String tabText;
 
-private:
+protected: // these should be available to sub-classes if needed.
+    
+    /**
+     * @brief      Creates a new DataWindow using the windowSelector (button)
+     *             and ``tabText``. The new object is stored in (and owned by)
+     *             VisualizerEditor::dataWindow.
+     * @details    Use this to make a new DataWindow. If needed, you can
+     *             transfer ownership of the new object from
+     *             VisualizerEditor::dataWindow to _your_ own ScopedPointer.
+     */
+    void makeNewWindow();
 
-    void initializeSelectors();
-    bool isPlaying;
+    /**
+     * @brief      Use this to efficiently compare or find what is on the
+     *             currently active tab.
+     *
+     * @return     The active tab content Component.
+     */
+    Component* getActiveTabContentComponent() const;
 
+    /**
+     * @brief      Selects the specified _tab_ in the DataViewport.
+     *
+     * @param[in]  tindex  The index which was returned by VisualizerEditor::addTab
+     */
+    void setActiveTabId(int tindex);
+
+    /**
+     * @brief      Remove the specified tab from DataViewport.
+     *
+     * @param[in]  tindex  The index which was returned by VisualizerEditor::addTab
+     */
+    void removeTab(int tindex);
+
+    /**
+     * @brief      Adds a new tab to the DataViewport.
+     *
+     * @param[in]  tab_text    The tab text
+     * @param      vis_canvas  The content Visualizer (Canvas) Component for this tab.
+     *
+     * @return     The identifier token for this tab. You must provide this
+     *             identifier to access/remove this tab.
+     */
+    int addTab(String tab_text, Visualizer* vis_canvas);
+
+    bool isPlaying; /**< Acquisition status flag */
+
+    // So that we can override buttonClick. That's not possible if these are private.
     SelectorButton* windowSelector;
     SelectorButton* tabSelector;
 
+private:
+    void initializeSelectors();
     int tabIndex;
-
-
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(VisualizerEditor);
 

--- a/Source/Processors/Editors/VisualizerEditor.h
+++ b/Source/Processors/Editors/VisualizerEditor.h
@@ -107,6 +107,7 @@ public:
     void editorWasClicked();
 
     void updateVisualizer();
+    virtual void windowClosed();
 
     void saveCustomParameters(XmlElement* xml);
     void loadCustomParameters(XmlElement* xml);
@@ -129,8 +130,15 @@ protected: // these should be available to sub-classes if needed.
      * @details    Use this to make a new DataWindow. If needed, you can
      *             transfer ownership of the new object from
      *             VisualizerEditor::dataWindow to _your_ own ScopedPointer.
+     *
+     * @param[in]  enableCallbacks  **When** ``true``, it passes "``this``" to
+     *                              constructor of the DataWindow and
+     *                              VisualizerEditor::windowClosed() is invoked
+     *                              when window is closed. **When** ``false``,
+     *                              ``this`` is not passed and callback does not
+     *                              happen.
      */
-    void makeNewWindow();
+    void makeNewWindow(bool enableCallbacks = false);
 
     /**
      * @brief      Use this to efficiently compare or find what is on the

--- a/Source/Processors/Editors/VisualizerEditor.h
+++ b/Source/Processors/Editors/VisualizerEditor.h
@@ -196,10 +196,10 @@ protected: // these should be available to sub-classes if needed.
     // So that we can override buttonClick. That's not possible if these are private.
     SelectorButton* windowSelector;
     SelectorButton* tabSelector;
+    int tabIndex;
 
 private:
     void initializeSelectors();
-    int tabIndex;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(VisualizerEditor);
 

--- a/Source/Processors/Visualization/DataWindow.cpp
+++ b/Source/Processors/Visualization/DataWindow.cpp
@@ -27,13 +27,20 @@
 DataWindow::DataWindow(Button* cButton, String name)
     : DocumentWindow(name,
                      Colours::black,
-                     DocumentWindow::allButtons),
-    controlButton(cButton)
+                     DocumentWindow::allButtons)
+    , controlButton(cButton)
+    , vizEditor(nullptr)
 
 {
     centreWithSize(800,500);
     setUsingNativeTitleBar(true);
     setResizable(true,false);
+}
+
+DataWindow::DataWindow(Button* button, VisualizerEditor* editor, String name)
+    : DataWindow(button, name)
+{
+    vizEditor = editor;
 }
 
 DataWindow::~DataWindow()
@@ -46,4 +53,7 @@ void DataWindow::closeButtonPressed()
     setContentNonOwned(0,false);
     setVisible(false);
     controlButton->setToggleState(false,dontSendNotification);
+    if (vizEditor != nullptr){
+        dynamic_cast<VisualizerEditor*>(vizEditor)->windowClosed();
+    }
 }

--- a/Source/Processors/Visualization/DataWindow.h
+++ b/Source/Processors/Visualization/DataWindow.h
@@ -25,7 +25,6 @@
 #define __DATAWINDOW_H_FDDAB8D0__
 
 #include "../../../JuceLibraryCode/JuceHeader.h"
-#include "../Editors/VisualizerEditor.h"
 
 /**
 
@@ -35,21 +34,41 @@
 
 */
 
-class VisualizerEditor;
 class DataWindow : public DocumentWindow
 {
 public:
     DataWindow(Button* button, String name);
-    DataWindow(Button* button, VisualizerEditor* editor, String name);
     ~DataWindow();
-
+    
     void closeButtonPressed();
+    
+    class Listener
+    {
+    public:
+        /** Destructor. */
+        virtual ~Listener()  {}
+
+        /** Called when the window is closed. */
+        virtual void windowClosed () = 0;
+    };
+
+    /**
+     * @brief      Registers a listener to receive event when this is closed. If
+     *             the listener is already registered, this will not register it
+     *             again.
+     */
+    void addListener (Listener* newListener);
+
+    /**
+     * @brief      Removes a previously-registered DataWindow listener
+     */
+    void removeListener (Listener* listener);
 
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DataWindow);
 
     Button* controlButton;
-    VisualizerEditor* vizEditor;
+    ListenerList<Listener> closeWindowListeners;
 };
 
 

--- a/Source/Processors/Visualization/DataWindow.h
+++ b/Source/Processors/Visualization/DataWindow.h
@@ -25,6 +25,7 @@
 #define __DATAWINDOW_H_FDDAB8D0__
 
 #include "../../../JuceLibraryCode/JuceHeader.h"
+#include "../Editors/VisualizerEditor.h"
 
 /**
 
@@ -34,10 +35,12 @@
 
 */
 
+class VisualizerEditor;
 class DataWindow : public DocumentWindow
 {
 public:
     DataWindow(Button* button, String name);
+    DataWindow(Button* button, VisualizerEditor* editor, String name);
     ~DataWindow();
 
     void closeButtonPressed();
@@ -46,7 +49,7 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(DataWindow);
 
     Button* controlButton;
-
+    VisualizerEditor* vizEditor;
 };
 
 


### PR DESCRIPTION
These changes were made primarily to accommodate for the cyclops-stimulator. Since `buttonClicked` manipulates the `DataViewport` via `AccessClass`, a sub-class of `VisualizerEditor` cannot functionally override the method.
Hence:

* Added `protected` methods which manipulate `DataViewport` (via `AccessClass`)
* moved the SelectorButtons into `protected` area, essential!
* All of the additions _are_ essential to the cyclops-stimulator.
* There is NO change in the public interface.

Now, _my_ `buttonClicked` method can access the SelectorButtons, manipulate `DataViewport`.
Please remove the (new) comments from VisualizerEditor::buttonClicked (`.cpp`), they are not needed anymore.