### PR TITLE
Development

### DIFF
--- a/Source/Plugins/ChannelMappingNode/ChannelMappingEditor.h
+++ b/Source/Plugins/ChannelMappingNode/ChannelMappingEditor.h
@@ -63,8 +63,6 @@ public:
 
     void mouseDoubleClick(const MouseEvent& e);
 
-    void mouseWheelMove(const MouseEvent& event, const MouseWheelDetails& wheel);
-
     void collapsedStateChanged();
 
 	void startAcquisition();
@@ -88,10 +86,10 @@ private:
     ScopedPointer<ElectrodeEditorButton> selectAllButton;
     ScopedPointer<ElectrodeEditorButton> modifyButton;
     ScopedPointer<ElectrodeEditorButton> resetButton;
-    ScopedPointer<TriangleButton> upButton;
-    ScopedPointer<TriangleButton> downButton;
     ScopedPointer<LoadButton> loadButton;
     ScopedPointer<SaveButton> saveButton;
+    ScopedPointer<Viewport> electrodeButtonViewport;
+    ScopedPointer<Component> electrodeButtonHolder;
 
     Array<int> channelArray;
     Array<int> referenceArray;
@@ -113,9 +111,6 @@ private:
     bool isConfigured;
 
     ScopedPointer<DynamicObject> info;
-
-    float scrollDistance;
-
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ChannelMappingEditor);
 


### PR DESCRIPTION
Fixed the bug #65.
Analysis:
This bug is there for following reasons.
1.ElectrodeButton for channels is directly added to the ChannelMappingEditor component.
2.When we drag the button we set the visibility of the lastHoverButton which makes it visible and shows on top of other components.
3. Also finding the correct button Logic is not proper as we are not considering the buttons which are scrolled up and invisible.

Solution:
1. Create Viewport for holding the ElectrodeButton for channels.
2. Also create a Holder Component to hold all ElectrodeButton.
3. Add the ElectrodeButton to Holder Component and set the size of the Holder Component to fit all buttons.
4. Set setViewPosition for Viewport based on the scroll and drag.

More Improvement:
1. We can remove upButton and downButton.
2. Viewport has its own scrolling which can be used for scrolling. Currently its been hidden using code "electrodeButtonViewport->setScrollBarsShown(false,false,true,true);" 

Please review and let me know the feedback @jsiegle 