### PR TITLE
Save gain, reference and affected channel state in CAR plugin

### DIFF
--- a/Source/Plugins/CAR/CAR.cpp
+++ b/Source/Plugins/CAR/CAR.cpp
@@ -138,3 +138,43 @@ void CAR::setAffectedChannelState (int channel, bool newState)
         m_affectedChannels.add (channel);
 }
 
+void CAR::saveCustomChannelParametersToXml(XmlElement* channelElement,
+    int channelNumber, InfoObjectCommon::InfoObjectType channelType)
+{
+    if (channelType == InfoObjectCommon::DATA_CHANNEL)
+    {
+        XmlElement* groupState = channelElement->createNewChildElement("GROUPSTATE");
+        
+        const Array<int>& referenceChannels = getReferenceChannels();
+        bool isReferenceChannel = referenceChannels.contains(channelNumber);
+        groupState->setAttribute("reference", isReferenceChannel);
+
+        const Array<int>& affectedChannels = getAffectedChannels();
+        bool isAffectedChannel = affectedChannels.contains(channelNumber);
+        groupState->setAttribute("affected", isAffectedChannel);
+    }
+}
+
+void CAR::loadCustomChannelParametersFromXml(XmlElement* channelElement,
+    InfoObjectCommon::InfoObjectType channelType)
+{
+    if (channelType == InfoObjectCommon::DATA_CHANNEL)
+    {
+        int channelNumber = channelElement->getIntAttribute("number");
+
+        forEachXmlChildElementWithTagName(*channelElement, groupState, "GROUPSTATE")
+        {
+            if (groupState->hasAttribute("reference"))
+            {
+                bool isReferenceChannel = groupState->getBoolAttribute("reference");
+                setReferenceChannelState(channelNumber, isReferenceChannel);
+            }
+
+            if (groupState->hasAttribute("affected"))
+            {
+                bool isAffectedChannel = groupState->getBoolAttribute("affected");
+                setAffectedChannelState(channelNumber, isAffectedChannel);
+            }
+        }
+    }
+}

--- a/Source/Plugins/CAR/CAR.h
+++ b/Source/Plugins/CAR/CAR.h
@@ -80,6 +80,11 @@ public:
     void setReferenceChannelState (int channel, bool newState);
     void setAffectedChannelState  (int channel, bool newState);
 
+    /** Saving/loading channel parameters */
+    void saveCustomChannelParametersToXml(XmlElement* channelElement,
+        int channelNumber, InfoObjectCommon::InfoObjectType channelType);
+    void loadCustomChannelParametersFromXml(XmlElement* channelElement,
+        InfoObjectCommon::InfoObjectType channelType);
 
 private:
     LinearSmoothedValueAtomic<float> m_gainLevel;

--- a/Source/Plugins/CAR/CAREditor.cpp
+++ b/Source/Plugins/CAR/CAREditor.cpp
@@ -144,3 +144,24 @@ void CAREditor::sliderEvent (Slider* sliderWhichValueHasChanged)
 
     processor->setGainLevel ( (float)sliderWhichValueHasChanged->getValue());
 }
+
+void CAREditor::saveCustomParameters(XmlElement* xml)
+{
+    auto processor = static_cast<CAR*> (getProcessor());
+
+    xml->setAttribute("Type", "CAREditor");
+
+    XmlElement* paramValues = xml->createNewChildElement("VALUES");
+    paramValues->setAttribute("gainLevel", processor->getGainLevel());
+}
+
+void CAREditor::loadCustomParameters(XmlElement* xml)
+{
+    auto processor = static_cast<CAR*> (getProcessor());
+
+    forEachXmlChildElementWithTagName(*xml, xmlNode, "VALUES")
+    {
+        double gain = xmlNode->getDoubleAttribute("gainLevel", m_gainSlider->getValue());
+        m_gainSlider->setValue(gain, sendNotificationSync);
+    }
+}

--- a/Source/Plugins/CAR/CAREditor.h
+++ b/Source/Plugins/CAR/CAREditor.h
@@ -58,6 +58,9 @@ public:
     void sliderEvent (Slider* sliderWhichValueHasChanged) override;
     void channelChanged (int channel, bool newState) override;
 
+    /** Saving/loading parameters */
+    void saveCustomParameters(XmlElement* xml) override;
+    void loadCustomParameters(XmlElement* xml) override;
 
 private:
     enum ChannelsType


### PR DESCRIPTION
What it says on the tin - save the Common Avg Ref parameters to XML (gain in an editor custom attribute and reference/affected channels in each channel's custom attributes).