### PR TITLE
Reduce wasted space in spike viewer, make scrollbar visible

### DIFF
--- a/Source/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
+++ b/Source/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
@@ -123,22 +123,22 @@ void SpikeDisplayCanvas::refreshState()
 
 void SpikeDisplayCanvas::resized()
 {
-    viewport->setBounds(0,0,getWidth(),getHeight()-90);
+    viewport->setBounds(0, 0, getWidth(), getHeight()-30); // leave space at bottom for buttons
 
     spikeDisplay->setBounds(0,0,getWidth()-scrollBarThickness, spikeDisplay->getTotalHeight());
 
-    clearButton->setBounds(10, getHeight()-40, 100,20);
+    clearButton->setBounds(10, getHeight()-25, 130, 20);
 
-    lockThresholdsButton->setBounds(130, getHeight()-40, 130,20);
+    lockThresholdsButton->setBounds(10+130+10, getHeight()-25, 130, 20);
 
-    invertSpikesButton->setBounds(270, getHeight()-40, 130,20);
+    invertSpikesButton->setBounds(10+130+10+130+10, getHeight()-25, 130, 20);
 
 }
 
 void SpikeDisplayCanvas::paint(Graphics& g)
 {
 
-    g.fillAll(Colours::darkgrey);
+    g.fillAll(Colours::black);
 
 }
 
@@ -423,7 +423,7 @@ void SpikeDisplay::resized()
 
         }
 
-        totalHeight = (int) maxHeight + 50;
+        totalHeight = (int) maxHeight;
 
         // std::cout << "New height = " << totalHeight << std::endl;
 


### PR DESCRIPTION
Here's what it looks like now, when scrolled all the way down on 64 single channels:

![spikeviewlayout](https://user-images.githubusercontent.com/799467/41421949-2e9e9d7a-6ff8-11e8-8c99-9f20984f01c5.png)
