### PR TITLE
Update ExampleProcessor.h

### DIFF
--- a/Source/Plugins/ExampleProcessor/ExampleProcessor.h
+++ b/Source/Plugins/ExampleProcessor/ExampleProcessor.h
@@ -50,7 +50,7 @@ public:
     ExampleProcessor();
 
     /** The class destructor, used to deallocate memory */
-    ~ExampleProcessor();
+    ~ExampleProcessor(){};
 
     /** Determines whether the processor is treated as a source. */
     bool isSource()


### PR DESCRIPTION
To fix error during running open-ephys

Loading Plugin: ExampleProcessor ... ../../Source/Processors/PluginManager/PluginManager.cpp:177: Failed to load plugin DLL: /home/username/plugin-GUI/Builds/Linux/build/plugins/ExampleProcessor.so: undefined symbol: _ZTV19ExampleProcessorEditor
 DLL Load FAILED