### PR TITLE
Fix Julia path and flags in Makefile

### DIFF
--- a/Source/Plugins/JuliaProcessor/Makefile
+++ b/Source/Plugins/JuliaProcessor/Makefile
@@ -11,11 +11,15 @@ SRC := $(foreach sdir,$(SRC_DIR),$(wildcard $(sdir)/*.cpp))
 OBJ := $(addprefix $(OBJDIR)/,$(notdir $(SRC:.cpp=.o)))
 
 
-JULIA =  /home/jvoigts/Documents/Github/julia/
+JL_SHARE =  $(shell julia -e 'print(joinpath(JULIA_HOME,Base.DATAROOTDIR,"julia"))')
 
-# flags to compile "JuliaProcessor". $(JULIA): toplevel of julia package
-CXXFLAGS += -I $(JULIA)/src -I $(JULIA)/src/support -I $(JULIA)/usr/include
-LDFLAGS += -L $(JULIA)/usr/lib -Wl,-R $(JULIA)/usr/lib -ljulia
+# flags to compile "JuliaProcessor". $(JL_SHARE): toplevel of julia package
+#CXXFLAGS += -I $(JL_SHARE)/src -I $(JULIA)/src/support -I $(JULIA)/usr/include
+#LDFLAGS += -L $(JL_SHARE)/usr/lib -Wl,-R $(JULIA)/usr/lib -ljulia
+CFLAGS   += $(shell $(JL_SHARE)/julia-config.jl --cflags)
+CXXFLAGS += $(shell $(JL_SHARE)/julia-config.jl --cflags)
+LDFLAGS  += $(shell $(JL_SHARE)/julia-config.jl --ldflags)
+LDLIBS   += $(shell $(JL_SHARE)/julia-config.jl --ldlibs)
 
 BLDCMD := $(CXX) -shared -o $(OUTDIR)/$(TARGET) $(OBJ) $(LDFLAGS) $(RESOURCES) $(TARGET_ARCH)
 
@@ -33,7 +37,7 @@ $(OUTDIR)/$(TARGET): objdir $(OBJ)
 $(OBJDIR)/%.o : %.cpp
 	@echo "Compiling $<"
 	@$(CXX) $(CXXFLAGS) -o "$@" -c "$<"
-	
+
 objdir:
 	-@mkdir -p $(OBJDIR)
 


### PR DESCRIPTION
The Makefile of the JuliaProcessor plugin used
absolute file paths, which prevented compilation.
I have replaced the absolute path with a shell
macro as suggested by Julia's embedding
documentation.

Fixing this revealed a second problem: the linker
flags were incorrect. I have replaced the
offedning flag '-ljulia' with build flags
generated by julia, as per Julia's embedding docs.

See issue #80