### PR TITLE
Strip NULL when writing messages to file

### DIFF
--- a/Source/Plugins/BinaryWriter/BinaryRecording.cpp
+++ b/Source/Plugins/BinaryWriter/BinaryRecording.cpp
@@ -339,7 +339,7 @@ void BinaryRecording::writeMessage(const MidiMessage& event, int64 timestamp)
 	diskWriteLock.enter();
 	fwrite(timestampText.toUTF8(), 1, timestampText.length(), messageFile);
 	fwrite(" ", 1, 1, messageFile);
-	fwrite(dataptr, 1, msgLength, messageFile);
+	fwrite(dataptr, 1, msgLength-1, messageFile);
 	fwrite("\n", 1, 1, messageFile);
 	diskWriteLock.exit();
 

--- a/Source/Processors/RecordNode/OriginalRecording.cpp
+++ b/Source/Processors/RecordNode/OriginalRecording.cpp
@@ -403,7 +403,7 @@ void OriginalRecording::writeMessage(const MidiMessage& event, int64 timestamp)
     diskWriteLock.enter();
     fwrite(timestampText.toUTF8(),1,timestampText.length(),messageFile);
     fwrite(" ",1,1,messageFile);
-    fwrite(dataptr,1,msgLength,messageFile);
+    fwrite(dataptr,1,msgLength-1,messageFile);
     fwrite("\n",1,1,messageFile);
     diskWriteLock.exit();
 


### PR DESCRIPTION
It seems that all messages are UTF8 null-terminated strings, which is fine. But writing those NULL bytes to the messages file on disk isn't ideal in my opinion, because it unnecessarily makes those files unreadable in a text editor. For each message, this decrements the number of bytes written to disk by 1, effectively stripping the NULL byte, for both the original and binary recording engines. I've tested both, and the `.events` and `.eventsmessages` files (original and binary engines, respectively) are now viewable in a text editor.

I don't know if this is an issue with any of the other recording engines (KWIK, NWB), since they don't currently show up as an option for me.