### PR TITLE
add destructor to ExampleEditor.cpp

### DIFF
--- a/Source/Plugins/ExampleProcessor/ExampleEditor.cpp
+++ b/Source/Plugins/ExampleProcessor/ExampleEditor.cpp
@@ -36,6 +36,12 @@ ExampleEditor::ExampleEditor(GenericProcessor* parentNode, bool useDefaultParame
 	addAndMakeVisible(exampleButton);
 }
 
+
+ExampleEditor::~ExampleEditor()
+{
+}
+
+
 /**
 The listener methods that reacts to the button click. The same method is called for all buttons
 on the editor, so the button variable, which cointains a pointer to the button that called the method


### PR DESCRIPTION
This is a followup to PR #101, because it doesn't look like that one got updated or merged. I had the same problem with being unable to load an example plugin, and I think this fixes it. Let me know if the destructor should actually do something in this example instead of being blank.