### PR TITLE
Improve the efficiency of AudioNode's audio monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,13 +120,35 @@ Builds/MacOSX/open-ephys.xcodeproj/*.pbxuser
 Builds/MacOSX/open-ephys.xcodeproj/xcuserdata
 Builds/MacOSX/open-ephys.xcodeproj/project.xcworkspace
 Builds/MacOSX/build
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/*.mode1v3
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/*.pbxuser
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/xcuserdata
-Projucer/Builds/MacOSX/The Projucer.xcodeproj/project.xcworkspace
+Projucer/Builds/MacOSX/Projucer.xcodeproj/*.mode1v3
+Projucer/Builds/MacOSX/Projucer.xcodeproj/*.pbxuser
+Projucer/Builds/MacOSX/Projucer.xcodeproj/xcuserdata
+Projucer/Builds/MacOSX/Projucer.xcodeproj/project.xcworkspace
 Projucer/Builds/MacOSX/build
 Projucer/Builds/MacOSX/Projucer.xcodeproj/xcuserdata
 Projucer/Builds/MacOSX/Projucer.xcodeproj/project.xcworkspace
+
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+*default.perspectivev3
+xcuserdata/
+
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+PluginGenerator/Builds/MacOSX/OpenEphys_PluginGenerator.xcodeproj/project.xcworkspace/contents.xcworkspacedata
 
 # 9. Plugin build dirs
 build/

--- a/Source/Processors/AudioNode/AudioNode.cpp
+++ b/Source/Processors/AudioNode/AudioNode.cpp
@@ -113,7 +113,11 @@ void AudioNode::addInputChannel(GenericProcessor* sourceNode, int chan)
 
     setPlayConfigDetails(channelIndex+1,0,44100.0,128);
 
-    dataChannelArray.add(new DataChannel(*sourceNode->getDataChannel(chan)));
+    auto dataChannel = sourceNode->getDataChannel(chan);
+    auto dataChannelCopy = new DataChannel(*dataChannel);
+    dataChannelCopy->setMonitored(dataChannel->isMonitored());
+    
+    dataChannelArray.add(dataChannelCopy);
 
 }
 

--- a/Source/Processors/AudioNode/AudioNode.cpp
+++ b/Source/Processors/AudioNode/AudioNode.cpp
@@ -197,7 +197,8 @@ void AudioNode::recreateBuffers()
 
     }
 
-    tempBuffer->setSize(getNumInputs(), 4096);
+//    tempBuffer->setSize(getNumInputs(), 4096);
+    tempBuffer->setSize(1, 4096);
 }
 
 bool AudioNode::enable()
@@ -244,14 +245,14 @@ void AudioNode::process(AudioSampleBuffer& buffer)
         if (dataChannelArray.size() > 0) // we have some channels
         {
 
-            tempBuffer->clear();
+//            tempBuffer->clear();
 
             for (int i = 0; i < buffer.getNumChannels()-2; i++) // cycle through them all
             {
-
+                
                 if (dataChannelArray[i]->isMonitored())
                 {
-
+                    tempBuffer->clear();
                     //std::cout << "Processing channel " << i << std::endl;
 
                     if (!bufferSwap[i])
@@ -335,7 +336,8 @@ void AudioNode::process(AudioSampleBuffer& buffer)
                     if (samplesToCopyFromIncomingBuffer > 0)
                     {
 
-                        tempBuffer->addFrom(i,       // destination channel
+                        //tempBuffer->addFrom(i,       // destination channel
+                        tempBuffer->addFrom(0,       // destination channel
                                             samplesToCopyFromOverflowBuffer,           // destination start sample
                                             buffer,      // source
                                             i+2,           // source channel (add 2 to account for output channels)
@@ -403,7 +405,8 @@ void AudioNode::process(AudioSampleBuffer& buffer)
                         buffer.addFrom(0,    // destChannel
                                        destBufferPos,  // destSampleOffset
                                        *tempBuffer,     // source
-                                       i,    // sourceChannel
+                                       //i,    // sourceChannel
+                                       0,       // sourceChannel
                                        sourceBufferPos,// sourceSampleOffset
                                        1,        // number of samples
                                        invAlpha*gain);      // gain to apply to source
@@ -411,7 +414,8 @@ void AudioNode::process(AudioSampleBuffer& buffer)
                         buffer.addFrom(0,    // destChannel
                                        destBufferPos,   // destSampleOffset
                                        *tempBuffer,     // source
-                                       i,      // sourceChannel
+                                       //i,      // sourceChannel
+                                       0,      // sourceChannel
                                        nextPos,      // sourceSampleOffset
                                        1,        // number of samples
                                        alpha*gain);       // gain to apply to source

--- a/Source/Processors/Channel/InfoObjects.cpp
+++ b/Source/Processors/Channel/InfoObjects.cpp
@@ -214,8 +214,8 @@ DataChannel::DataChannel(const DataChannel& ch)
 		m_type(ch.m_type),
 		m_bitVolts(ch.m_bitVolts),
 		m_isEnabled(true),
-		m_isMonitored(false),
-		m_isRecording(false)
+		m_isMonitored(ch.m_isMonitored),
+		m_isRecording(ch.m_isRecording)
 {
 }
 

--- a/Source/Processors/Channel/InfoObjects.cpp
+++ b/Source/Processors/Channel/InfoObjects.cpp
@@ -214,8 +214,8 @@ DataChannel::DataChannel(const DataChannel& ch)
 		m_type(ch.m_type),
 		m_bitVolts(ch.m_bitVolts),
 		m_isEnabled(true),
-		m_isMonitored(ch.m_isMonitored),
-		m_isRecording(ch.m_isRecording)
+		m_isMonitored(false),
+		m_isRecording(false)
 {
 }
 

--- a/Source/Processors/Editors/ChannelSelector.cpp
+++ b/Source/Processors/Editors/ChannelSelector.cpp
@@ -680,9 +680,16 @@ void ChannelSelector::buttonClicked(Button* button)
 
             if (acquisitionIsActive) // use setParameter to change parameter safely
             {
-                AccessClass::getProcessorGraph()->
+                if ( AccessClass::getProcessorGraph()->
                 getRecordNode()->
-                setChannelStatus(ch, status);
+                setChannelStatus(ch, status) )
+                {
+                    const_cast<DataChannel*>(ch)->setRecordState(status);
+                }
+                
+                // make sure that the button matches the system's actual state, in case
+                // user's interaction was disallowed
+                b->setToggleState(const_cast<DataChannel*>(ch)->getRecordState(), dontSendNotification);
             }
             else     // change parameter directly
             {

--- a/Source/Processors/Editors/ChannelSelector.cpp
+++ b/Source/Processors/Editors/ChannelSelector.cpp
@@ -655,18 +655,18 @@ void ChannelSelector::buttonClicked(Button* button)
             bool status = b->getToggleState();
 
          //   std::cout << "Requesting audio monitor for channel " << ch->nodeIndex + 1 << std::endl;
+            
+            // change parameter directly on editor
+            //     This is another of those ugly things that will go away once the
+            //     probe audio system is implemented, but is needed to maintain compatibility
+            //     between the older recording system and the newer channel objects.
+            const_cast<DataChannel*>(ch)->setMonitored(status);
 
-            if (acquisitionIsActive) // use setParameter to change parameter safely
+            
+            if (acquisitionIsActive) // use setParameter to change audio node's copy of parameter safely, if running
             {
                 AccessClass::getProcessorGraph()->
                 getAudioNode()->setChannelStatus(ch, status);
-            }
-            else     // change parameter directly
-            {
-				//This is another of those ugly things that will go away once the
-				//probe audio system is implemented, but is needed to maintain compatibility
-				//between the older recording system and the newer channel objects.
-				const_cast<DataChannel*>(ch)->setMonitored(status);
             }
         }
         else if (b->getType() == RECORD)

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -69,7 +69,8 @@ RecordNode::~RecordNode()
 
 void RecordNode::setChannel(const DataChannel* ch)
 {
-    int channelNum = dataChannelArray.indexOf(ch);
+//    int channelNum = dataChannelArray.indexOf(ch);
+    int channelNum = getDataChannelIndex(ch->getSourceIndex(), ch->getSourceNodeID(), ch->getSubProcessorIdx());
 
     std::cout << "Record node setting channel to " << channelNum << std::endl;
 
@@ -77,7 +78,7 @@ void RecordNode::setChannel(const DataChannel* ch)
 
 }
 
-void RecordNode::setChannelStatus(const DataChannel* ch, bool status)
+bool RecordNode::setChannelStatus(const DataChannel* ch, bool status)
 {
 
     //std::cout << "Setting channel status!" << std::endl;
@@ -87,7 +88,8 @@ void RecordNode::setChannelStatus(const DataChannel* ch, bool status)
         setParameter(2, 1.0f);
     else
         setParameter(2, 0.0f);
-
+    
+    return status == dataChannelArray[currentChannel]->getRecordState();
 }
 
 

--- a/Source/Processors/RecordNode/RecordNode.h
+++ b/Source/Processors/RecordNode/RecordNode.h
@@ -106,8 +106,11 @@ public:
     /** Turns recording on and off for a particular channel.
 
         Channel numbers are absolute (based on RecordNode channel mapping).
+        
+        Returns a bool indicating whether the status update was successful (true)
+        or blocked (false) because recording is currently in progress.
     */
-    void setChannelStatus(const DataChannel* ch, bool status);
+    bool setChannelStatus(const DataChannel* ch, bool status);
 
     /** Used to clear all connections prior to the start of acquisition.
     */


### PR DESCRIPTION
AudioNode's upsampling procedure was taking too many cycles per buffer. Profiling showed that the overwhelming majority of time spent in this procedure was clearing a temporary work buffer.

The temporaryBuffer was sized such that there was room for every channel, at 4096 samples per channel. But it doesn't carry any state between audio callbacks, so it should be okay make a single channel buffer that is cleared and reused for each channel that is monitored on each callback.

Doing so reduced the cpu load for this procedure significantly and makes the overall performance scale proportionately to the number of data channels being monitored.