### PR TITLE
Some bug fixes for new LFP viewer

### DIFF
--- a/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -230,7 +230,7 @@ void LfpDisplayCanvas::update()
     channelOverlapFactor = options->selectedOverlapValue.getFloatValue();
 
 	std::cout << "Checking channels: " << nChans << std::endl;
-	for (int i = 0; i <= processor->getNumInputs() + 1; i++) // extra channel for events
+	for (int i = 0; i < processor->getNumInputs() + 1; i++) // extra channel for events
     {
 		//std::cout << i << std::endl;
 		if (processor->getNumInputs() > 0)
@@ -282,7 +282,7 @@ void LfpDisplayCanvas::update()
 
 		std::cout << "Changing channels on LFP display" << std::endl;
 		if (nChans > 0)
-			lfpDisplay->setNumChannels(nChans + 1); // add an extra channel for events
+			lfpDisplay->setNumChannels(nChans);
 
         // update channel names
 		//std::cout << "Updating channel names" << std::endl;

--- a/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -37,7 +37,7 @@ LfpDisplayEditor::LfpDisplayEditor(GenericProcessor* parentNode, bool useDefault
     
     subprocessorSelection = new ComboBox("Subprocessor sample rate");
 //    subprocessorSelection->setBounds(subprocessorSelectionLabel->getX()+5, subprocessorSelectionLabel->getBottom(), 60, 22);
-    subprocessorSelection->setBounds(10, 30, 50, 22);
+    subprocessorSelection->setBounds(10, 30, 55, 22);
     subprocessorSelection->addListener(this);
     addAndMakeVisible(subprocessorSelection);
     
@@ -148,18 +148,17 @@ void LfpDisplayEditor::updateSubprocessorSelectorOptions()
 
 			subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
 			//setCanvasDrawableSubprocessor(defaultSubprocessor);
-		}
-		else
-		{
-			subprocessorSelection->addItem("None", 1);
-			subprocessorSelection->setSelectedId(1, dontSendNotification);
 
-			String sampleRateLabelText = "Sample Rate: <not available>";
-			subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
-			//setCanvasDrawableSubprocessor(-1);
-
+            return;
 		}
 	}
+
+    subprocessorSelection->addItem("None", 1);
+    subprocessorSelection->setSelectedId(1, dontSendNotification);
+
+    String sampleRateLabelText = "Sample Rate: <not available>";
+    subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
+    //setCanvasDrawableSubprocessor(-1);
 }
 
 void LfpDisplayEditor::setCanvasDrawableSubprocessor(int index)

--- a/Source/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -123,13 +123,10 @@ void LfpDisplayNode::updateSettings()
     displayBufferIndex.clear();
 	displayBufferIndex.insertMultiple(0, 0, numChannelsInSubprocessor + numEventChannels);
     
-    // update the editor's subprocessor selection display, only if there's a mismatch in # of subprocessors
-	if (numSubprocessors != totalSubprocessors)
-	{
-		LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
-		ed->updateSubprocessorSelectorOptions();
-		numSubprocessors = totalSubprocessors;
-	}
+    // update the editor's subprocessor selection display and sample rate
+	LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
+	ed->updateSubprocessorSelectorOptions();
+	numSubprocessors = totalSubprocessors;
 }
 
 uint32 LfpDisplayNode::getChannelSourceID(const EventChannel* event) const


### PR DESCRIPTION
This fixes a couple issues I was observing:

- Crash when changing the number of channels in the LFP viewer canvas (e.g. loading a file into a file reader after the canvas had been opened, or changing the source node). I think setNumChannels should be called with just the number of continuous channels, not sure if that breaks something else though.

- Sample rate on the LFP viewer editor not updating if the canvas is already open (changed it to update whenever updateSubprocessorSelectorOptions is called).

(When I went into this I didn't realize how much this plugin is still in development, so I understand if you're already working on bigger changes!)