### PR TITLE
add juce namespace to (u)int64 types

### DIFF
--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -78,12 +78,12 @@ void highlightEditor(GenericEditor* ed)
     getEditorViewport()->makeEditorVisible(ed);
 }
 
-int64 getGlobalTimestamp()
+juce::int64 getGlobalTimestamp()
 {
 	return getProcessorGraph()->getGlobalTimestamp(false);
 }
 
-int64 getSoftwareTimestamp()
+juce::int64 getSoftwareTimestamp()
 {
 	return getProcessorGraph()->getGlobalTimestamp(true);
 }

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -61,7 +61,7 @@ PLUGIN_API void highlightEditor(GenericEditor* ed);
 /** Gets the timestamp selected on the MessageCenter interface
 Defaults to the first hardware timestamp source or the software one if
 no hardware timestamping is present*/
-PLUGIN_API int64 getGlobalTimestamp();
+PLUGIN_API juce::int64 getGlobalTimestamp();
 
 /** Gets the sample rate selected on the MessageCenter interface
 Defaults to the dample rate of the first hardware source or 
@@ -69,7 +69,7 @@ the software high resolution timer if no hardware source is present*/
 PLUGIN_API float getGlobalSampleRate();
 
 /** Gets the software timestamp based on a high resolution timer aligned to the start of each processing block */
-PLUGIN_API int64 getSoftwareTimestamp();
+PLUGIN_API juce::int64 getSoftwareTimestamp();
 
 /** Gets the ticker frequency of the software timestamp clock*/
 PLUGIN_API float getSoftwareSampleRate();

--- a/Source/Processors/Events/Events.h
+++ b/Source/Processors/Events/Events.h
@@ -86,7 +86,7 @@ public:
 	virtual ~EventBase();
 	virtual void serialize(void* dstBuffer, size_t dstSize) const = 0;
 	EventType getBaseType() const;
-	int64 getTimestamp() const;
+	juce::int64 getTimestamp() const;
 	uint16 getSourceID() const;
 	uint16 getSubProcessorIdx() const;
 	uint16 getSourceIndex() const;
@@ -97,15 +97,15 @@ public:
 	static uint16 getSourceID(const MidiMessage& msg);
 	static uint16 getSubProcessorIdx(const MidiMessage& msg);
 	static uint16 getSourceIndex(const MidiMessage& msg);
-	static int64 getTimestamp(const MidiMessage &msg);
+	static juce::int64 getTimestamp(const MidiMessage &msg);
 protected:
-	EventBase(EventType type, int64 timestamp, uint16 sourceID, uint16 subIdx, uint16 sourceIndex);
+	EventBase(EventType type, juce::int64 timestamp, uint16 sourceID, uint16 subIdx, uint16 sourceIndex);
 	EventBase() = delete;
 
 	static bool compareMetaData(const MetaDataEventObject* channelInfo, const MetaDataValueArray& metaData);
 
 	const EventType m_baseType;
-	const int64 m_timestamp;
+	const juce::int64 m_timestamp;
 	const uint16 m_sourceID;
 	const uint16 m_sourceSubIdx;
 	const uint16 m_sourceIndex;
@@ -118,8 +118,8 @@ class PLUGIN_API SystemEvent
 	: public EventBase
 {
 public:
-	static size_t fillTimestampAndSamplesData(HeapBlock<char>& data, const GenericProcessor* proc, int16 subProcessorIdx, int64 timestamp, uint32 nSamples);
-	static size_t fillTimestampSyncTextData(HeapBlock<char>& data, const GenericProcessor* proc, int16 subProcessorIdx, int64 timestamp, bool softwareTime = false);
+	static size_t fillTimestampAndSamplesData(HeapBlock<char>& data, const GenericProcessor* proc, int16 subProcessorIdx, juce::int64 timestamp, uint32 nSamples);
+	static size_t fillTimestampSyncTextData(HeapBlock<char>& data, const GenericProcessor* proc, int16 subProcessorIdx, juce::int64 timestamp, bool softwareTime = false);
 	static SystemEventType getSystemEventType(const MidiMessage& msg);
 	static uint32 getNumSamples(const MidiMessage& msg);
 	static String getSyncText(const MidiMessage& msg);
@@ -150,7 +150,7 @@ public:
 	static EventPtr deserializeFromMessage(const MidiMessage& msg, const EventChannel* channelInfo);
 
 protected:
-	Event(const EventChannel* channelInfo, int64 timestamp, uint16 channel);
+	Event(const EventChannel* channelInfo, juce::int64 timestamp, uint16 channel);
 	Event() = delete;
 	bool serializeHeader(EventChannel::EventChannelTypes type, char* buffer, size_t dstSize) const;
 	static bool createChecks(const EventChannel* channelInfo, EventChannel::EventChannelTypes eventType, uint16 channel);
@@ -180,12 +180,12 @@ public:
 	
 	const void* getTTLWordPointer() const;
 
-	static TTLEventPtr createTTLEvent(const EventChannel* channelInfo, int64 timestamp, const void* eventData, int dataSize, uint16 channel);
-	static TTLEventPtr createTTLEvent(const EventChannel* channelInfo, int64 timestamp, const void* eventData, int dataSize, const MetaDataValueArray& metaData, uint16 channel);
+	static TTLEventPtr createTTLEvent(const EventChannel* channelInfo, juce::int64 timestamp, const void* eventData, int dataSize, uint16 channel);
+	static TTLEventPtr createTTLEvent(const EventChannel* channelInfo, juce::int64 timestamp, const void* eventData, int dataSize, const MetaDataValueArray& metaData, uint16 channel);
 	static TTLEventPtr deserializeFromMessage(const MidiMessage& msg, const EventChannel* channelInfo);
 private:
 	TTLEvent() = delete;
-	TTLEvent(const EventChannel* channelInfo, int64 timestamp, uint16 channel, const void* eventData);
+	TTLEvent(const EventChannel* channelInfo, juce::int64 timestamp, uint16 channel, const void* eventData);
 
 	JUCE_LEAK_DETECTOR(TTLEvent);
 };
@@ -202,12 +202,12 @@ public:
 	void serialize(void* dstBuffer, size_t dstSize) const override;
 	String getText() const;
 
-	static TextEventPtr createTextEvent(const EventChannel* channelInfo, int64 timestamp, const String& text, uint16 channel = 0);
-	static TextEventPtr createTextEvent(const EventChannel* channelInfo, int64 timestamp, const String& text, const MetaDataValueArray& metaData, uint16 channel = 0);
+	static TextEventPtr createTextEvent(const EventChannel* channelInfo, juce::int64 timestamp, const String& text, uint16 channel = 0);
+	static TextEventPtr createTextEvent(const EventChannel* channelInfo, juce::int64 timestamp, const String& text, const MetaDataValueArray& metaData, uint16 channel = 0);
 	static TextEventPtr deserializeFromMessage(const MidiMessage& msg, const EventChannel* channelInfo);
 private:
 	TextEvent() = delete;
-	TextEvent(const EventChannel* channelInfo, int64 timestamp, uint16 channel, const String& text);
+	TextEvent(const EventChannel* channelInfo, juce::int64 timestamp, uint16 channel, const String& text);
 
 	JUCE_LEAK_DETECTOR(TextEvent);
 };
@@ -227,16 +227,16 @@ public:
 	EventChannel::EventChannelTypes getBinaryType() const;
 
 	template<typename T>
-	static BinaryEventPtr createBinaryEvent(const EventChannel* channelInfo, int64 timestamp, const T* data, int dataSize, uint16 channel = 0);
+	static BinaryEventPtr createBinaryEvent(const EventChannel* channelInfo, juce::int64 timestamp, const T* data, int dataSize, uint16 channel = 0);
 
 	template<typename T>
-	static BinaryEventPtr createBinaryEvent(const EventChannel* channelInfo, int64 timestamp, const T* data, int dataSize, const MetaDataValueArray& metaData, uint16 channel = 0);
+	static BinaryEventPtr createBinaryEvent(const EventChannel* channelInfo, juce::int64 timestamp, const T* data, int dataSize, const MetaDataValueArray& metaData, uint16 channel = 0);
 
 	static BinaryEventPtr deserializeFromMessage(const MidiMessage& msg, const EventChannel* channelInfo);
 	
 private:
 	BinaryEvent() = delete;
-	BinaryEvent(const EventChannel* channelInfo, int64 timestamp, uint16 channel, const void* data, EventChannel::EventChannelTypes type);
+	BinaryEvent(const EventChannel* channelInfo, juce::int64 timestamp, uint16 channel, const void* data, EventChannel::EventChannelTypes type);
 	
 	template<typename T>
 	static EventChannel::EventChannelTypes getType();
@@ -296,14 +296,14 @@ public:
 
 	uint16 getSortedID() const;
 
-	static SpikeEventPtr createSpikeEvent(const SpikeChannel* channelInfo, int64 timestamp, Array<float> thresholds, SpikeBuffer& dataSource, uint16 sortedID);
-	static SpikeEventPtr createSpikeEvent(const SpikeChannel* channelInfo, int64 timestamp, Array<float> thresholds, SpikeBuffer& dataSource, uint16 sortedID, const MetaDataValueArray& metaData);
+	static SpikeEventPtr createSpikeEvent(const SpikeChannel* channelInfo, juce::int64 timestamp, Array<float> thresholds, SpikeBuffer& dataSource, uint16 sortedID);
+	static SpikeEventPtr createSpikeEvent(const SpikeChannel* channelInfo, juce::int64 timestamp, Array<float> thresholds, SpikeBuffer& dataSource, uint16 sortedID, const MetaDataValueArray& metaData);
 
 	static SpikeEventPtr deserializeFromMessage(const MidiMessage& msg, const SpikeChannel* channelInfo);
 private:
 	SpikeEvent() = delete;
-	SpikeEvent(const SpikeChannel* channelInfo, int64 timestamp, Array<float> thresholds, HeapBlock<float>& data, uint16 sortedID);
-	static SpikeEvent* createBasicSpike(const SpikeChannel* channelInfo, int64 timestamp, Array<float> threshold, SpikeBuffer& dataSource, uint16 sortedID);
+	SpikeEvent(const SpikeChannel* channelInfo, juce::int64 timestamp, Array<float> thresholds, HeapBlock<float>& data, uint16 sortedID);
+	static SpikeEvent* createBasicSpike(const SpikeChannel* channelInfo, juce::int64 timestamp, Array<float> threshold, SpikeBuffer& dataSource, uint16 sortedID);
 
 	const Array<float> m_thresholds;
 	const SpikeChannel* m_channelInfo;

--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -600,7 +600,7 @@ uint32 GenericProcessor::getNumSamples (int channelNum) const
 
 
 /** Used to get the timestamp for a given buffer, for a given source node. */
-uint64 GenericProcessor::getTimestamp (int channelNum) const
+juce::uint64 GenericProcessor::getTimestamp (int channelNum) const
 {
     int sourceNodeId = 0;
 	int subProcessorIdx = 0;
@@ -649,14 +649,14 @@ uint32 GenericProcessor::getNumSourceSamples(uint32 fullSourceID) const
 	return nSamples;
 }
 
-uint64 GenericProcessor::getSourceTimestamp(uint16 processorID, uint16 subProcessorIdx) const
+juce::uint64 GenericProcessor::getSourceTimestamp(uint16 processorID, uint16 subProcessorIdx) const
 {
 	return getSourceTimestamp(getProcessorFullId(processorID, subProcessorIdx));
 }
 
-uint64 GenericProcessor::getSourceTimestamp(uint32 fullSourceID) const
+juce::uint64 GenericProcessor::getSourceTimestamp(uint32 fullSourceID) const
 {
-	uint64 ts;
+	juce::uint64 ts;
 	try
 	{
 		ts = timestamps.at(fullSourceID);
@@ -670,7 +670,7 @@ uint64 GenericProcessor::getSourceTimestamp(uint32 fullSourceID) const
 
 
 /** Used to set the timestamp for a given buffer, for a given channel. */
-void GenericProcessor::setTimestampAndSamples(uint64 timestamp, uint32 nSamples, int subProcessorIdx)
+void GenericProcessor::setTimestampAndSamples(juce::uint64 timestamp, uint32 nSamples, int subProcessorIdx)
 {
 
 	MidiBuffer& eventBuffer = *m_currentMidiBuffer;
@@ -732,7 +732,7 @@ int GenericProcessor::processEventBuffer()
 				uint16 sourceSubProcessorIdx = *reinterpret_cast<const uint16*>(dataptr + 4);
 				uint32 sourceID = getProcessorFullId(sourceNodeID, sourceSubProcessorIdx);
 
-				uint64 timestamp = *reinterpret_cast<const uint64*>(dataptr + 8);
+				juce::uint64 timestamp = *reinterpret_cast<const juce::uint64*>(dataptr + 8);
 				uint32 nSamples = *reinterpret_cast<const uint32*>(dataptr + 16);
 				numSamples[sourceID] = nSamples;
 				timestamps[sourceID] = timestamp;

--- a/Source/Processors/GenericProcessor/GenericProcessor.h
+++ b/Source/Processors/GenericProcessor/GenericProcessor.h
@@ -468,7 +468,7 @@ public:
     uint32 getNumSamples (int channelNumber) const;
 
     /** Used to get the timestamp for a given buffer, for a given channel. */
-    uint64 getTimestamp (int channelNumber) const;
+    juce::uint64 getTimestamp (int channelNumber) const;
 
 	/** Used to get the number of samples a specific source generates. 
 	Look by source ID and subprocessor index */
@@ -481,12 +481,12 @@ public:
 
 	/** Used to get the current timestamp of a specific source.
 	Look by source ID and subprocessor index */
-	uint64 getSourceTimestamp(uint16 processorID, uint16 subProcessorIdx) const;
+	juce::uint64 getSourceTimestamp(uint16 processorID, uint16 subProcessorIdx) const;
 
 	/** Used to get the current timestamp of a specific source.
 	Look by full source ID.
 	@see GenericProcessor::getProcessorFullId(uint16,uint16) */
-	uint64 getSourceTimestamp(uint32 fullSourceID) const;
+	juce::uint64 getSourceTimestamp(uint32 fullSourceID) const;
 
 	virtual int getNumSubProcessors() const;
 
@@ -518,7 +518,7 @@ public:
 
     PluginProcessorType getProcessorType() const;
 
-	int64 getLastProcessedsoftwareTime() const;
+	juce::int64 getLastProcessedsoftwareTime() const;
 
 	static uint32 getProcessorFullId(uint16 processorId, uint16 subprocessorIdx);
 
@@ -538,7 +538,7 @@ public:
 
 protected:
 	/** Used to set the timestamp for a given buffer, for a given source node. */
-	void setTimestampAndSamples(uint64 timestamp, uint32 nSamples, int subProcessorIdx = 0);
+	void setTimestampAndSamples(juce::uint64 timestamp, uint32 nSamples, int subProcessorIdx = 0);
 
 	/** Can be called by processors that need to respond to incoming events.
 	Set respondToSpikes to true if the processor should also search for spikes*/
@@ -601,9 +601,9 @@ protected:
 
 private:
 	std::map<uint32, uint32> numSamples;
-	std::map<uint32, int64> timestamps;
+	std::map<uint32, juce::int64> timestamps;
 
-	int64 m_lastProcessTime;
+	juce::int64 m_lastProcessTime;
 
 	void createDataChannelsByType(DataChannel::DataChannelTypes type);
 


### PR DESCRIPTION
There is a clash between juce's definition of int64 and the definition used by many other libraries (e.g., opencv). Juce's int64 data type is defined as "long long" whereas int64 is often defined as "long int" on 64 bit platforms (at least on linux platforms; see int64_t in stdint.h"). This prevents plugins using any of these libraries from compiling. However, int64-related data type clashes can easily be avoided by explicitly adding juce's namespace to all juce int64 data types. This does not affect compatibility/stability with the existing code base.