### PR TITLE
Update setup.sh to use new Makefile

### DIFF
--- a/Builds/Linux/setup.sh
+++ b/Builds/Linux/setup.sh
@@ -31,7 +31,7 @@ PROC_DIR=${BUILD_HOME%/*/*}
 make -j4
 
 if [ $? -eq 0 ]; then
-	sudo ln -s -f $BUILD_HOME/build/open-ephys /usr/bin/.
+	sudo ln -s -f $BUILD_HOME/build/open-ephys.so /usr/bin/open-ephys
 	echo "-----> GUI compile successful."
 else
 	echo "-----> GUI compile failed."

--- a/Builds/Linux/setup.sh
+++ b/Builds/Linux/setup.sh
@@ -39,23 +39,7 @@ else
 fi
 
 # Step 2: Compile plugins
-PLUGIN_SRC_DIR="${PROC_DIR}/Source/Processors"
-PLUGINS=`ls -d ${PLUGIN_SRC_DIR}/*`
-
-cd $PLUGIN_SRC_DIR
-for PLUGIN in ${PLUGINS}
-do
-	if [ -f $PLUGIN/Makefile ]; then
-		cd $PLUGIN
-		make clean
-		make
-		if [ $? -ne 0 ]; then
-			echo "-----> Plugin compile failed."
-			exit
-		fi
-		cd ..
-	fi
-done
+make -j4 -f Makefile.plugins
 
 if [ $? -eq 0 ]; then
 	echo "-----> Plugin installation sucessful."


### PR DESCRIPTION
These two simple patches are for the linux setup.sh script:
- Link the correct binary to ```/usr/bin``` 
- Use new ```Makefile.plugins``` to build plugins as described in the wiki