### PR TITLE
Bugfix for FileReader plugin

### DIFF
--- a/Source/Processors/FileReader/FileReader.cpp
+++ b/Source/Processors/FileReader/FileReader.cpp
@@ -245,14 +245,14 @@ void FileReader::process (AudioSampleBuffer& buffer)
         {
             samplesToRead = stopSample - currentSample;
             if (samplesToRead > 0)
-                input->readData (readBuffer + samplesRead, samplesToRead);
+                input->readData (readBuffer + samplesRead * currentNumChannels, samplesToRead);
 
             input->seekTo (startSample);
             currentSample = startSample;
         }
         else
         {
-            input->readData (readBuffer + samplesRead, samplesToRead);
+            input->readData (readBuffer + samplesRead * currentNumChannels, samplesToRead);
 
             currentSample += samplesToRead;
         }


### PR DESCRIPTION
The FileReader produced glitches when it reached the end of the input buffer/file and restarted playback from the beginning. The issue is that during the write buffer address calculation the number of samples already read were not multiplied by the number of channels, and this way some proper data was overwritten whereas the end of the buffer was not updated.