### PR TITLE
Fix bug where multiple signal chains appear to be selected

### DIFF
--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1075,15 +1075,15 @@ SignalChainTabButton::SignalChainTabButton() : Button("Name"),
 
 void SignalChainTabButton::clicked()
 {
+    if (getToggleState())
+    {
+        //std::cout << "Button clicked: " << firstEditor->getName() << std::endl;
+        EditorViewport* ev = (EditorViewport*) getParentComponent();
 
-    //std::cout << "Button clicked: " << firstEditor->getName() << std::endl;
-    EditorViewport* ev = (EditorViewport*) getParentComponent();
-
-    scm->updateVisibleEditors(firstEditor, 0, 0, ACTIVATE);
-    ev->leftmostEditor = offset;
-    ev->refreshEditors();
-
-
+        scm->updateVisibleEditors(firstEditor, 0, 0, ACTIVATE);
+        ev->leftmostEditor = offset;
+        ev->refreshEditors();
+    }
 }
 
 void SignalChainTabButton::paintButton(Graphics& g, bool isMouseOver, bool isButtonDown)
@@ -1468,7 +1468,7 @@ const String EditorViewport::loadState(File fileToLoad)
 	bool pluginAPI = false;
 	bool rhythmNodePatch = false;
     String versionString;
-	
+
     forEachXmlChildElement(*xml, element)
     {
         if (element->hasTagName("INFO"))


### PR DESCRIPTION
There's a bug in the editor viewport where multiple `SignalChainTabButtons` can become activated, even though they're supposed to be radio buttons. Steps to reproduce:

* From an empty signal chain, add two sources.
* Select the signal chain button that is not currently selected. Now they will both appear to be active.

The problem is in the `SignalChainTabButton::clicked` hook, which is supposed to update the visible editors to show the newly selected signal chain. The `updateVisibleEditors` function that is called silently toggles on the tab button corresponding to the editor being activated, which is supposed to be the active signal chain. However, `clicked` actually gets called for the buttons being toggled off as well (before the one being turned on). So we have to check whether the button is actually on, and if not do nothing.