### PR TITLE
Make datestring in .continuous file headers fixed width

### DIFF
--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -221,7 +221,14 @@ String RecordNode::generateDateString() const
 
     String datestring;
 
-    datestring += String(calendar.getDayOfMonth());
+    int day;
+    day = calendar.getDayOfMonth();
+
+    if (day < 10)
+      datestring += 0;
+
+    datestring += day;
+
     datestring += "-";
     datestring += calendar.getMonthName(true);
     datestring += "-";
@@ -233,12 +240,18 @@ String RecordNode::generateDateString() const
     mins = calendar.getMinutes();
     secs = calendar.getSeconds();
 
+    if (hrs < 10)
+        datestring += 0;
+
     datestring += hrs;
 
     if (mins < 10)
         datestring += 0;
 
     datestring += mins;
+
+    if (secs < 10)
+        datestring += 0;
 
     if (secs < 0)
         datestring += 0;


### PR DESCRIPTION
As discussed in #129, the date_created field of .continuous file headers does
not have fixed width days of the month, hours, or seconds, which makes parsing
the header difficult and often ambiguous. I have changed the RecordNode class
to produce fixed width datestrings, which should fix this problem.

I was unable to compile with these changes, but the previous commit (226bfab)
won't compile for me either. However, I can make these changes to an earlier
commit and compile successfully.