### PR TITLE
splitter constructor doesn't set processor type, with fun consequences

### DIFF
--- a/Source/Processors/Merger/Merger.cpp
+++ b/Source/Processors/Merger/Merger.cpp
@@ -34,6 +34,7 @@ Merger::Merger()
       mergeEventsB(true), mergeContinuousB(true),
       sourceNodeA(0), sourceNodeB(0), activePath(0)
 {
+    setProcessorType(PROCESSOR_TYPE_MERGER);
     sendSampleCount = false;
 }
 

--- a/Source/Processors/Splitter/Splitter.cpp
+++ b/Source/Processors/Splitter/Splitter.cpp
@@ -30,6 +30,7 @@ Splitter::Splitter()
     : GenericProcessor("Splitter"),
       destNodeA(0), destNodeB(0), activePath(0)
 {
+    setProcessorType(PROCESSOR_TYPE_SPLITTER);
     sendSampleCount = false;
 }
 


### PR DESCRIPTION
Issues and repros:

Issue 1: Splitter view is now a game of three card monte.

Repro:

1) start a signal chan like so: rhythm fpga -> splitter -> lfp viewer (or anything) 

2) click on the other (lower) path of the splitter view

3) click on the upper path of the splitter view to re-display

Expected:

We see the lfp viewer signal chain view appear.

Observed:

We see nothing! The lfp viewer is still visible in the graph view, with a line between it and the splitter. We lose $20.

Issue 2: Dropping an item into second path of splitter "deletes" the splitters first connection

1) continuing after step 3 above, re-select the lower path

2) add a bandpass filter, another lfp viewer... whatever.

Expected:

We see a bandpass filter (or whatever) added to the signal chain and graph view. In the graph view, the splitter has two relationships: one with the lfp viewer, and one with the bandpass filter.

Observed:

In the graph view, though the lfp viewer remains and the bandpass filter (or whatever) appears, the line between the splitter and the lfp viewer disappears.

Fix... see the PR. In short, the splitter constructor was missing:

```c++
setProcessorType(PROCESSOR_TYPE_SPLITTER)
```

