### PR TITLE
Sample math plugin

### DIFF
--- a/Builds/VisualStudio2013/Plugins/Plugins.sln
+++ b/Builds/VisualStudio2013/Plugins/Plugins.sln
@@ -62,6 +62,7 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RhythmNode", "RhythmNode\RhythmNode.vcxproj", "{3FFC6E87-5767-4245-9760-249E239965AB}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "IntanRecordingController", "IntanRecordingController\IntanRecordingController.vcxproj", "{6BA7767C-DBDA-44DF-8095-220FD1E2D91A}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SampleMath", "SampleMath\SampleMath.vcxproj", "{0D0614BC-D593-4307-931B-8DB3897021BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -349,6 +350,18 @@ Global
 		{6BA7767C-DBDA-44DF-8095-220FD1E2D91A}.Release|Win32.Build.0 = Release|Win32
 		{6BA7767C-DBDA-44DF-8095-220FD1E2D91A}.Release|x64.ActiveCfg = Release|x64
 		{6BA7767C-DBDA-44DF-8095-220FD1E2D91A}.Release|x64.Build.0 = Release|x64
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Debug|Win32.ActiveCfg = Debug|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Debug|Win32.Build.0 = Debug|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Debug|x64.ActiveCfg = Debug|x64
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Debug|x64.Build.0 = Debug|x64
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Release|Win32.ActiveCfg = Release|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Release|Win32.Build.0 = Release|Win32
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Release|x64.ActiveCfg = Release|x64
+		{0D0614BC-D593-4307-931B-8DB3897021BE}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj
+++ b/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -16,13 +24,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
@@ -33,9 +54,19 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Debug32.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Debug64.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Release32.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="..\Plugin_Release64.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup />
@@ -43,7 +74,15 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -55,7 +94,19 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -64,6 +115,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\..\Source\Plugins\SampleMath\OpenEphysLib.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\SampleMath\SampleMath.cpp" />
+    <ClCompile Include="..\..\..\..\Source\Plugins\SampleMath\SampleMathEditor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\Source\Plugins\SampleMath\SampleMath.h" />
+    <ClInclude Include="..\..\..\..\Source\Plugins\SampleMath\SampleMathEditor.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj
+++ b/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0D0614BC-D593-4307-931B-8DB3897021BE}</ProjectGuid>
+    <RootNamespace>SampleMath</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v120</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj.filters
+++ b/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj.filters
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+</Project>

--- a/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj.filters
+++ b/Builds/VisualStudio2013/Plugins/SampleMath/SampleMath.vcxproj.filters
@@ -14,4 +14,23 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\Source\Plugins\SampleMath\OpenEphysLib.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\SampleMath\SampleMath.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\Source\Plugins\SampleMath\SampleMathEditor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\Source\Plugins\SampleMath\SampleMath.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\Source\Plugins\SampleMath\SampleMathEditor.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/Source/Plugins/SampleMath/Makefile
+++ b/Source/Plugins/SampleMath/Makefile
@@ -1,0 +1,38 @@
+
+LIBNAME := $(notdir $(CURDIR))
+OBJDIR := $(OBJDIR)/$(LIBNAME)
+TARGET := $(LIBNAME).so
+
+SRC_DIR := ${shell find ./ -type d -print}
+VPATH := $(SOURCE_DIRS)
+
+SRC := $(foreach sdir,$(SRC_DIR),$(wildcard $(sdir)/*.cpp))
+OBJ := $(addprefix $(OBJDIR)/,$(notdir $(SRC:.cpp=.o)))
+
+BLDCMD := $(CXX) -shared -o $(OUTDIR)/$(TARGET) $(OBJ) $(LDFLAGS) $(RESOURCES) $(TARGET_ARCH)
+
+VPATH = $(SRC_DIR)
+
+.PHONY: objdir
+
+$(OUTDIR)/$(TARGET): objdir $(OBJ)
+	-@mkdir -p $(BINDIR)
+	-@mkdir -p $(LIBDIR)
+	-@mkdir -p $(OUTDIR)
+	@echo "Building $(TARGET)"
+	@$(BLDCMD)
+
+$(OBJDIR)/%.o : %.cpp
+	@echo "Compiling $<"
+	@$(CXX) $(CXXFLAGS) -o "$@" -c "$<"
+
+
+objdir:
+	-@mkdir -p $(OBJDIR)
+
+clean:
+	@echo "Cleaning $(LIBNAME)"
+	-@rm -rf $(OBJDIR)
+	-@rm -f $(OUTDIR)/$(TARGET)
+
+-include $(OBJ:%.o=%.d)

--- a/Source/Plugins/SampleMath/OpenEphysLib.cpp
+++ b/Source/Plugins/SampleMath/OpenEphysLib.cpp
@@ -48,7 +48,7 @@ extern "C" EXPORT int getPluginInfo(int index, Plugin::PluginInfo* info)
 	{
 	case 0:
 		info->type = Plugin::PLUGIN_TYPE_PROCESSOR;
-		info->processor.name = "Samp Math";
+		info->processor.name = "Sample Math";
 		info->processor.type = Plugin::FilterProcessor;
 		info->processor.creator = &(Plugin::createProcessor<SampleMath>);
 		break;

--- a/Source/Plugins/SampleMath/OpenEphysLib.cpp
+++ b/Source/Plugins/SampleMath/OpenEphysLib.cpp
@@ -1,0 +1,70 @@
+/*
+------------------------------------------------------------------
+
+This file is part of a plugin for the Open Ephys GUI
+Copyright (C) 2018 Translational NeuroEngineering Laboratory
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include <PluginInfo.h>
+#include "SampleMath.h"
+#include <string>
+#ifdef WIN32
+#include <Windows.h>
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __attribute__((visibility("default")))
+#endif
+
+using namespace Plugin;
+#define NUM_PLUGINS 1
+
+extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
+{
+	info->apiVersion = PLUGIN_API_VER;
+	info->name = "Sample Math";
+	info->libVersion = 1;
+	info->numPlugins = NUM_PLUGINS;
+}
+
+extern "C" EXPORT int getPluginInfo(int index, Plugin::PluginInfo* info)
+{
+	switch (index)
+	{
+	case 0:
+		info->type = Plugin::PLUGIN_TYPE_PROCESSOR;
+		info->processor.name = "Samp Math";
+		info->processor.type = Plugin::FilterProcessor;
+		info->processor.creator = &(Plugin::createProcessor<SampleMath>);
+		break;
+	default:
+		return -1;
+		break;
+	}
+	return 0;
+}
+
+#ifdef WIN32
+BOOL WINAPI DllMain(IN HINSTANCE hDllHandle,
+	IN DWORD     nReason,
+	IN LPVOID    Reserved)
+{
+	return TRUE;
+}
+
+#endif

--- a/Source/Plugins/SampleMath/SampleMath.cpp
+++ b/Source/Plugins/SampleMath/SampleMath.cpp
@@ -1,0 +1,214 @@
+/*
+------------------------------------------------------------------
+
+This file is part of a plugin for the Open Ephys GUI
+Copyright (C) 2018 Translational NeuroEngineering Laboratory
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "SampleMath.h"
+#include "SampleMathEditor.h"
+
+SampleMath::SampleMath()
+    : GenericProcessor  ("Samp Math")
+    , operation         (ADD)
+    , useChannel        (false)
+    , constant          (0)
+    , selectedChannel   (-1)
+{
+    setProcessorType(PROCESSOR_TYPE_FILTER);
+}
+
+SampleMath::~SampleMath() {}
+
+AudioProcessorEditor* SampleMath::createEditor()
+{
+    editor = new SampleMathEditor(this);
+    return editor;
+}
+
+void SampleMath::process(AudioSampleBuffer& continuousBuffer)
+{
+    Operation currOp = operation;
+    int currSelectedChannel = selectedChannel;
+
+    const float* rp;
+    if (useChannel)
+    {
+        rp = continuousBuffer.getReadPointer(currSelectedChannel);
+    }
+
+    // iterate over active channels
+    Array<int> activeChannels = editor->getActiveChannels();
+    bool selectedChannelIsActive = false;
+    for (int chan : activeChannels)
+    {
+        if (useChannel && chan == currSelectedChannel)
+        {
+            selectedChannelIsActive = true;
+            continue; // process separately at end
+        }
+
+        float* wp = continuousBuffer.getWritePointer(chan);
+        int numValues = getNumSamples(chan);
+
+        switch (currOp)
+        {
+        case ADD:
+            if (useChannel)
+                FloatVectorOperations::add(wp, rp, numValues);
+            else
+                FloatVectorOperations::add(wp, constant, numValues);
+            break;
+
+        case SUBTRACT:
+            if (useChannel)
+                FloatVectorOperations::subtract(wp, rp, numValues);
+            else
+                FloatVectorOperations::add(wp, -constant, numValues);
+            break;
+
+        case MULTIPLY:
+            if (useChannel)
+                FloatVectorOperations::multiply(wp, rp, numValues);
+            else
+                FloatVectorOperations::multiply(wp, constant, numValues);
+            break;
+
+        case DIVIDE:
+            if (useChannel)
+                for (int i = 0; i < numValues; ++i)
+                    wp[i] /= rp[i];
+            else
+                FloatVectorOperations::multiply(wp, 1.0f / constant, numValues);
+            break;
+
+        default: jassertfalse; break;
+        }
+    }
+
+    if (selectedChannelIsActive)
+    {
+        int numValues = getNumSamples(currSelectedChannel);
+        float* wp = continuousBuffer.getWritePointer(currSelectedChannel);
+
+        switch (currOp)
+        {
+        case ADD:
+            FloatVectorOperations::add(wp, wp, numValues);
+            break;
+
+        case SUBTRACT:
+            FloatVectorOperations::clear(wp, numValues);
+            break;
+
+        case MULTIPLY:
+            FloatVectorOperations::multiply(wp, wp, numValues);
+            break;
+
+        case DIVIDE:
+            FloatVectorOperations::fill(wp, 1.0f, numValues);
+        }
+    }
+}
+
+void SampleMath::setParameter(int parameterIndex, float newValue)
+{
+    switch (parameterIndex)
+    {
+    case OPERATION:
+        operation = static_cast<Operation>(static_cast<int>(newValue));
+        break;
+
+    case USE_CHANNEL:
+        if (newValue)
+            validateActiveChannels();
+        useChannel = static_cast<bool>(newValue);
+        break;
+
+    case CONSTANT:
+        constant = newValue;
+        break;
+
+    case CHANNEL:
+        int newChanNum = static_cast<int>(newValue);
+        if (newChanNum == -1 || newChanNum >= getTotalDataChannels())
+        {
+            if (!CoreServices::getAcquisitionStatus())
+                selectedChannel = -1;
+            break;
+        }
+
+        validSubProcFullID = chanToFullID(newChanNum);
+        if (useChannel)
+            validateActiveChannels();
+        selectedChannel = newChanNum;
+        break;
+    }
+}
+
+void SampleMath::updateSettings()
+{
+    // refresh selected channel, and if still valid, validate active channels if necessary
+    int numChannels = getNumInputs();
+    if (numChannels == 0)
+    {
+        selectedChannel = -1; // = none available
+        return;
+    }
+    
+    if (selectedChannel >= numChannels || selectedChannel == -1)
+    {
+        selectedChannel = 0; // reset to default
+    }
+
+    validSubProcFullID = chanToFullID(selectedChannel);
+    if (useChannel)
+        validateActiveChannels();
+}
+
+// private
+
+void SampleMath::validateActiveChannels()
+{
+    Array<int> activeChannels = editor->getActiveChannels();
+    int numChannels = getNumInputs();
+    bool p, r, a, haveSentMessage = false;
+    const String message = "Deselecting channels that don't match subprocessor of selected reference";
+    for (int chan : activeChannels)
+    {
+        if (chan >= numChannels) // can happen during update if # of channels decreases
+            continue;
+
+        if (chanToFullID(chan) != validSubProcFullID)
+        {
+            if (!haveSentMessage)
+                CoreServices::sendStatusMessage(message);
+            editor->getChannelSelectionState(chan, &p, &r, &a);
+            editor->setChannelSelectionState(chan - 1, false, r, a);
+        }
+    }
+}
+
+juce::uint32 SampleMath::chanToFullID(int chanNum) const
+{
+    const DataChannel* chan = getDataChannel(chanNum);
+    uint16 sourceNodeID = chan->getSourceNodeID();
+    uint16 subProcessorIdx = chan->getSubProcessorIdx();
+    return getProcessorFullId(sourceNodeID, subProcessorIdx);
+}

--- a/Source/Plugins/SampleMath/SampleMath.h
+++ b/Source/Plugins/SampleMath/SampleMath.h
@@ -1,0 +1,90 @@
+/*
+------------------------------------------------------------------
+
+This file is part of a plugin for the Open Ephys GUI
+Copyright (C) 2018 Translational NeuroEngineering Laboratory
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef SAMPLE_MATH_H_INCLUDED
+#define SAMPLE_MATH_H_INCLUDED
+
+#include <ProcessorHeaders.h>
+
+/*
+ * Allows adding, subtracting, multiplying and dividing constants or channels from selected channels.
+ *
+ * @see GenericProcessor
+ */
+
+enum Param
+{
+    OPERATION,
+    USE_CHANNEL,
+    CONSTANT,
+    CHANNEL
+};
+
+// corresponds to indices of ComboBox choices
+enum Operation
+{
+    ADD = 1,
+    SUBTRACT,
+    MULTIPLY,
+    DIVIDE
+};
+
+class SampleMath : public GenericProcessor
+{
+    friend class SampleMathEditor;
+
+public:
+    SampleMath();
+    ~SampleMath();
+
+    bool hasEditor() const { return true; }
+    AudioProcessorEditor* createEditor() override;
+
+    void process(AudioSampleBuffer& continuousBuffer) override;
+
+    void setParameter(int parameterIndex, float newValue) override;
+
+    void updateSettings() override;
+
+private:
+    /*
+    * Checks whether all active channels are from the same subprocessor as the selected one,
+    * if using the selected channel for the operation rather than a constant, and if not deselects
+    * those that do not match. Checks each channel against validSubProcFullId.
+    */
+    void validateActiveChannels();
+
+    // utilities
+    juce::uint32 chanToFullID(int chanNum) const;
+
+    // parameters
+    Operation operation;
+    bool useChannel; // whether operator parameter is a constant or a channel
+    float constant;
+    int selectedChannel; // -1 = none available
+    juce::uint32 validSubProcFullID; // = subproccessor full ID of selected channel
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SampleMath);
+};
+
+#endif // SAMPLE_MATH_H_INCLUDED

--- a/Source/Plugins/SampleMath/SampleMathEditor.cpp
+++ b/Source/Plugins/SampleMath/SampleMathEditor.cpp
@@ -1,0 +1,233 @@
+/*
+------------------------------------------------------------------
+
+This file is part of a plugin for the Open Ephys GUI
+Copyright (C) 2018 Translational NeuroEngineering Laboratory
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "SampleMathEditor.h"
+#include <string> // stof
+#include <cfloat> // limits
+
+SampleMathEditor::SampleMathEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors)
+    : GenericEditor(parentNode, useDefaultParameterEditors)
+{
+    desiredWidth = 100;
+    SampleMath* processor = static_cast<SampleMath*>(parentNode);
+
+    int xCenter = desiredWidth / 2 - 5; // account for drawer button
+    int yPos = 35;
+
+    operationBox = new ComboBox("operation");
+    operationBox->addItem("+", ADD);
+    operationBox->addItem(L"\u2212", SUBTRACT);
+    operationBox->addItem(L"\u00d7", MULTIPLY);
+    operationBox->addItem(L"\u00f7", DIVIDE);
+    operationBox->setSelectedId(processor->operation, dontSendNotification);
+    int width = 40;
+    operationBox->setBounds(xCenter - width / 2, yPos, width, 20);
+    operationBox->addListener(this);
+    addAndMakeVisible(operationBox);
+
+    useChannelBox = new ComboBox("useChannel");
+    useChannelBox->addItem("CONST", 1);
+    useChannelBox->addItem("CHAN", 2);
+    useChannelBox->setSelectedId(processor->useChannel ? 2 : 1, dontSendNotification);
+    width = 70;
+    useChannelBox->setBounds(xCenter - width / 2, yPos += 30, width, 20);
+    useChannelBox->addListener(this);
+    addAndMakeVisible(useChannelBox);
+
+    channelSelectionBox = new ComboBox("channelSelection");
+    width = 50;
+    channelSelectionBox->setBounds(xCenter - width / 2, yPos += 30, width, 20);
+    channelSelectionBox->addListener(this);
+    channelSelectionBox->setTooltip(CHANNEL_SELECT_TOOLTIP);
+    channelSelectionBox->setVisible(processor->useChannel);
+    addChildComponent(channelSelectionBox);
+
+    constantEditable = new Label("constantE");
+    constantEditable->setEditable(true);
+    width = 60;
+    constantEditable->setBounds(xCenter - width / 2, yPos, width, 20);
+    constantEditable->setText(String(processor->constant), dontSendNotification);
+    constantEditable->setColour(Label::backgroundColourId, Colours::grey);
+    constantEditable->setColour(Label::textColourId, Colours::white);
+    constantEditable->addListener(this);
+    constantEditable->setVisible(!channelSelectionBox->isVisible());
+    addChildComponent(constantEditable);
+}
+
+SampleMathEditor::~SampleMathEditor() {}
+
+void SampleMathEditor::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
+{
+    SampleMath* processor = static_cast<SampleMath*>(getProcessor());
+    if (comboBoxThatHasChanged == operationBox)
+    {
+        processor->setParameter(OPERATION, static_cast<float>(operationBox->getSelectedId()));
+    }
+    else if (comboBoxThatHasChanged == useChannelBox)
+    {
+        bool useChannel = static_cast<bool>(useChannelBox->getSelectedId() - 1);
+        if (useChannel)
+        {
+            constantEditable->setVisible(false);
+            channelSelectionBox->setVisible(true);
+        }
+        else
+        {
+            channelSelectionBox->setVisible(false);
+            constantEditable->setVisible(true);
+        }
+        processor->setParameter(USE_CHANNEL, static_cast<float>(useChannel));
+    }
+    else if (comboBoxThatHasChanged == channelSelectionBox)
+    {
+        processor->setParameter(CHANNEL, static_cast<float>(channelSelectionBox->getSelectedId() - 1));
+    }
+}
+
+void SampleMathEditor::labelTextChanged(Label* labelThatHasChanged)
+{
+    SampleMath* processor = static_cast<SampleMath*>(getProcessor());
+    if (labelThatHasChanged == constantEditable)
+    {
+        float floatInput;
+        bool valid = updateFloatLabel(labelThatHasChanged, -FLT_MAX, FLT_MAX,
+            processor->constant, &floatInput);
+
+        if (valid)
+            processor->setParameter(CONSTANT, floatInput);
+    }
+}
+
+void SampleMathEditor::updateSettings()
+{
+    SampleMath* processor = static_cast<SampleMath*>(getProcessor());
+
+    // repopulate channel selection box
+    channelSelectionBox->clear();
+    int numChannels = processor->getNumInputs();
+    for (int i = 1; i <= numChannels; ++i)
+        channelSelectionBox->addItem(String(i), i);
+    
+    // update selected item
+    if (processor->selectedChannel >= 0)
+        channelSelectionBox->setSelectedId(processor->selectedChannel + 1, dontSendNotification);
+}
+
+void SampleMathEditor::channelChanged(int chan, bool newState)
+{
+    SampleMath* processor = static_cast<SampleMath*>(getProcessor());
+    if (newState == true && processor->useChannel)
+    {
+        bool subProcessorMismatch = processor->chanToFullID(chan) != processor->validSubProcFullID;
+        if (subProcessorMismatch)
+        {
+            // turn channel back off
+            CoreServices::sendStatusMessage("Cannot select this channel due to subprocessor mismatch");
+            bool p, r, a;
+            getChannelSelectionState(chan, &p, &r, &a);
+            setChannelSelectionState(chan - 1, false, r, a);
+        }
+    }
+}
+
+void SampleMathEditor::collapsedStateChanged()
+{
+    switch (useChannelBox->getSelectedId())
+    {
+    case 2:
+        constantEditable->setVisible(false);
+        break;
+
+    case 1:
+    default:
+        channelSelectionBox->setVisible(false);
+        break;
+    }
+}
+
+void SampleMathEditor::saveCustomParameters(XmlElement* xml)
+{
+    xml->setAttribute("Type", "SampleMath");
+
+    SampleMath* processor = static_cast<SampleMath*>(getProcessor());
+    XmlElement* paramValues = xml->createNewChildElement("VALUES");
+    paramValues->setAttribute("operation", processor->operation);
+    paramValues->setAttribute("useChannel", processor->useChannel);
+    paramValues->setAttribute("constant", processor->constant);
+    paramValues->setAttribute("selectedChannel", processor->selectedChannel + 1); // one-based!
+}
+
+void SampleMathEditor::loadCustomParameters(XmlElement* xml)
+{
+    forEachXmlChildElementWithTagName(*xml, xmlNode, "VALUES")
+    {
+        // select channel while useChannel is false to avoid unnecessarily inactivating channels
+        int selectedChannel = xmlNode->getIntAttribute("selectedChannel", channelSelectionBox->getSelectedId());
+        if (selectedChannel > 0 && selectedChannel <= channelSelectionBox->getNumItems())
+        {
+            channelSelectionBox->setSelectedId(selectedChannel, sendNotificationSync);
+        }
+
+        operationBox->setSelectedId(xmlNode->getIntAttribute("operation", operationBox->getSelectedId()), sendNotificationAsync);
+        constantEditable->setText(xmlNode->getStringAttribute("constant", constantEditable->getText()), sendNotificationAsync);
+        int useChannelIdx = 1 + xmlNode->getIntAttribute("useChannel", useChannelBox->getSelectedId() - 1);
+        useChannelBox->setSelectedId(useChannelIdx, sendNotificationAsync);
+    }
+}
+
+// static utilities
+
+bool SampleMathEditor::updateFloatLabel(Label* labelThatHasChanged,
+    float minValue, float maxValue, float defaultValue, float* result)
+{
+    String& input = labelThatHasChanged->getText();
+    bool valid = parseInput(input, minValue, maxValue, result);
+    if (!valid)
+        labelThatHasChanged->setText(String(defaultValue), dontSendNotification);
+    else
+        labelThatHasChanged->setText(String(*result), dontSendNotification);
+
+    return valid;
+}
+
+bool SampleMathEditor::parseInput(String& in, float min, float max, float* out)
+{
+    float parsedFloat;
+    try
+    {
+        parsedFloat = std::stof(in.toRawUTF8());
+    }
+    catch (...)
+    {
+        return false;
+    }
+
+    if (parsedFloat < min)
+        *out = min;
+    else if (parsedFloat > max)
+        *out = max;
+    else
+        *out = parsedFloat;
+
+    return true;
+}

--- a/Source/Plugins/SampleMath/SampleMathEditor.h
+++ b/Source/Plugins/SampleMath/SampleMathEditor.h
@@ -1,0 +1,75 @@
+/*
+------------------------------------------------------------------
+
+This file is part of a plugin for the Open Ephys GUI
+Copyright (C) 2018 Translational NeuroEngineering Laboratory
+
+------------------------------------------------------------------
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef SAMPLE_MATH_EDITOR_H_INCLUDED
+#define SAMPLE_MATH_EDITOR_H_INCLUDED
+
+#include <EditorHeaders.h>
+#include "SampleMath.h"
+
+class SampleMathEditor : public GenericEditor, public ComboBox::Listener, public Label::Listener
+{
+public:
+    SampleMathEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors = false);
+    ~SampleMathEditor();
+
+    // implements ComboBox::Listener
+    void comboBoxChanged(ComboBox* comboBoxThatHasChanged) override;
+
+    // implements Label::Listener
+    void labelTextChanged(Label* labelThatHasChanged) override;
+
+    // keep channel selector valid
+    void updateSettings() override;
+
+    // catch invalid channel selections
+    void channelChanged(int chan, bool newState) override;
+
+    // hide irrelevant control when re-expanded
+    void collapsedStateChanged() override;
+
+    void saveCustomParameters(XmlElement* xml) override;
+    void loadCustomParameters(XmlElement* xml) override;
+
+private:
+    // utility for label listening
+    // ouputs whether the label contained a valid input; if so, it is stored in *result.
+    static bool updateFloatLabel(Label* labelThatHasChanged,
+        float minValue, float maxValue, float defaultValue, float* result);
+
+    // Attempt to parse an input string into a float between min and max, inclusive.
+    // Returns false if no float could be parsed.
+    static bool parseInput(String& in, float min, float max, float* out);
+
+    // UI elements
+    ScopedPointer<ComboBox> operationBox;
+    ScopedPointer<ComboBox> useChannelBox;
+    ScopedPointer<ComboBox> channelSelectionBox;
+    ScopedPointer<Label> constantEditable;
+
+    const String CHANNEL_SELECT_TOOLTIP = "Note: Can only be applied to channels from the same source/subprocessor.";
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SampleMathEditor);
+};
+
+#endif // SAMPLE_MATH_EDITOR_H_INCLUDED


### PR DESCRIPTION
The sample math plugin performs simple arithmetic on its inputs, adding, subtracting, multiplying or dividing by a constant or one of the inputs. I already posted it on the 3rd-party plugins page, but I'm putting this here just in case you think it's worth including as a default plugin. Some example uses:

* Subtracting out a reference (overlapping with Common Avg Ref functionality)
* Demeaning and normalization (using running mean and std dev plugin)
* Increasing dynamic range of low-intensity signals, for more precise recordings
* Scaling a control input to another plugin (I don't think this applies to any built-in plugins, but that's what we're planning to use it for)

![sm_chan](https://user-images.githubusercontent.com/8973825/39071805-69f1c75c-44b6-11e8-8271-4fe2ff5aa697.png) ![sm_const](https://user-images.githubusercontent.com/8973825/39071809-6a0d9d92-44b6-11e8-8dee-13a8f1435733.png)

I totally get it if you don't want to add any more defaults - just thought that if you do, this might be a good candidate since it's pretty general-purpose. 