### PR TITLE
Fix EventBroadcaster Windows linker include directories, which fixes …

### DIFF
--- a/Builds/VisualStudio2013/Plugins/EventBroadcaster/EventBroadcaster.vcxproj
+++ b/Builds/VisualStudio2013/Plugins/EventBroadcaster/EventBroadcaster.vcxproj
@@ -79,7 +79,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>..\..\Debug\bin;../../../../Resources/windows-libs/ZeroMQ/lib_x86</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../../Resources/windows-libs/ZeroMQ/lib_x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libzmq-v120-mt-4_0_4.lib;open-ephys.lib;setupapi.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -92,7 +92,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>..\..\x64\Debug64\bin;../../../../Resources/windows-libs/ZeroMQ/lib_x64</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../../Resources/windows-libs/ZeroMQ/lib_x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libzmq-v120-mt-4_0_4.lib;open-ephys.lib;setupapi.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -109,7 +109,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>..\..\Debug\bin;../../../../Resources/windows-libs/ZeroMQ/lib_x86</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../../Resources/windows-libs/ZeroMQ/lib_x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libzmq-v120-mt-4_0_4.lib;open-ephys.lib;setupapi.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -126,7 +126,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>..\..\x64\Release64\bin;../../../../Resources/windows-libs/ZeroMQ/lib_x64</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>../../../../Resources/windows-libs/ZeroMQ/lib_x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>libzmq-v120-mt-4_0_4.lib;open-ephys.lib;setupapi.lib;opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
…building on 32-bit Release

Pretty self-explanatory - the Event Broadcaster wasn't building in 32-bit Release mode with the default settings (probably not noticed since most people are on 64-bit). This should fix it.