### PR TITLE
add pre-build action to create Env.xcconfig if it doesn't exist

### DIFF
--- a/Builds/MacOSX/OpenEphys.xcworkspace/xcshareddata/xcschemes/All.xcscheme
+++ b/Builds/MacOSX/OpenEphys.xcworkspace/xcshareddata/xcschemes/All.xcscheme
@@ -1,10 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0720"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "#!/bin/bash&#10;cd $PROJECT_DIR/Plugins/Config&#10;if [[ ! -a Env.xcconfig ]]&#10;then&#10;touch Env.xcconfig&#10;fi"
+               shellToInvoke = "/bin/bash">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "62F40A2101C1715EE4F8C87B"
+                     BuildableName = "open-ephys.app"
+                     BlueprintName = "open-ephys (App)"
+                     ReferencedContainer = "container:open-ephys.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Builds/MacOSX/Plugins/Config/Plugin.xcconfig
+++ b/Builds/MacOSX/Plugins/Config/Plugin.xcconfig
@@ -3,7 +3,7 @@ JULIA_PATH = /Applications/Julia-0.5.app/Contents/Resources/julia
 MAC_PACKAGE_DIR = /opt/local
 
 // Pull in machine-specific settings from git-ignored file, if it exists.
-#include? "Env.xcconfig"
+#include "Env.xcconfig"
 
 ALWAYS_SEARCH_USER_PATHS = NO
 CLANG_ANALYZER_NONNULL = YES

--- a/Builds/MacOSX/open-ephys.xcodeproj/xcshareddata/xcschemes/open-ephys (App).xcscheme
+++ b/Builds/MacOSX/open-ephys.xcodeproj/xcshareddata/xcschemes/open-ephys (App).xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "#!/bin/bash&#10;cd $PROJECT_DIR/Plugins/Config&#10;if [[ ! -a Env.xcconfig ]]&#10;then&#10;touch Env.xcconfig&#10;fi"
+               shellToInvoke = "/bin/bash">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "62F40A2101C1715EE4F8C87B"
+                     BuildableName = "open-ephys.app"
+                     BlueprintName = "open-ephys (App)"
+                     ReferencedContainer = "container:open-ephys.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "62F40A2101C1715EE4F8C87B"
+               BuildableName = "open-ephys.app"
+               BlueprintName = "open-ephys (App)"
+               ReferencedContainer = "container:open-ephys.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "62F40A2101C1715EE4F8C87B"
+            BuildableName = "open-ephys.app"
+            BlueprintName = "open-ephys (App)"
+            ReferencedContainer = "container:open-ephys.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "62F40A2101C1715EE4F8C87B"
+            BuildableName = "open-ephys.app"
+            BlueprintName = "open-ephys (App)"
+            ReferencedContainer = "container:open-ephys.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "62F40A2101C1715EE4F8C87B"
+            BuildableName = "open-ephys.app"
+            BlueprintName = "open-ephys (App)"
+            ReferencedContainer = "container:open-ephys.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
See comment on ce0c3fb.

I've added a pre-build action to both xcode targets that creates Env.xcconfig if it doesn't exist. Also went from #include to #include?, since the latter is incompatible with versions of xcode <8.