### PR TITLE
Fix bug when loading LFP viewer with no channels

### DIFF
--- a/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -313,9 +313,11 @@ void LfpDisplayCanvas::update()
             lfpDisplay->channelInfo[i]->updateType();
         }
         
-		if (nChans > 0)
-			std::cout << "Rebuilding drawable channels" << std::endl;
+        if (nChans > 0)
+        {
+            std::cout << "Rebuilding drawable channels" << std::endl;
             lfpDisplay->rebuildDrawableChannelsList();
+        }
     }
     
 	}


### PR DESCRIPTION
Currently, the GUI crashes when trying to load a config file that contains an LFP viewer with no input channels. This fixes the bug, which seems to have been caused by missing curly braces on a multi-line if statement.