### PR TITLE
Fix bug with DataChannels and audio monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,13 +120,35 @@ Builds/MacOSX/open-ephys.xcodeproj/*.pbxuser
 Builds/MacOSX/open-ephys.xcodeproj/xcuserdata
 Builds/MacOSX/open-ephys.xcodeproj/project.xcworkspace
 Builds/MacOSX/build
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/*.mode1v3
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/*.pbxuser
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/xcuserdata
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/project.xcworkspace
+Projucer/Builds/MacOSX/Projucer.xcodeproj/*.mode1v3
+Projucer/Builds/MacOSX/Projucer.xcodeproj/*.pbxuser
+Projucer/Builds/MacOSX/Projucer.xcodeproj/xcuserdata
+Projucer/Builds/MacOSX/Projucer.xcodeproj/project.xcworkspace
 Projucer/Builds/MacOSX/build
 Projucer/Builds/MacOSX/Projucer.xcodeproj/xcuserdata
 Projucer/Builds/MacOSX/Projucer.xcodeproj/project.xcworkspace
+
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+*default.perspectivev3
+xcuserdata/
+
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+PluginGenerator/Builds/MacOSX/OpenEphys_PluginGenerator.xcodeproj/project.xcworkspace/contents.xcworkspacedata
 
 # 9. Plugin build dirs
 build/

--- a/Source/Processors/AudioNode/AudioNode.cpp
+++ b/Source/Processors/AudioNode/AudioNode.cpp
@@ -113,7 +113,11 @@ void AudioNode::addInputChannel(GenericProcessor* sourceNode, int chan)
 
     setPlayConfigDetails(channelIndex+1,0,44100.0,128);
 
-    dataChannelArray.add(new DataChannel(*sourceNode->getDataChannel(chan)));
+    auto dataChannel = sourceNode->getDataChannel(chan);
+    auto dataChannelCopy = new DataChannel(*dataChannel);
+    dataChannelCopy->setMonitored(dataChannel->isMonitored());
+    
+    dataChannelArray.add(dataChannelCopy);
 
 }
 

--- a/Source/Processors/Channel/InfoObjects.cpp
+++ b/Source/Processors/Channel/InfoObjects.cpp
@@ -214,8 +214,8 @@ DataChannel::DataChannel(const DataChannel& ch)
 		m_type(ch.m_type),
 		m_bitVolts(ch.m_bitVolts),
 		m_isEnabled(true),
-		m_isMonitored(false),
-		m_isRecording(false)
+		m_isMonitored(ch.m_isMonitored),
+		m_isRecording(ch.m_isRecording)
 {
 }
 

--- a/Source/Processors/Channel/InfoObjects.cpp
+++ b/Source/Processors/Channel/InfoObjects.cpp
@@ -214,8 +214,8 @@ DataChannel::DataChannel(const DataChannel& ch)
 		m_type(ch.m_type),
 		m_bitVolts(ch.m_bitVolts),
 		m_isEnabled(true),
-		m_isMonitored(ch.m_isMonitored),
-		m_isRecording(ch.m_isRecording)
+		m_isMonitored(false),
+		m_isRecording(false)
 {
 }
 

--- a/Source/Processors/Editors/ChannelSelector.cpp
+++ b/Source/Processors/Editors/ChannelSelector.cpp
@@ -680,9 +680,16 @@ void ChannelSelector::buttonClicked(Button* button)
 
             if (acquisitionIsActive) // use setParameter to change parameter safely
             {
-                AccessClass::getProcessorGraph()->
+                if ( AccessClass::getProcessorGraph()->
                 getRecordNode()->
-                setChannelStatus(ch, status);
+                setChannelStatus(ch, status) )
+                {
+                    const_cast<DataChannel*>(ch)->setRecordState(status);
+                }
+                
+                // make sure that the button matches the system's actual state, in case
+                // user's interaction was disallowed
+                b->setToggleState(const_cast<DataChannel*>(ch)->getRecordState(), dontSendNotification);
             }
             else     // change parameter directly
             {

--- a/Source/Processors/Editors/ChannelSelector.cpp
+++ b/Source/Processors/Editors/ChannelSelector.cpp
@@ -655,18 +655,18 @@ void ChannelSelector::buttonClicked(Button* button)
             bool status = b->getToggleState();
 
          //   std::cout << "Requesting audio monitor for channel " << ch->nodeIndex + 1 << std::endl;
+            
+            // change parameter directly on editor
+            //     This is another of those ugly things that will go away once the
+            //     probe audio system is implemented, but is needed to maintain compatibility
+            //     between the older recording system and the newer channel objects.
+            const_cast<DataChannel*>(ch)->setMonitored(status);
 
-            if (acquisitionIsActive) // use setParameter to change parameter safely
+            
+            if (acquisitionIsActive) // use setParameter to change audio node's copy of parameter safely, if running
             {
                 AccessClass::getProcessorGraph()->
                 getAudioNode()->setChannelStatus(ch, status);
-            }
-            else     // change parameter directly
-            {
-				//This is another of those ugly things that will go away once the
-				//probe audio system is implemented, but is needed to maintain compatibility
-				//between the older recording system and the newer channel objects.
-				const_cast<DataChannel*>(ch)->setMonitored(status);
             }
         }
         else if (b->getType() == RECORD)

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -69,7 +69,8 @@ RecordNode::~RecordNode()
 
 void RecordNode::setChannel(const DataChannel* ch)
 {
-    int channelNum = dataChannelArray.indexOf(ch);
+//    int channelNum = dataChannelArray.indexOf(ch);
+    int channelNum = getDataChannelIndex(ch->getSourceIndex(), ch->getSourceNodeID(), ch->getSubProcessorIdx());
 
     std::cout << "Record node setting channel to " << channelNum << std::endl;
 
@@ -77,7 +78,7 @@ void RecordNode::setChannel(const DataChannel* ch)
 
 }
 
-void RecordNode::setChannelStatus(const DataChannel* ch, bool status)
+bool RecordNode::setChannelStatus(const DataChannel* ch, bool status)
 {
 
     //std::cout << "Setting channel status!" << std::endl;
@@ -87,7 +88,8 @@ void RecordNode::setChannelStatus(const DataChannel* ch, bool status)
         setParameter(2, 1.0f);
     else
         setParameter(2, 0.0f);
-
+    
+    return status == dataChannelArray[currentChannel]->getRecordState();
 }
 
 

--- a/Source/Processors/RecordNode/RecordNode.h
+++ b/Source/Processors/RecordNode/RecordNode.h
@@ -106,8 +106,11 @@ public:
     /** Turns recording on and off for a particular channel.
 
         Channel numbers are absolute (based on RecordNode channel mapping).
+        
+        Returns a bool indicating whether the status update was successful (true)
+        or blocked (false) because recording is currently in progress.
     */
-    void setChannelStatus(const DataChannel* ch, bool status);
+    bool setChannelStatus(const DataChannel* ch, bool status);
 
     /** Used to clear all connections prior to the start of acquisition.
     */


### PR DESCRIPTION
DataChannel objects are currently copied when they are prepped for acquisition. Also, the copy constructor for DataChannel did not (before these commits) inherit the recording, enabled, or monitored state from the original when the original is copied.

Changing the state _during_ acquisition resulted in changing the copy as desired, but the original DataChannel's state was left unchanged. Stopping acquisition and resuming would not be up-to-date with user configuration during the last acquisition. Changing state before enabling acquisition would not propagate to the copy, because the copy constructor hardcoded the value. Both of these issues were changed in this commit.

Since RecordNodes are handled in the same way, it is likely that this bug exists there too. However that behavior has not been changed yet.

Other stray changes:

Minor updates to MacOS .gitignore rules. A few new things to ignore, and some more generalized versions of existing rules. The generalized ignore rules have, for now, been included along with their more specific rules.