### PR TITLE
Improve .npy file writing support

### DIFF
--- a/Source/Plugins/BinaryWriter/NpyFile.h
+++ b/Source/Plugins/BinaryWriter/NpyFile.h
@@ -55,13 +55,22 @@ namespace BinaryRecordingEngine
 		void increaseRecordCount(int count = 1);
 	private:
 		bool openFile(String path);
+		String getShapeString();
 		void writeHeader(const Array<NpyType>& typeList);
+		void updateHeader();
 		ScopedPointer<FileOutputStream> m_file;
+		int64 m_headerLen; // total header length
 		bool m_okOpen{ false };
 		int64 m_recordCount{ 0 };
-		size_t m_countPos;
+		size_t m_shapePos;
 		unsigned int m_dim1;
 		unsigned int m_dim2;
+
+		// Compile-time constants
+
+		// flush file buffer to disk and update the .npy header every this many records:
+		const int recordBufferSize{ 128 };
+
 	};
 
 };


### PR DESCRIPTION
* Overwrite, never append new .npy file to end of existing one
* Pad header to properly align to 64 byte multiples
* Force flush() to disk every recordBufferSize records
* Update shape field in header on every flush()
* Ensure sure shape field doesn't exceed header on update
* Factor out shape string construction, fix empty array shape
* General cleanup

I've tested this by writing to 1D and 2D arrays, loading them in with `np.load()` in Python, resaving them with `np.save()` to another `.npy` file, and comparing the two files. From my testing so far, the hashes come out equal.