### PR TITLE
Fix 'drawableSubprocessor' not being set when not loading settings or explicitly selecting a subprocessor

### DIFF
--- a/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -71,7 +71,6 @@ void LfpDisplayEditor::stopAcquisition()
 Visualizer* LfpDisplayEditor::createNewCanvas()
 {
     canvas = new LfpDisplayCanvas(lfpProcessor);
-    updateSubprocessorSelectorOptions();
     return canvas;
 }
 
@@ -141,7 +140,7 @@ void LfpDisplayEditor::updateSubprocessorSelectorOptions()
 
 		if (defaultSubprocessor >= 0)
 		{
-			subprocessorSelection->setSelectedId(defaultSubprocessor + 1, dontSendNotification);
+			subprocessorSelection->setSelectedId(defaultSubprocessor + 1, sendNotification);
 
 			String sampleRateLabelText = "Sample Rate: ";
 			sampleRateLabelText += String(inputSampleRates[*(inputSubprocessorIndices.begin() + defaultSubprocessor)]);

--- a/Source/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -147,7 +147,6 @@ void LfpDisplayNode::setSubprocessor(int sp)
 	subprocessorToDraw = sp;
 	std::cout << "LfpDisplayNode setting subprocessor to " << sp << std::endl;
 	updateSubprocessorsFlag = false;
-	updateSettings();
 	
 }
 


### PR DESCRIPTION
Currently, the LFP viewer has a bug where the canvas's `drawableSubprocessor` field doesn't get set in the typical case of adding a new LFP viewer to a signal chain and not selecting a subprocessor from the ComboBox. The `updateSubprocessorSelectorOptions` method selects the default subprocessor to display in the ComboBox, but doesn't send a notification, which is a problem because the ComboBox listener is responsible for setting `drawableSubprocessor`. The end result is that the canvas does not refresh properly and the data does not get displayed.

This fixes the bug by making `updateSubprocessorSelectorOptions` send a notification, and getting rid of a resulting circular call to `updateSettings` which should never be necessary, given the contexts in which the containing function `LfpDisplayNode::setSubprocessor` is currently called. The other change just removes a call to `updateSubprocessorSelectorOptions` which seems to be redundant with line 88 in that file.