### PR TITLE
Fix invisible channel rows issue in Channel Mapper

### DIFF
--- a/Source/Plugins/ChannelMappingNode/ChannelMappingEditor.cpp
+++ b/Source/Plugins/ChannelMappingNode/ChannelMappingEditor.cpp
@@ -228,9 +228,13 @@ void ChannelMappingEditor::refreshButtonLocations()
         button->setBounds(column*width, row*height, width, height);
         totalWidth =  jmax(totalWidth, ++column*width);
         
-        if (column % 16 == 0)
+        if (column == 1)
         {
-            totalHeight =  jmax(totalHeight, ++row*height);
+            totalHeight = jmax(totalHeight, (row + 1)*height);
+        }
+        else if (column == 16)
+        {
+            row++;
             column = 0;            
         }
     }


### PR DESCRIPTION
This change fixes an issue where any non-full rows of channels would not be visible in the Channel Mapper (e.g. if there are 35 inputs, the first 32 channels show in 2 rows of 16, but the last 3 channels are invisible). As far as I can tell, the issue was limited to these channel buttons not being visible; with this fix they should have all the functionality of the other, previously visible channel buttons.