### PR TITLE
Fix eventData size limit of 255 bytes

### DIFF
--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -750,7 +750,7 @@ void GenericProcessor::addEvent (MidiBuffer& eventBuffer,
                                  int sampleNum,
                                  uint8 eventId,
                                  uint8 eventChannel,
-                                 uint8 numBytes,
+                                 int numBytes,
                                  uint8* eventData,
                                  bool isTimestamp)
 {

--- a/Source/Processors/GenericProcessor/GenericProcessor.h
+++ b/Source/Processors/GenericProcessor/GenericProcessor.h
@@ -381,7 +381,7 @@ public:
                            int sampleNum,
                            uint8 eventID = 0,
                            uint8 eventChannel = 0,
-                           uint8 numBytes = 0,
+                           int numBytes = 0,
                            uint8* data = 0,
                            bool isTimestamp = false);
 


### PR DESCRIPTION
This fixes an overflow that could be easily triggered by sending a long message via the message center (bottom bar in the GUI), resulting in only some fraction of the message being written to the messages file. Note that this triggers a recompile of a bunch of (presumably dependent) modules. Not sure if changing the data type of numBytes from uint8 to int has some other knock-on effects that I'm unaware of. Seems to work, so far.