### PR TITLE
BinaryWriter: fix data loss in large .npy files, tweaks, clean up

### DIFF
--- a/Source/Plugins/BinaryWriter/BinaryRecording.cpp
+++ b/Source/Plugins/BinaryWriter/BinaryRecording.cpp
@@ -29,9 +29,9 @@ using namespace BinaryRecordingEngine;
 
 BinaryRecording::BinaryRecording()
 {
-	m_scaledBuffer.malloc(MAX_BUFFER_SIZE);
-	m_intBuffer.malloc(MAX_BUFFER_SIZE);
-	m_tsBuffer.malloc(MAX_BUFFER_SIZE);
+    m_scaledBuffer.malloc(MAX_BUFFER_SIZE);
+    m_intBuffer.malloc(MAX_BUFFER_SIZE);
+    m_tsBuffer.malloc(MAX_BUFFER_SIZE);
 }
 
 BinaryRecording::~BinaryRecording()
@@ -41,461 +41,461 @@ BinaryRecording::~BinaryRecording()
 
 String BinaryRecording::getEngineID() const
 {
-	return "RAWBINARY";
+    return "RAWBINARY";
 }
 
 String BinaryRecording::getProcessorString(const InfoObjectCommon* channelInfo)
 {
-	String fName = (channelInfo->getCurrentNodeName().replaceCharacter(' ', '_') + "-" + String(channelInfo->getCurrentNodeID()));
-	if (channelInfo->getCurrentNodeID() == channelInfo->getSourceNodeID()) //it is the channel source
-	{
-		fName += "." + String(channelInfo->getSubProcessorIdx());
-	}
-	else
-	{
-		fName += "_" + String(channelInfo->getSourceNodeID()) + "." + String(channelInfo->getSubProcessorIdx());
-	}
-	fName += File::separatorString;
-	return fName;
+    String fName = (channelInfo->getCurrentNodeName().replaceCharacter(' ', '_') + "-" + String(channelInfo->getCurrentNodeID()));
+    if (channelInfo->getCurrentNodeID() == channelInfo->getSourceNodeID()) //it is the channel source
+    {
+        fName += "." + String(channelInfo->getSubProcessorIdx());
+    }
+    else
+    {
+        fName += "_" + String(channelInfo->getSourceNodeID()) + "." + String(channelInfo->getSubProcessorIdx());
+    }
+    fName += File::separatorString;
+    return fName;
 }
 
 void BinaryRecording::openFiles(File rootFolder, int experimentNumber, int recordingNumber)
 {
-	String basepath = rootFolder.getFullPathName() + rootFolder.separatorString + "experiment" + String(experimentNumber)
-		+ File::separatorString + "recording" + String(recordingNumber + 1) + File::separatorString;
-	String contPath = basepath + "continuous" + File::separatorString;
-	//Open channel files
-	int nProcessors = getNumRecordedProcessors();
+    String basepath = rootFolder.getFullPathName() + rootFolder.separatorString + "experiment" + String(experimentNumber)
+        + File::separatorString + "recording" + String(recordingNumber + 1) + File::separatorString;
+    String contPath = basepath + "continuous" + File::separatorString;
+    //Open channel files
+    int nProcessors = getNumRecordedProcessors();
 
-	m_channelIndexes.insertMultiple(0, 0, getNumRecordedChannels());
-	m_fileIndexes.insertMultiple(0, 0, getNumRecordedChannels());
+    m_channelIndexes.insertMultiple(0, 0, getNumRecordedChannels());
+    m_fileIndexes.insertMultiple(0, 0, getNumRecordedChannels());
 
-	Array<const DataChannel*> indexedDataChannels;
-	Array<unsigned int> indexedChannelCount;
-	Array<var> jsonContinuousfiles;
-	Array<var> jsonChannels;
-	StringArray continuousFileNames;
-	int lastId = 0;
-	for (int proc = 0; proc < nProcessors; proc++)
-	{
-		const RecordProcessorInfo& pInfo = getProcessorInfo(proc);
-		int recChans = pInfo.recordedChannels.size();
+    Array<const DataChannel*> indexedDataChannels;
+    Array<unsigned int> indexedChannelCount;
+    Array<var> jsonContinuousfiles;
+    Array<var> jsonChannels;
+    StringArray continuousFileNames;
+    int lastId = 0;
+    for (int proc = 0; proc < nProcessors; proc++)
+    {
+        const RecordProcessorInfo& pInfo = getProcessorInfo(proc);
+        int recChans = pInfo.recordedChannels.size();
 
-		for (int chan = 0; chan < recChans; chan++)
-		{
-			int recordedChan = pInfo.recordedChannels[chan];
-			int realChan = getRealChannel(recordedChan);
-			const DataChannel* channelInfo = getDataChannel(realChan);
-			int sourceId = channelInfo->getSourceNodeID();
-			int sourceSubIdx = channelInfo->getSubProcessorIdx();
-			int nInfoArrays = indexedDataChannels.size();
-			bool found = false;
-			DynamicObject::Ptr jsonChan = new DynamicObject();
-			jsonChan->setProperty("channel_name", channelInfo->getName());
-			jsonChan->setProperty("description", channelInfo->getDescription());
-			jsonChan->setProperty("identifier", channelInfo->getIdentifier());
-			jsonChan->setProperty("history", channelInfo->getHistoricString());
-			jsonChan->setProperty("bit_volts", channelInfo->getBitVolts());
-			jsonChan->setProperty("units", channelInfo->getDataUnits());
-			jsonChan->setProperty("source_processor_index", channelInfo->getSourceIndex());
-			jsonChan->setProperty("recorded_processor_index", channelInfo->getCurrentNodeChannelIdx());
-			createChannelMetaData(channelInfo, jsonChan);
-			for (int i = lastId; i < nInfoArrays; i++)
-			{
-				if (sourceId == indexedDataChannels[i]->getSourceNodeID() && sourceSubIdx == indexedDataChannels[i]->getSubProcessorIdx())
-				{
-					unsigned int count = indexedChannelCount[i];
-					m_channelIndexes.set(recordedChan, count);
-					m_fileIndexes.set(recordedChan, i);
-					indexedChannelCount.set(i, count + 1);
-					jsonChannels.getReference(i).append(var(jsonChan));
-					found = true;
-					break;
-				}
-			}
-			if (!found)
-			{
-				String datPath = getProcessorString(channelInfo);
-				continuousFileNames.add(contPath + datPath + "continuous.dat");
-				
-				ScopedPointer<NpyFile> tFile = new NpyFile(contPath + datPath + "timestamps.npy", NpyType(BaseType::INT64,1));
-				m_dataTimestampFiles.add(tFile.release());
+        for (int chan = 0; chan < recChans; chan++)
+        {
+            int recordedChan = pInfo.recordedChannels[chan];
+            int realChan = getRealChannel(recordedChan);
+            const DataChannel* channelInfo = getDataChannel(realChan);
+            int sourceId = channelInfo->getSourceNodeID();
+            int sourceSubIdx = channelInfo->getSubProcessorIdx();
+            int nInfoArrays = indexedDataChannels.size();
+            bool found = false;
+            DynamicObject::Ptr jsonChan = new DynamicObject();
+            jsonChan->setProperty("channel_name", channelInfo->getName());
+            jsonChan->setProperty("description", channelInfo->getDescription());
+            jsonChan->setProperty("identifier", channelInfo->getIdentifier());
+            jsonChan->setProperty("history", channelInfo->getHistoricString());
+            jsonChan->setProperty("bit_volts", channelInfo->getBitVolts());
+            jsonChan->setProperty("units", channelInfo->getDataUnits());
+            jsonChan->setProperty("source_processor_index", channelInfo->getSourceIndex());
+            jsonChan->setProperty("recorded_processor_index", channelInfo->getCurrentNodeChannelIdx());
+            createChannelMetaData(channelInfo, jsonChan);
+            for (int i = lastId; i < nInfoArrays; i++)
+            {
+                if (sourceId == indexedDataChannels[i]->getSourceNodeID() && sourceSubIdx == indexedDataChannels[i]->getSubProcessorIdx())
+                {
+                    unsigned int count = indexedChannelCount[i];
+                    m_channelIndexes.set(recordedChan, count);
+                    m_fileIndexes.set(recordedChan, i);
+                    indexedChannelCount.set(i, count + 1);
+                    jsonChannels.getReference(i).append(var(jsonChan));
+                    found = true;
+                    break;
+                }
+            }
+            if (!found)
+            {
+                String datPath = getProcessorString(channelInfo);
+                continuousFileNames.add(contPath + datPath + "continuous.dat");
 
-				m_fileIndexes.set(recordedChan, nInfoArrays);
-				m_channelIndexes.set(recordedChan, 0);
-				indexedChannelCount.add(1);
-				indexedDataChannels.add(channelInfo);
+                ScopedPointer<NpyFile> tFile = new NpyFile(contPath + datPath + "timestamps.npy", NpyType(BaseType::INT64,1));
+                m_dataTimestampFiles.add(tFile.release());
 
-				Array<var> jsonChanArray;
-				jsonChanArray.add(var(jsonChan));
-				jsonChannels.add(var(jsonChanArray));
-				DynamicObject::Ptr jsonFile = new DynamicObject();
-				jsonFile->setProperty("folder_name", datPath.replace(File::separatorString, "/")); //to make it more system agnostic, replace separator with only one slash
-				jsonFile->setProperty("sample_rate", channelInfo->getSampleRate());
-				jsonFile->setProperty("source_processor_name", channelInfo->getSourceName());
-				jsonFile->setProperty("source_processor_id", channelInfo->getSourceNodeID());
-				jsonFile->setProperty("source_processor_sub_idx", channelInfo->getSubProcessorIdx());
-				jsonFile->setProperty("recorded_processor", channelInfo->getCurrentNodeName());
-				jsonFile->setProperty("recorded_processor_id", channelInfo->getCurrentNodeID());
-				jsonContinuousfiles.add(var(jsonFile));
-			}
-		}
-		lastId = indexedDataChannels.size();
-	}
-	int nFiles = continuousFileNames.size();
-	for (int i = 0; i < nFiles; i++)
-	{
-		int numChannels = jsonChannels.getReference(i).size();
-		ScopedPointer<SequentialBlockFile> bFile = new SequentialBlockFile(numChannels, samplesPerBlock);
-		if (bFile->openFile(continuousFileNames[i]))
-			m_DataFiles.add(bFile.release());
-		else
-			m_DataFiles.add(nullptr);
-		DynamicObject::Ptr jsonFile = jsonContinuousfiles.getReference(i).getDynamicObject();
-		jsonFile->setProperty("num_channels", numChannels);
-		jsonFile->setProperty("channels", jsonChannels.getReference(i));
-	}
+                m_fileIndexes.set(recordedChan, nInfoArrays);
+                m_channelIndexes.set(recordedChan, 0);
+                indexedChannelCount.add(1);
+                indexedDataChannels.add(channelInfo);
 
-	int nChans = getNumRecordedChannels();
-	//Timestamps
-	Array<uint32> procIDs;
-	for (int i = 0; i < nChans; i++)
-	{
-		if (i == 0)
-			std::cout << "Start timestamp: " << getTimestamp(i) << std::endl;
-		m_startTS.add(getTimestamp(i));
-	}
+                Array<var> jsonChanArray;
+                jsonChanArray.add(var(jsonChan));
+                jsonChannels.add(var(jsonChanArray));
+                DynamicObject::Ptr jsonFile = new DynamicObject();
+                jsonFile->setProperty("folder_name", datPath.replace(File::separatorString, "/")); //to make it more system agnostic, replace separator with only one slash
+                jsonFile->setProperty("sample_rate", channelInfo->getSampleRate());
+                jsonFile->setProperty("source_processor_name", channelInfo->getSourceName());
+                jsonFile->setProperty("source_processor_id", channelInfo->getSourceNodeID());
+                jsonFile->setProperty("source_processor_sub_idx", channelInfo->getSubProcessorIdx());
+                jsonFile->setProperty("recorded_processor", channelInfo->getCurrentNodeName());
+                jsonFile->setProperty("recorded_processor_id", channelInfo->getCurrentNodeID());
+                jsonContinuousfiles.add(var(jsonFile));
+            }
+        }
+        lastId = indexedDataChannels.size();
+    }
+    int nFiles = continuousFileNames.size();
+    for (int i = 0; i < nFiles; i++)
+    {
+        int numChannels = jsonChannels.getReference(i).size();
+        ScopedPointer<SequentialBlockFile> bFile = new SequentialBlockFile(numChannels, samplesPerBlock);
+        if (bFile->openFile(continuousFileNames[i]))
+            m_DataFiles.add(bFile.release());
+        else
+            m_DataFiles.add(nullptr);
+        DynamicObject::Ptr jsonFile = jsonContinuousfiles.getReference(i).getDynamicObject();
+        jsonFile->setProperty("num_channels", numChannels);
+        jsonFile->setProperty("channels", jsonChannels.getReference(i));
+    }
 
-	int nEvents = getNumRecordedEvents();
-	String eventPath(basepath + "events" + File::separatorString);
-	Array<var> jsonEventFiles;
+    int nChans = getNumRecordedChannels();
+    //Timestamps
+    Array<uint32> procIDs;
+    for (int i = 0; i < nChans; i++)
+    {
+        if (i == 0)
+            std::cout << "Start timestamp: " << getTimestamp(i) << std::endl;
+        m_startTS.add(getTimestamp(i));
+    }
 
-	for (int ev = 0; ev < nEvents; ev++)
-	{
-		const EventChannel* chan = getEventChannel(ev);
-		String eventName = getProcessorString(chan);
-		NpyType type;
-		String dataFileName;
+    int nEvents = getNumRecordedEvents();
+    String eventPath(basepath + "events" + File::separatorString);
+    Array<var> jsonEventFiles;
 
-		switch (chan->getChannelType())
-		{
-		case EventChannel::TEXT:
-			eventName += "TEXT_group";
-			type = NpyType(BaseType::CHAR, chan->getLength());
-			dataFileName = "text";
-			break;
-		case EventChannel::TTL:
-			eventName += "TTL";
-			type = NpyType(BaseType::INT16, 1);
-			dataFileName = "channel_states";
-			break;
-		default:
-			eventName += "BINARY_group";
-			type = NpyType(chan->getEquivalentMetaDataType(), chan->getLength());
-			dataFileName = "data_array";
-			break;
-		}
-		eventName += "_" + String(chan->getSourceIndex() + 1) + File::separatorString;
-		ScopedPointer<EventRecording> rec = new EventRecording();
-		
-		rec->mainFile = new NpyFile(eventPath + eventName + dataFileName + ".npy", type);
-		rec->timestampFile = new NpyFile(eventPath + eventName + "timestamps.npy", NpyType(BaseType::INT64, 1));
-		rec->channelFile = new NpyFile(eventPath + eventName + "channels.npy", NpyType(BaseType::UINT16, 1));
-		if (chan->getChannelType() == EventChannel::TTL && m_saveTTLWords)
-		{
-			rec->extraFile = new NpyFile(eventPath + eventName + "full_words.npy", NpyType(BaseType::UINT8, chan->getDataSize()));
-		}
+    for (int ev = 0; ev < nEvents; ev++)
+    {
+        const EventChannel* chan = getEventChannel(ev);
+        String eventName = getProcessorString(chan);
+        NpyType type;
+        String dataFileName;
 
-		DynamicObject::Ptr jsonChannel = new DynamicObject();
-		jsonChannel->setProperty("folder_name", eventName.replace(File::separatorString, "/"));
-		jsonChannel->setProperty("channel_name", chan->getName());
-		jsonChannel->setProperty("description", chan->getDescription());
-		jsonChannel->setProperty("identifier", chan->getIdentifier());
-		jsonChannel->setProperty("sample_rate", chan->getSampleRate());
-		jsonChannel->setProperty("type", jsonTypeValue(type.getType()));
-		jsonChannel->setProperty("num_channels", (int)chan->getNumChannels());
-		jsonChannel->setProperty("source_processor", chan->getSourceName());
-		createChannelMetaData(chan, jsonChannel);
+        switch (chan->getChannelType())
+        {
+        case EventChannel::TEXT:
+            eventName += "TEXT_group";
+            type = NpyType(BaseType::CHAR, chan->getLength());
+            dataFileName = "text";
+            break;
+        case EventChannel::TTL:
+            eventName += "TTL";
+            type = NpyType(BaseType::INT16, 1);
+            dataFileName = "channel_states";
+            break;
+        default:
+            eventName += "BINARY_group";
+            type = NpyType(chan->getEquivalentMetaDataType(), chan->getLength());
+            dataFileName = "data_array";
+            break;
+        }
+        eventName += "_" + String(chan->getSourceIndex() + 1) + File::separatorString;
+        ScopedPointer<EventRecording> rec = new EventRecording();
 
-		rec->metaDataFile = createEventMetadataFile(chan, eventPath + eventName + "metadata.npy", jsonChannel);
-		m_eventFiles.add(rec.release());
-		jsonEventFiles.add(var(jsonChannel));
-	}
+        rec->mainFile = new NpyFile(eventPath + eventName + dataFileName + ".npy", type);
+        rec->timestampFile = new NpyFile(eventPath + eventName + "timestamps.npy", NpyType(BaseType::INT64, 1));
+        rec->channelFile = new NpyFile(eventPath + eventName + "channels.npy", NpyType(BaseType::UINT16, 1));
+        if (chan->getChannelType() == EventChannel::TTL && m_saveTTLWords)
+        {
+            rec->extraFile = new NpyFile(eventPath + eventName + "full_words.npy", NpyType(BaseType::UINT8, chan->getDataSize()));
+        }
 
-	int nSpikes = getNumRecordedSpikes();
-	Array<const SpikeChannel*> indexedSpikes;
-	Array<uint16> indexedChannels;
-	m_spikeFileIndexes.insertMultiple(0, 0, nSpikes);
-	m_spikeChannelIndexes.insertMultiple(0, 0, nSpikes);
-	String spikePath(basepath + "spikes" + File::separatorString);
-	Array<var> jsonSpikeFiles;
-	Array<var> jsonSpikeChannels;
-	std::map<uint32, int> groupMap;
-	for (int sp = 0; sp < nSpikes; sp++)
-	{
-		const SpikeChannel* ch = getSpikeChannel(sp);
-		DynamicObject::Ptr jsonChannel = new DynamicObject();
-		unsigned int numSpikeChannels = ch->getNumChannels();
-		jsonChannel->setProperty("channel_name", ch->getName());
-		jsonChannel->setProperty("description", ch->getDescription());
-		jsonChannel->setProperty("identifier", ch->getIdentifier());
-		Array<var> jsonChannelInfo;
-		for (int i = 0; i < numSpikeChannels; i++)
-		{
-			SourceChannelInfo sourceInfo = ch->getSourceChannelInfo()[i];
-			DynamicObject::Ptr jsonSpikeChInfo = new DynamicObject();
-			jsonSpikeChInfo->setProperty("source_processor_id", sourceInfo.processorID);
-			jsonSpikeChInfo->setProperty("source_processor_sub_idx", sourceInfo.subProcessorID);
-			jsonSpikeChInfo->setProperty("source_processor_channel", sourceInfo.channelIDX);
-			jsonChannelInfo.add(var(jsonSpikeChInfo));
-		}
-		jsonChannel->setProperty("source_channel_info", jsonChannelInfo);
-		createChannelMetaData(ch, jsonChannel);
+        DynamicObject::Ptr jsonChannel = new DynamicObject();
+        jsonChannel->setProperty("folder_name", eventName.replace(File::separatorString, "/"));
+        jsonChannel->setProperty("channel_name", chan->getName());
+        jsonChannel->setProperty("description", chan->getDescription());
+        jsonChannel->setProperty("identifier", chan->getIdentifier());
+        jsonChannel->setProperty("sample_rate", chan->getSampleRate());
+        jsonChannel->setProperty("type", jsonTypeValue(type.getType()));
+        jsonChannel->setProperty("num_channels", (int)chan->getNumChannels());
+        jsonChannel->setProperty("source_processor", chan->getSourceName());
+        createChannelMetaData(chan, jsonChannel);
 
-		int nIndexed = indexedSpikes.size();
-		bool found = false;
-		for (int i = 0; i < nIndexed; i++)
-		{
-			const SpikeChannel* ich = indexedSpikes[i];
-			//identical channels (same data and metadata) from the same processor go to the same file
-			if (ch->getSourceNodeID() == ich->getSourceNodeID() && ch->getSubProcessorIdx() == ich->getSubProcessorIdx() && *ch == *ich)
-			{
-				found = true;
-				m_spikeFileIndexes.set(sp, i);
-				unsigned int numChans = indexedChannels[i];
-				indexedChannels.set(i, numChans);
-				m_spikeChannelIndexes.set(sp, numChans + 1);
-				jsonSpikeChannels.getReference(i).append(var(jsonChannel));
-				break;
-			}
-		}
-		
-		if (!found)
-		{
-			int fileIndex = m_spikeFiles.size();
-			m_spikeFileIndexes.set(sp, fileIndex);
-			indexedSpikes.add(ch);
-			m_spikeChannelIndexes.set(sp, 0);
-			indexedChannels.add(1);
-			ScopedPointer<EventRecording> rec = new EventRecording();
-			
-			uint32 procID = GenericProcessor::getProcessorFullId(ch->getSourceNodeID(), ch->getSubProcessorIdx());
-			int groupIndex = ++groupMap[procID];
+        rec->metaDataFile = createEventMetadataFile(chan, eventPath + eventName + "metadata.npy", jsonChannel);
+        m_eventFiles.add(rec.release());
+        jsonEventFiles.add(var(jsonChannel));
+    }
 
-			String spikeName = getProcessorString(ch) + "spike_group_" + String(groupIndex) + File::separatorString;
+    int nSpikes = getNumRecordedSpikes();
+    Array<const SpikeChannel*> indexedSpikes;
+    Array<uint16> indexedChannels;
+    m_spikeFileIndexes.insertMultiple(0, 0, nSpikes);
+    m_spikeChannelIndexes.insertMultiple(0, 0, nSpikes);
+    String spikePath(basepath + "spikes" + File::separatorString);
+    Array<var> jsonSpikeFiles;
+    Array<var> jsonSpikeChannels;
+    std::map<uint32, int> groupMap;
+    for (int sp = 0; sp < nSpikes; sp++)
+    {
+        const SpikeChannel* ch = getSpikeChannel(sp);
+        DynamicObject::Ptr jsonChannel = new DynamicObject();
+        unsigned int numSpikeChannels = ch->getNumChannels();
+        jsonChannel->setProperty("channel_name", ch->getName());
+        jsonChannel->setProperty("description", ch->getDescription());
+        jsonChannel->setProperty("identifier", ch->getIdentifier());
+        Array<var> jsonChannelInfo;
+        for (int i = 0; i < numSpikeChannels; i++)
+        {
+            SourceChannelInfo sourceInfo = ch->getSourceChannelInfo()[i];
+            DynamicObject::Ptr jsonSpikeChInfo = new DynamicObject();
+            jsonSpikeChInfo->setProperty("source_processor_id", sourceInfo.processorID);
+            jsonSpikeChInfo->setProperty("source_processor_sub_idx", sourceInfo.subProcessorID);
+            jsonSpikeChInfo->setProperty("source_processor_channel", sourceInfo.channelIDX);
+            jsonChannelInfo.add(var(jsonSpikeChInfo));
+        }
+        jsonChannel->setProperty("source_channel_info", jsonChannelInfo);
+        createChannelMetaData(ch, jsonChannel);
 
-			rec->mainFile = new NpyFile(spikePath + spikeName + "spike_waveforms.npy", NpyType(BaseType::INT16, ch->getTotalSamples()), ch->getNumChannels());
-			rec->timestampFile = new NpyFile(spikePath + spikeName + "spike_times.npy", NpyType(BaseType::INT64, 1));
-			rec->channelFile = new NpyFile(spikePath + spikeName + "spike_electrode_indices.npy", NpyType(BaseType::UINT16, 1));
-			rec->extraFile = new NpyFile(spikePath + spikeName + "spike_clusters.npy", NpyType(BaseType::UINT16, 1));
-			Array<NpyType> tsTypes;
-			
-			Array<var> jsonChanArray;
-			jsonChanArray.add(var(jsonChannel));
-			jsonSpikeChannels.add(var(jsonChanArray));
-			DynamicObject::Ptr jsonFile = new DynamicObject();
-			
-			jsonFile->setProperty("folder_name", spikeName.replace(File::separatorString,"/"));
-			jsonFile->setProperty("sample_rate", ch->getSampleRate());
-			jsonFile->setProperty("source_processor", ch->getSourceName());
-			jsonFile->setProperty("num_channels", (int)numSpikeChannels);
-			jsonFile->setProperty("pre_peak_samples", (int)ch->getPrePeakSamples());
-			jsonFile->setProperty("post_peak_samples", (int)ch->getPostPeakSamples());
-			
-			rec->metaDataFile = createEventMetadataFile(ch, spikePath + spikeName + "metadata.npy", jsonFile);
-			m_spikeFiles.add(rec.release());
-			jsonSpikeFiles.add(var(jsonFile));
-		}
-	}
-	int nSpikeFiles = jsonSpikeFiles.size();
-	for (int i = 0; i < nSpikeFiles; i++)
-	{
-		int size = jsonSpikeChannels.getReference(i).size();
-		DynamicObject::Ptr jsonFile = jsonSpikeFiles.getReference(i).getDynamicObject();
-		jsonFile->setProperty("num_channels", size);
-		jsonFile->setProperty("channels", jsonSpikeChannels.getReference(i));
-	}
+        int nIndexed = indexedSpikes.size();
+        bool found = false;
+        for (int i = 0; i < nIndexed; i++)
+        {
+            const SpikeChannel* ich = indexedSpikes[i];
+            //identical channels (same data and metadata) from the same processor go to the same file
+            if (ch->getSourceNodeID() == ich->getSourceNodeID() && ch->getSubProcessorIdx() == ich->getSubProcessorIdx() && *ch == *ich)
+            {
+                found = true;
+                m_spikeFileIndexes.set(sp, i);
+                unsigned int numChans = indexedChannels[i];
+                indexedChannels.set(i, numChans);
+                m_spikeChannelIndexes.set(sp, numChans + 1);
+                jsonSpikeChannels.getReference(i).append(var(jsonChannel));
+                break;
+            }
+        }
 
-	File syncFile = File(basepath + "sync_messages.txt");
-	Result res = syncFile.create();
-	if (res.failed())
-	{
-		std::cerr << "Error creating sync text file:" << res.getErrorMessage() << std::endl;
-	}
-	else
-	{
-		m_syncTextFile = syncFile.createOutputStream();
-	}
-	
-	m_recordingNum = recordingNumber;
+        if (!found)
+        {
+            int fileIndex = m_spikeFiles.size();
+            m_spikeFileIndexes.set(sp, fileIndex);
+            indexedSpikes.add(ch);
+            m_spikeChannelIndexes.set(sp, 0);
+            indexedChannels.add(1);
+            ScopedPointer<EventRecording> rec = new EventRecording();
 
-	DynamicObject::Ptr jsonSettingsFile = new DynamicObject();
-	jsonSettingsFile->setProperty("GUI version", CoreServices::getGUIVersion());
-	jsonSettingsFile->setProperty("continuous", jsonContinuousfiles);
-	jsonSettingsFile->setProperty("events", jsonEventFiles);
-	jsonSettingsFile->setProperty("spikes", jsonSpikeFiles);
-	FileOutputStream settingsFileStream(File(basepath + "structure.oebin"));
+            uint32 procID = GenericProcessor::getProcessorFullId(ch->getSourceNodeID(), ch->getSubProcessorIdx());
+            int groupIndex = ++groupMap[procID];
 
-	jsonSettingsFile->writeAsJSON(settingsFileStream, 2, false);
+            String spikeName = getProcessorString(ch) + "spike_group_" + String(groupIndex) + File::separatorString;
+
+            rec->mainFile = new NpyFile(spikePath + spikeName + "spike_waveforms.npy", NpyType(BaseType::INT16, ch->getTotalSamples()), ch->getNumChannels());
+            rec->timestampFile = new NpyFile(spikePath + spikeName + "spike_times.npy", NpyType(BaseType::INT64, 1));
+            rec->channelFile = new NpyFile(spikePath + spikeName + "spike_electrode_indices.npy", NpyType(BaseType::UINT16, 1));
+            rec->extraFile = new NpyFile(spikePath + spikeName + "spike_clusters.npy", NpyType(BaseType::UINT16, 1));
+            Array<NpyType> tsTypes;
+
+            Array<var> jsonChanArray;
+            jsonChanArray.add(var(jsonChannel));
+            jsonSpikeChannels.add(var(jsonChanArray));
+            DynamicObject::Ptr jsonFile = new DynamicObject();
+
+            jsonFile->setProperty("folder_name", spikeName.replace(File::separatorString,"/"));
+            jsonFile->setProperty("sample_rate", ch->getSampleRate());
+            jsonFile->setProperty("source_processor", ch->getSourceName());
+            jsonFile->setProperty("num_channels", (int)numSpikeChannels);
+            jsonFile->setProperty("pre_peak_samples", (int)ch->getPrePeakSamples());
+            jsonFile->setProperty("post_peak_samples", (int)ch->getPostPeakSamples());
+
+            rec->metaDataFile = createEventMetadataFile(ch, spikePath + spikeName + "metadata.npy", jsonFile);
+            m_spikeFiles.add(rec.release());
+            jsonSpikeFiles.add(var(jsonFile));
+        }
+    }
+    int nSpikeFiles = jsonSpikeFiles.size();
+    for (int i = 0; i < nSpikeFiles; i++)
+    {
+        int size = jsonSpikeChannels.getReference(i).size();
+        DynamicObject::Ptr jsonFile = jsonSpikeFiles.getReference(i).getDynamicObject();
+        jsonFile->setProperty("num_channels", size);
+        jsonFile->setProperty("channels", jsonSpikeChannels.getReference(i));
+    }
+
+    File syncFile = File(basepath + "sync_messages.txt");
+    Result res = syncFile.create();
+    if (res.failed())
+    {
+        std::cerr << "Error creating sync text file:" << res.getErrorMessage() << std::endl;
+    }
+    else
+    {
+        m_syncTextFile = syncFile.createOutputStream();
+    }
+
+    m_recordingNum = recordingNumber;
+
+    DynamicObject::Ptr jsonSettingsFile = new DynamicObject();
+    jsonSettingsFile->setProperty("GUI version", CoreServices::getGUIVersion());
+    jsonSettingsFile->setProperty("continuous", jsonContinuousfiles);
+    jsonSettingsFile->setProperty("events", jsonEventFiles);
+    jsonSettingsFile->setProperty("spikes", jsonSpikeFiles);
+    FileOutputStream settingsFileStream(File(basepath + "structure.oebin"));
+
+    jsonSettingsFile->writeAsJSON(settingsFileStream, 2, false);
 }
 
 NpyFile* BinaryRecording::createEventMetadataFile(const MetaDataEventObject* channel, String filename, DynamicObject* jsonFile)
 {
-	int nMetaData = channel->getEventMetaDataCount();
-	if (nMetaData < 1) return nullptr;
+    int nMetaData = channel->getEventMetaDataCount();
+    if (nMetaData < 1) return nullptr;
 
-	Array<NpyType> types;
-	Array<var> jsonMetaData;
-	for (int i = 0; i < nMetaData; i++)
-	{
-		const MetaDataDescriptor* md = channel->getEventMetaDataDescriptor(i);
-		types.add(NpyType(md->getName(), md->getType(), md->getLength()));
-		DynamicObject::Ptr jsonValues = new DynamicObject();
-		jsonValues->setProperty("name", md->getName());
-		jsonValues->setProperty("description", md->getDescription());
-		jsonValues->setProperty("identifier", md->getIdentifier());
-		jsonValues->setProperty("type", jsonTypeValue(md->getType()));
-		jsonValues->setProperty("length", (int)md->getLength());
-		jsonMetaData.add(var(jsonValues));
-	}
-	if (jsonFile)
-		jsonFile->setProperty("event_metadata", jsonMetaData);
-	return new NpyFile(filename, types);
+    Array<NpyType> types;
+    Array<var> jsonMetaData;
+    for (int i = 0; i < nMetaData; i++)
+    {
+        const MetaDataDescriptor* md = channel->getEventMetaDataDescriptor(i);
+        types.add(NpyType(md->getName(), md->getType(), md->getLength()));
+        DynamicObject::Ptr jsonValues = new DynamicObject();
+        jsonValues->setProperty("name", md->getName());
+        jsonValues->setProperty("description", md->getDescription());
+        jsonValues->setProperty("identifier", md->getIdentifier());
+        jsonValues->setProperty("type", jsonTypeValue(md->getType()));
+        jsonValues->setProperty("length", (int)md->getLength());
+        jsonMetaData.add(var(jsonValues));
+    }
+    if (jsonFile)
+        jsonFile->setProperty("event_metadata", jsonMetaData);
+    return new NpyFile(filename, types);
 }
 
 template <typename TO, typename FROM>
 void dataToVar(var& dataTo, const void* dataFrom, int length)
 {
-	const FROM* buffer = reinterpret_cast<const FROM*>(dataFrom);
-	for (int i = 0; i < length; i++)
-	{
-		dataTo.append(static_cast<TO>(*(buffer + i)));
-	}
+    const FROM* buffer = reinterpret_cast<const FROM*>(dataFrom);
+    for (int i = 0; i < length; i++)
+    {
+        dataTo.append(static_cast<TO>(*(buffer + i)));
+    }
 }
 
 void BinaryRecording::createChannelMetaData(const MetaDataInfoObject* channel, DynamicObject* jsonFile)
 {
-	int nMetaData = channel->getMetaDataCount();
-	if (nMetaData < 1) return;
+    int nMetaData = channel->getMetaDataCount();
+    if (nMetaData < 1) return;
 
-	Array<var> jsonMetaData;
-	for (int i = 0; i < nMetaData; i++)
-	{
-		const MetaDataDescriptor* md = channel->getMetaDataDescriptor(i);
-		const MetaDataValue* mv = channel->getMetaDataValue(i);
-		DynamicObject::Ptr jsonValues = new DynamicObject();
-		MetaDataDescriptor::MetaDataTypes type = md->getType();
-		unsigned int length = md->getLength();
-		jsonValues->setProperty("name", md->getName());
-		jsonValues->setProperty("description", md->getDescription());
-		jsonValues->setProperty("identifier", md->getIdentifier());
-		jsonValues->setProperty("type", jsonTypeValue(type));
-		jsonValues->setProperty("length", (int)length);
-		var val;
-		if (type == MetaDataDescriptor::CHAR)
-		{
-			String tmp;
-			mv->getValue(tmp);
-			val = tmp;
-		}
-		else
-		{
-			const void* buf = mv->getRawValuePointer();
-			switch (type)
-			{
-			case MetaDataDescriptor::INT8:
-				dataToVar<int, int8>(val, buf, length);
-				break;
-			case MetaDataDescriptor::UINT8:
-				dataToVar<int, uint8>(val, buf, length);
-				break;
-			case MetaDataDescriptor::INT16:
-				dataToVar<int, int16>(val, buf, length);
-				break;
-			case MetaDataDescriptor::UINT16:
-				dataToVar<int, uint16>(val, buf, length);
-				break;
-			case MetaDataDescriptor::INT32:
-				dataToVar<int, int32>(val, buf, length);
-				break;
-				//A full uint32 doesn't fit in a regular int, so we increase size
-			case MetaDataDescriptor::UINT32:
-				dataToVar<int64, uint8>(val, buf, length);
-				break;
-			case MetaDataDescriptor::INT64:
-				dataToVar<int64, int64>(val, buf, length);
-				break;
-				//This might overrun and end negative if the uint64 is really big, but there is no way to store a full uint64 in a var
-			case MetaDataDescriptor::UINT64:
-				dataToVar<int64, uint64>(val, buf, length);
-				break;
-			case MetaDataDescriptor::FLOAT:
-				dataToVar<float, float>(val, buf, length);
-				break;
-			case MetaDataDescriptor::DOUBLE:
-				dataToVar<double, double>(val, buf, length);
-				break;
-			default:
-				val = "invalid";
-			}
-		}
-		jsonValues->setProperty("value", val);
-		jsonMetaData.add(var(jsonValues));
-	}
-	jsonFile->setProperty("channel_metadata", jsonMetaData);
+    Array<var> jsonMetaData;
+    for (int i = 0; i < nMetaData; i++)
+    {
+        const MetaDataDescriptor* md = channel->getMetaDataDescriptor(i);
+        const MetaDataValue* mv = channel->getMetaDataValue(i);
+        DynamicObject::Ptr jsonValues = new DynamicObject();
+        MetaDataDescriptor::MetaDataTypes type = md->getType();
+        unsigned int length = md->getLength();
+        jsonValues->setProperty("name", md->getName());
+        jsonValues->setProperty("description", md->getDescription());
+        jsonValues->setProperty("identifier", md->getIdentifier());
+        jsonValues->setProperty("type", jsonTypeValue(type));
+        jsonValues->setProperty("length", (int)length);
+        var val;
+        if (type == MetaDataDescriptor::CHAR)
+        {
+            String tmp;
+            mv->getValue(tmp);
+            val = tmp;
+        }
+        else
+        {
+            const void* buf = mv->getRawValuePointer();
+            switch (type)
+            {
+            case MetaDataDescriptor::INT8:
+                dataToVar<int, int8>(val, buf, length);
+                break;
+            case MetaDataDescriptor::UINT8:
+                dataToVar<int, uint8>(val, buf, length);
+                break;
+            case MetaDataDescriptor::INT16:
+                dataToVar<int, int16>(val, buf, length);
+                break;
+            case MetaDataDescriptor::UINT16:
+                dataToVar<int, uint16>(val, buf, length);
+                break;
+            case MetaDataDescriptor::INT32:
+                dataToVar<int, int32>(val, buf, length);
+                break;
+                //A full uint32 doesn't fit in a regular int, so we increase size
+            case MetaDataDescriptor::UINT32:
+                dataToVar<int64, uint8>(val, buf, length);
+                break;
+            case MetaDataDescriptor::INT64:
+                dataToVar<int64, int64>(val, buf, length);
+                break;
+                //This might overrun and end negative if the uint64 is really big, but there is no way to store a full uint64 in a var
+            case MetaDataDescriptor::UINT64:
+                dataToVar<int64, uint64>(val, buf, length);
+                break;
+            case MetaDataDescriptor::FLOAT:
+                dataToVar<float, float>(val, buf, length);
+                break;
+            case MetaDataDescriptor::DOUBLE:
+                dataToVar<double, double>(val, buf, length);
+                break;
+            default:
+                val = "invalid";
+            }
+        }
+        jsonValues->setProperty("value", val);
+        jsonMetaData.add(var(jsonValues));
+    }
+    jsonFile->setProperty("channel_metadata", jsonMetaData);
 }
 
 void BinaryRecording::closeFiles()
 {
-	resetChannels();
+    resetChannels();
 }
 
 void BinaryRecording::resetChannels()
 {
-	m_DataFiles.clear();
-	m_channelIndexes.clear();
-	m_fileIndexes.clear();
-	m_dataTimestampFiles.clear();
-	m_eventFiles.clear();
-	m_spikeChannelIndexes.clear();
-	m_spikeFileIndexes.clear();
-	m_spikeFiles.clear();
-	m_syncTextFile = nullptr;
+    m_DataFiles.clear();
+    m_channelIndexes.clear();
+    m_fileIndexes.clear();
+    m_dataTimestampFiles.clear();
+    m_eventFiles.clear();
+    m_spikeChannelIndexes.clear();
+    m_spikeFileIndexes.clear();
+    m_spikeFiles.clear();
+    m_syncTextFile = nullptr;
 
-	m_scaledBuffer.malloc(MAX_BUFFER_SIZE);
-	m_intBuffer.malloc(MAX_BUFFER_SIZE);
-	m_tsBuffer.malloc(MAX_BUFFER_SIZE);
-	m_bufferSize = MAX_BUFFER_SIZE;
-	m_startTS.clear();
+    m_scaledBuffer.malloc(MAX_BUFFER_SIZE);
+    m_intBuffer.malloc(MAX_BUFFER_SIZE);
+    m_tsBuffer.malloc(MAX_BUFFER_SIZE);
+    m_bufferSize = MAX_BUFFER_SIZE;
+    m_startTS.clear();
 }
 
 void BinaryRecording::writeData(int writeChannel, int realChannel, const float* buffer, int size)
 {
-	if (size > m_bufferSize) //Shouldn't happen, and if it happens it'll be slow, but better this than crashing. Will be reset on file close and reset.
-	{
-		std::cerr << "Write buffer overrun, resizing to" << size << std::endl;
-		m_bufferSize = size;
-		m_scaledBuffer.malloc(size);
-		m_intBuffer.malloc(size);
-		m_tsBuffer.malloc(size);
-	}
-	double multFactor = 1 / (float(0x7fff) * getDataChannel(realChannel)->getBitVolts());
-	FloatVectorOperations::copyWithMultiply(m_scaledBuffer.getData(), buffer, multFactor, size);
-	AudioDataConverters::convertFloatToInt16LE(m_scaledBuffer.getData(), m_intBuffer.getData(), size);
-	int fileIndex = m_fileIndexes[writeChannel];
-	m_DataFiles[fileIndex]->writeChannel(getTimestamp(writeChannel) - m_startTS[writeChannel], m_channelIndexes[writeChannel], m_intBuffer.getData(), size);
+    if (size > m_bufferSize) //Shouldn't happen, and if it happens it'll be slow, but better this than crashing. Will be reset on file close and reset.
+    {
+        std::cerr << "Write buffer overrun, resizing to" << size << std::endl;
+        m_bufferSize = size;
+        m_scaledBuffer.malloc(size);
+        m_intBuffer.malloc(size);
+        m_tsBuffer.malloc(size);
+    }
+    double multFactor = 1 / (float(0x7fff) * getDataChannel(realChannel)->getBitVolts());
+    FloatVectorOperations::copyWithMultiply(m_scaledBuffer.getData(), buffer, multFactor, size);
+    AudioDataConverters::convertFloatToInt16LE(m_scaledBuffer.getData(), m_intBuffer.getData(), size);
+    int fileIndex = m_fileIndexes[writeChannel];
+    m_DataFiles[fileIndex]->writeChannel(getTimestamp(writeChannel) - m_startTS[writeChannel], m_channelIndexes[writeChannel], m_intBuffer.getData(), size);
 
-	if (m_channelIndexes[writeChannel] == 0)
-	{
-		int64 baseTS = getTimestamp(writeChannel);
-		//Let's hope that the compiler is smart enough to vectorize this. 
-		for (int i = 0; i < size; i++)
-		{
-			m_tsBuffer[i] = (baseTS + i);
-		}
-		m_dataTimestampFiles[fileIndex]->writeData(m_tsBuffer, size*sizeof(int64));
-		m_dataTimestampFiles[fileIndex]->increaseRecordCount(size);
-	}
+    if (m_channelIndexes[writeChannel] == 0)
+    {
+        int64 baseTS = getTimestamp(writeChannel);
+        //Let's hope that the compiler is smart enough to vectorize this.
+        for (int i = 0; i < size; i++)
+        {
+            m_tsBuffer[i] = (baseTS + i);
+        }
+        m_dataTimestampFiles[fileIndex]->writeData(m_tsBuffer, size*sizeof(int64));
+        m_dataTimestampFiles[fileIndex]->increaseRecordCount(size);
+    }
 }
 
 
@@ -505,137 +505,137 @@ void BinaryRecording::addSpikeElectrode(int index, const SpikeChannel* elec)
 
 void BinaryRecording::writeEventMetaData(const MetaDataEvent* event, NpyFile* file)
 {
-	if (!file || !event) return;
-	int nMetaData = event->getMetadataValueCount();
-	for (int i = 0; i < nMetaData; i++)
-	{
-		const MetaDataValue* val = event->getMetaDataValue(i);
-		file->writeData(val->getRawValuePointer(), val->getDataSize());
-	}
+    if (!file || !event) return;
+    int nMetaData = event->getMetadataValueCount();
+    for (int i = 0; i < nMetaData; i++)
+    {
+        const MetaDataValue* val = event->getMetaDataValue(i);
+        file->writeData(val->getRawValuePointer(), val->getDataSize());
+    }
 }
 
 void BinaryRecording::writeEvent(int eventIndex, const MidiMessage& event)
 {
-	EventPtr ev = Event::deserializeFromMessage(event, getEventChannel(eventIndex));
-	EventRecording* rec = m_eventFiles[eventIndex];
-	if (!rec) return;
-	const EventChannel* info = getEventChannel(eventIndex);
-	int64 ts = ev->getTimestamp();
-	rec->timestampFile->writeData(&ts, sizeof(int64));
+    EventPtr ev = Event::deserializeFromMessage(event, getEventChannel(eventIndex));
+    EventRecording* rec = m_eventFiles[eventIndex];
+    if (!rec) return;
+    const EventChannel* info = getEventChannel(eventIndex);
+    int64 ts = ev->getTimestamp();
+    rec->timestampFile->writeData(&ts, sizeof(int64));
 
-	uint16 chan = ev->getChannel() +1;
-	rec->channelFile->writeData(&chan, sizeof(uint16));
+    uint16 chan = ev->getChannel() +1;
+    rec->channelFile->writeData(&chan, sizeof(uint16));
 
-	if (ev->getEventType() == EventChannel::TTL)
-	{
-		TTLEvent* ttl = static_cast<TTLEvent*>(ev.get());
-		int16 data = (ttl->getChannel()+1) * (ttl->getState() ? 1 : -1);
-		rec->mainFile->writeData(&data, sizeof(int16));
-		if (rec->extraFile)
-			rec->extraFile->writeData(ttl->getTTLWordPointer(), info->getDataSize());
-	}
-	else
-	{
-		rec->mainFile->writeData(ev->getRawDataPointer(), info->getDataSize());
-	}
-	
-	writeEventMetaData(ev.get(), rec->metaDataFile);
-	increaseEventCounts(rec);
+    if (ev->getEventType() == EventChannel::TTL)
+    {
+        TTLEvent* ttl = static_cast<TTLEvent*>(ev.get());
+        int16 data = (ttl->getChannel()+1) * (ttl->getState() ? 1 : -1);
+        rec->mainFile->writeData(&data, sizeof(int16));
+        if (rec->extraFile)
+            rec->extraFile->writeData(ttl->getTTLWordPointer(), info->getDataSize());
+    }
+    else
+    {
+        rec->mainFile->writeData(ev->getRawDataPointer(), info->getDataSize());
+    }
+
+    writeEventMetaData(ev.get(), rec->metaDataFile);
+    increaseEventCounts(rec);
 }
 
 void BinaryRecording::writeTimestampSyncText(uint16 sourceID, uint16 sourceIdx, int64 timestamp, float, String text)
 {
-	if (!m_syncTextFile)
-		return;
-	m_syncTextFile->writeText(text + "\n", false, false);
+    if (!m_syncTextFile)
+        return;
+    m_syncTextFile->writeText(text + "\n", false, false);
 }
 
 
 
 void BinaryRecording::writeSpike(int electrodeIndex, const SpikeEvent* spike)
 {
-	const SpikeChannel* channel = getSpikeChannel(electrodeIndex);
-	EventRecording* rec = m_spikeFiles[m_spikeFileIndexes[electrodeIndex]];
-	uint16 spikeChannel = m_spikeChannelIndexes[electrodeIndex];
+    const SpikeChannel* channel = getSpikeChannel(electrodeIndex);
+    EventRecording* rec = m_spikeFiles[m_spikeFileIndexes[electrodeIndex]];
+    uint16 spikeChannel = m_spikeChannelIndexes[electrodeIndex];
 
-	int totalSamples = channel->getTotalSamples() * channel->getNumChannels();
+    int totalSamples = channel->getTotalSamples() * channel->getNumChannels();
 
 
-	if (totalSamples > m_bufferSize) //Shouldn't happen, and if it happens it'll be slow, but better this than crashing. Will be reset on file close and reset.
-	{
-		std::cerr << "(spike) Write buffer overrun, resizing to" << totalSamples << std::endl;
-		m_bufferSize = totalSamples;
-		m_scaledBuffer.malloc(totalSamples);
-		m_intBuffer.malloc(totalSamples);
-	}
-	double multFactor = 1 / (float(0x7fff) * channel->getChannelBitVolts(0));
-	FloatVectorOperations::copyWithMultiply(m_scaledBuffer.getData(), spike->getDataPointer(), multFactor, totalSamples);
-	AudioDataConverters::convertFloatToInt16LE(m_scaledBuffer.getData(), m_intBuffer.getData(), totalSamples);
-	rec->mainFile->writeData(m_intBuffer.getData(), totalSamples*sizeof(int16));
-	
-	int64 ts = spike->getTimestamp();
-	rec->timestampFile->writeData(&ts, sizeof(int64));
+    if (totalSamples > m_bufferSize) //Shouldn't happen, and if it happens it'll be slow, but better this than crashing. Will be reset on file close and reset.
+    {
+        std::cerr << "(spike) Write buffer overrun, resizing to" << totalSamples << std::endl;
+        m_bufferSize = totalSamples;
+        m_scaledBuffer.malloc(totalSamples);
+        m_intBuffer.malloc(totalSamples);
+    }
+    double multFactor = 1 / (float(0x7fff) * channel->getChannelBitVolts(0));
+    FloatVectorOperations::copyWithMultiply(m_scaledBuffer.getData(), spike->getDataPointer(), multFactor, totalSamples);
+    AudioDataConverters::convertFloatToInt16LE(m_scaledBuffer.getData(), m_intBuffer.getData(), totalSamples);
+    rec->mainFile->writeData(m_intBuffer.getData(), totalSamples*sizeof(int16));
 
-	rec->channelFile->writeData(&spikeChannel, sizeof(uint16));
+    int64 ts = spike->getTimestamp();
+    rec->timestampFile->writeData(&ts, sizeof(int64));
 
-	uint16 sortedID = spike->getSortedID();
-	rec->extraFile->writeData(&sortedID, sizeof(uint16));
-	writeEventMetaData(spike, rec->metaDataFile);
+    rec->channelFile->writeData(&spikeChannel, sizeof(uint16));
 
-	increaseEventCounts(rec);
+    uint16 sortedID = spike->getSortedID();
+    rec->extraFile->writeData(&sortedID, sizeof(uint16));
+    writeEventMetaData(spike, rec->metaDataFile);
+
+    increaseEventCounts(rec);
 }
 
 void BinaryRecording::increaseEventCounts(EventRecording* rec)
 {
-	rec->mainFile->increaseRecordCount();
-	rec->timestampFile->increaseRecordCount();
-	if (rec->extraFile) rec->extraFile->increaseRecordCount();
-	if (rec->channelFile) rec->channelFile->increaseRecordCount();
-	if (rec->metaDataFile) rec->metaDataFile->increaseRecordCount();
+    rec->mainFile->increaseRecordCount();
+    rec->timestampFile->increaseRecordCount();
+    if (rec->extraFile) rec->extraFile->increaseRecordCount();
+    if (rec->channelFile) rec->channelFile->increaseRecordCount();
+    if (rec->metaDataFile) rec->metaDataFile->increaseRecordCount();
 }
 
 RecordEngineManager* BinaryRecording::getEngineManager()
 {
-	RecordEngineManager* man = new RecordEngineManager("RAWBINARY", "Binary", &(engineFactory<BinaryRecording>));
-	EngineParameter* param;
-	param = new EngineParameter(EngineParameter::BOOL, 0, "Record TTL full words", true);
-	man->addParameter(param);
-	
-	return man;
+    RecordEngineManager* man = new RecordEngineManager("RAWBINARY", "Binary", &(engineFactory<BinaryRecording>));
+    EngineParameter* param;
+    param = new EngineParameter(EngineParameter::BOOL, 0, "Record TTL full words", true);
+    man->addParameter(param);
+
+    return man;
 }
 
 void BinaryRecording::setParameter(EngineParameter& parameter)
 {
-	boolParameter(0, m_saveTTLWords);
+    boolParameter(0, m_saveTTLWords);
 }
 
 String BinaryRecording::jsonTypeValue(BaseType type)
 {
-	switch (type)
-	{
-	case BaseType::CHAR:
-		return "string";
-	case BaseType::INT8:
-		return "int8";
-	case BaseType::UINT8:
-		return "uint8";
-	case BaseType::INT16:
-		return "int16";
-	case BaseType::UINT16:
-		return "uint16";
-	case BaseType::INT32:
-		return "int32";
-	case BaseType::UINT32:
-		return "uint32";
-	case BaseType::INT64:
-		return "int64";
-	case BaseType::UINT64:
-		return "uint64";
-	case BaseType::FLOAT:
-		return "float";
-	case BaseType::DOUBLE:
-		return "double";
-	default:
-		return String::empty;
-	}
+    switch (type)
+    {
+    case BaseType::CHAR:
+        return "string";
+    case BaseType::INT8:
+        return "int8";
+    case BaseType::UINT8:
+        return "uint8";
+    case BaseType::INT16:
+        return "int16";
+    case BaseType::UINT16:
+        return "uint16";
+    case BaseType::INT32:
+        return "int32";
+    case BaseType::UINT32:
+        return "uint32";
+    case BaseType::INT64:
+        return "int64";
+    case BaseType::UINT64:
+        return "uint64";
+    case BaseType::FLOAT:
+        return "float";
+    case BaseType::DOUBLE:
+        return "double";
+    default:
+        return String::empty;
+    }
 }

--- a/Source/Plugins/BinaryWriter/BinaryRecording.cpp
+++ b/Source/Plugins/BinaryWriter/BinaryRecording.cpp
@@ -46,14 +46,17 @@ String BinaryRecording::getEngineID() const
 
 String BinaryRecording::getProcessorString(const InfoObjectCommon* channelInfo)
 {
-    String fName = (channelInfo->getCurrentNodeName().replaceCharacter(' ', '_') + "-" + String(channelInfo->getCurrentNodeID()));
-    if (channelInfo->getCurrentNodeID() == channelInfo->getSourceNodeID()) //it is the channel source
+    String fName = (channelInfo->getCurrentNodeName().replaceCharacter(' ', '_') + "-" +
+                    String(channelInfo->getCurrentNodeID()));
+    if (channelInfo->getCurrentNodeID() == channelInfo->getSourceNodeID())
+    // found the channel source
     {
         fName += "." + String(channelInfo->getSubProcessorIdx());
     }
     else
     {
-        fName += "_" + String(channelInfo->getSourceNodeID()) + "." + String(channelInfo->getSubProcessorIdx());
+        fName += "_" + String(channelInfo->getSourceNodeID()) + "." +
+                 String(channelInfo->getSubProcessorIdx());
     }
     fName += File::separatorString;
     return fName;
@@ -469,9 +472,11 @@ void BinaryRecording::resetChannels()
     m_startTS.clear();
 }
 
-void BinaryRecording::writeData(int writeChannel, int realChannel, const float* buffer, int size)
+void BinaryRecording::writeData(int writeChannel, int realChannel, const float* buffer,
+                                int size)
 {
-    if (size > m_bufferSize) //Shouldn't happen, and if it happens it'll be slow, but better this than crashing. Will be reset on file close and reset.
+    if (size > m_bufferSize)
+    // shouldn't happen, and if it does it'll be slow, but better this than crashing
     {
         std::cerr << "Write buffer overrun, resizing to" << size << std::endl;
         m_bufferSize = size;
@@ -480,10 +485,14 @@ void BinaryRecording::writeData(int writeChannel, int realChannel, const float* 
         m_tsBuffer.malloc(size);
     }
     double multFactor = 1 / (float(0x7fff) * getDataChannel(realChannel)->getBitVolts());
-    FloatVectorOperations::copyWithMultiply(m_scaledBuffer.getData(), buffer, multFactor, size);
-    AudioDataConverters::convertFloatToInt16LE(m_scaledBuffer.getData(), m_intBuffer.getData(), size);
+    FloatVectorOperations::copyWithMultiply(m_scaledBuffer.getData(), buffer, multFactor,
+                                            size);
+    AudioDataConverters::convertFloatToInt16LE(m_scaledBuffer.getData(), m_intBuffer.getData(),
+                                               size);
     int fileIndex = m_fileIndexes[writeChannel];
-    m_DataFiles[fileIndex]->writeChannel(getTimestamp(writeChannel) - m_startTS[writeChannel], m_channelIndexes[writeChannel], m_intBuffer.getData(), size);
+    m_DataFiles[fileIndex]->writeChannel(getTimestamp(writeChannel) - m_startTS[writeChannel],
+                                         m_channelIndexes[writeChannel],
+                                         m_intBuffer.getData(), size);
 
     if (m_channelIndexes[writeChannel] == 0)
     {
@@ -543,7 +552,8 @@ void BinaryRecording::writeEvent(int eventIndex, const MidiMessage& event)
     increaseEventCounts(rec);
 }
 
-void BinaryRecording::writeTimestampSyncText(uint16 sourceID, uint16 sourceIdx, int64 timestamp, float, String text)
+void BinaryRecording::writeTimestampSyncText(uint16 sourceID, uint16 sourceIdx,
+                                             int64 timestamp, float, String text)
 {
     if (!m_syncTextFile)
         return;
@@ -596,11 +606,11 @@ void BinaryRecording::increaseEventCounts(EventRecording* rec)
 
 RecordEngineManager* BinaryRecording::getEngineManager()
 {
-    RecordEngineManager* man = new RecordEngineManager("RAWBINARY", "Binary", &(engineFactory<BinaryRecording>));
+    RecordEngineManager* man = new RecordEngineManager("BUSSELABRAWBINARY", "Binary",
+                                                       &(engineFactory<BinaryRecording>));
     EngineParameter* param;
     param = new EngineParameter(EngineParameter::BOOL, 0, "Record TTL full words", true);
     man->addParameter(param);
-
     return man;
 }
 

--- a/Source/Plugins/BinaryWriter/BinaryRecording.h
+++ b/Source/Plugins/BinaryWriter/BinaryRecording.h
@@ -76,7 +76,7 @@ namespace BinaryRecordingEngine
         HeapBlock<int64> m_tsBuffer;
         int m_bufferSize;
 
-        OwnedArray<SequentialBlockFile>  m_DataFiles;
+        OwnedArray<SequentialBlockFile> m_DataFiles;
         Array<unsigned int> m_channelIndexes;
         Array<unsigned int> m_fileIndexes;
         OwnedArray<EventRecording> m_eventFiles;

--- a/Source/Plugins/BinaryWriter/BinaryRecording.h
+++ b/Source/Plugins/BinaryWriter/BinaryRecording.h
@@ -30,71 +30,71 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace BinaryRecordingEngine
 {
 
-	class BinaryRecording : public RecordEngine
-	{
-	public:
-		BinaryRecording();
-		~BinaryRecording();
+    class BinaryRecording : public RecordEngine
+    {
+    public:
+        BinaryRecording();
+        ~BinaryRecording();
 
-		String getEngineID() const override;
-		void openFiles(File rootFolder, int experimentNumber, int recordingNumber) override;
-		void closeFiles() override;
-		void writeData(int writeChannel, int realChannel, const float* buffer, int size) override;
-		void writeEvent(int eventIndex, const MidiMessage& event) override;
-		void resetChannels() override;
-		void addSpikeElectrode(int index, const SpikeChannel* elec) override;
-		void writeSpike(int electrodeIndex, const SpikeEvent* spike) override;
-		void writeTimestampSyncText(uint16 sourceID, uint16 sourceIdx, int64 timestamp, float, String text) override;
-		void setParameter(EngineParameter& parameter) override;
+        String getEngineID() const override;
+        void openFiles(File rootFolder, int experimentNumber, int recordingNumber) override;
+        void closeFiles() override;
+        void writeData(int writeChannel, int realChannel, const float* buffer, int size) override;
+        void writeEvent(int eventIndex, const MidiMessage& event) override;
+        void resetChannels() override;
+        void addSpikeElectrode(int index, const SpikeChannel* elec) override;
+        void writeSpike(int electrodeIndex, const SpikeEvent* spike) override;
+        void writeTimestampSyncText(uint16 sourceID, uint16 sourceIdx, int64 timestamp, float, String text) override;
+        void setParameter(EngineParameter& parameter) override;
 
-		static RecordEngineManager* getEngineManager();
+        static RecordEngineManager* getEngineManager();
 
-	private:
+    private:
 
-		class EventRecording
-		{
-		public:
-			ScopedPointer<NpyFile> mainFile;
-			ScopedPointer<NpyFile> timestampFile;
-			ScopedPointer<NpyFile> metaDataFile;
-			ScopedPointer<NpyFile> channelFile;
-			ScopedPointer<NpyFile> extraFile;
-		};
-		
-
-		NpyFile* createEventMetadataFile(const MetaDataEventObject* channel, String fileName, DynamicObject* jsonObject);
-		void createChannelMetaData(const MetaDataInfoObject* channel, DynamicObject* jsonObject);
-		void writeEventMetaData(const MetaDataEvent* event, NpyFile* file);
-		void increaseEventCounts(EventRecording* rec);
-		static String jsonTypeValue(BaseType type);
-		static String getProcessorString(const InfoObjectCommon* channelInfo);
-
-		bool m_saveTTLWords{ true };
-	
-		HeapBlock<float> m_scaledBuffer;
-		HeapBlock<int16> m_intBuffer;
-		HeapBlock<int64> m_tsBuffer;
-		int m_bufferSize;
-
-		OwnedArray<SequentialBlockFile>  m_DataFiles;
-		Array<unsigned int> m_channelIndexes;
-		Array<unsigned int> m_fileIndexes;
-		OwnedArray<EventRecording> m_eventFiles;
-		OwnedArray<EventRecording> m_spikeFiles;
-		OwnedArray<NpyFile> m_dataTimestampFiles;
-		ScopedPointer<FileOutputStream> m_syncTextFile;
-
-		Array<unsigned int> m_spikeFileIndexes;
-		Array<uint16> m_spikeChannelIndexes;
-
-		int m_recordingNum;
-		Array<int64> m_startTS;
+        class EventRecording
+        {
+        public:
+            ScopedPointer<NpyFile> mainFile;
+            ScopedPointer<NpyFile> timestampFile;
+            ScopedPointer<NpyFile> metaDataFile;
+            ScopedPointer<NpyFile> channelFile;
+            ScopedPointer<NpyFile> extraFile;
+        };
 
 
-		//Compile-time constants
-		const int samplesPerBlock{ 4096 };
+        NpyFile* createEventMetadataFile(const MetaDataEventObject* channel, String fileName, DynamicObject* jsonObject);
+        void createChannelMetaData(const MetaDataInfoObject* channel, DynamicObject* jsonObject);
+        void writeEventMetaData(const MetaDataEvent* event, NpyFile* file);
+        void increaseEventCounts(EventRecording* rec);
+        static String jsonTypeValue(BaseType type);
+        static String getProcessorString(const InfoObjectCommon* channelInfo);
 
-	};
+        bool m_saveTTLWords{ true };
+
+        HeapBlock<float> m_scaledBuffer;
+        HeapBlock<int16> m_intBuffer;
+        HeapBlock<int64> m_tsBuffer;
+        int m_bufferSize;
+
+        OwnedArray<SequentialBlockFile>  m_DataFiles;
+        Array<unsigned int> m_channelIndexes;
+        Array<unsigned int> m_fileIndexes;
+        OwnedArray<EventRecording> m_eventFiles;
+        OwnedArray<EventRecording> m_spikeFiles;
+        OwnedArray<NpyFile> m_dataTimestampFiles;
+        ScopedPointer<FileOutputStream> m_syncTextFile;
+
+        Array<unsigned int> m_spikeFileIndexes;
+        Array<uint16> m_spikeChannelIndexes;
+
+        int m_recordingNum;
+        Array<int64> m_startTS;
+
+
+        //Compile-time constants
+        const int samplesPerBlock{ 4096 };
+
+    };
 
 }
 

--- a/Source/Plugins/BinaryWriter/FileMemoryBlock.h
+++ b/Source/Plugins/BinaryWriter/FileMemoryBlock.h
@@ -29,40 +29,40 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace BinaryRecordingEngine
 {
 
-	template <class StorageType = int16>
-	class FileMemoryBlock
-	{
-	public:
-		FileMemoryBlock(FileOutputStream* file, int blockSize, uint64 offset) :
-			m_data(blockSize, true),
-			m_file(file),
-			m_blockSize(blockSize),
-			m_offset(offset)
-		{};
-		~FileMemoryBlock() {
-			if (!m_flushed)
-			{
-				m_file->write(m_data, m_blockSize*sizeof(StorageType));
-			}
-		};
+    template <class StorageType = int16>
+    class FileMemoryBlock
+    {
+    public:
+        FileMemoryBlock(FileOutputStream* file, int blockSize, uint64 offset) :
+            m_data(blockSize, true),
+            m_file(file),
+            m_blockSize(blockSize),
+            m_offset(offset)
+        {};
+        ~FileMemoryBlock() {
+            if (!m_flushed)
+            {
+                m_file->write(m_data, m_blockSize*sizeof(StorageType));
+            }
+        };
 
-		inline uint64 getOffset() { return m_offset; }
-		inline StorageType* getData() { return m_data.getData(); }
-		void partialFlush(size_t size, bool markFlushed = true)
-		{
-			std::cout << "flushing last block " << size << std::endl;
-			m_file->write(m_data, size*sizeof(StorageType));
-			if (markFlushed)
-				m_flushed = true;
-		}
+        inline uint64 getOffset() { return m_offset; }
+        inline StorageType* getData() { return m_data.getData(); }
+        void partialFlush(size_t size, bool markFlushed = true)
+        {
+            std::cout << "flushing last block " << size << std::endl;
+            m_file->write(m_data, size*sizeof(StorageType));
+            if (markFlushed)
+                m_flushed = true;
+        }
 
-	private:
-		HeapBlock<StorageType> m_data;
-		FileOutputStream* const m_file;
-		const int m_blockSize;
-		const uint64 m_offset;
-		bool m_flushed{ false };
-		JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FileMemoryBlock);
-	};
+    private:
+        HeapBlock<StorageType> m_data;
+        FileOutputStream* const m_file;
+        const int m_blockSize;
+        const uint64 m_offset;
+        bool m_flushed{ false };
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FileMemoryBlock);
+    };
 }
 #endif

--- a/Source/Plugins/BinaryWriter/NpyFile.cpp
+++ b/Source/Plugins/BinaryWriter/NpyFile.cpp
@@ -168,7 +168,7 @@ void NpyFile::updateHeader()
             std::cerr << "Error. Header has grown too big to update in-place " << std::endl;
         }
         m_file->write(newShape.toUTF8(), newShape.getNumBytesAsUTF8());
-        //m_file->flush(); // doesn't seem to be necessary, already flushed due to overwrite
+        m_file->flush(); // not necessary, already flushed due to overwrite? do it anyway
         m_file->setPosition(currentPos); // restore position to end of file
     }
     else

--- a/Source/Plugins/BinaryWriter/NpyFile.cpp
+++ b/Source/Plugins/BinaryWriter/NpyFile.cpp
@@ -35,227 +35,227 @@ using namespace BinaryRecordingEngine;
 
 NpyFile::NpyFile(String path, const Array<NpyType>& typeList)
 {
-	m_dim1 = 1;
-	m_dim2 = 1;
+    m_dim1 = 1;
+    m_dim2 = 1;
 
-	/*If there is only one element on the list but is
-	an array, make this a multidimensional file.
-	*/
-	if (typeList.size() == 1)
-	{
-		NpyType type = typeList[0];
-		if (type.getType() != BaseType::CHAR) //strings work different
-			m_dim1 = type.getTypeLength();
-	}
-	
-	if (!openFile(path))
-		return;
-	writeHeader(typeList);
+    /*If there is only one element on the list but is
+    an array, make this a multidimensional file.
+    */
+    if (typeList.size() == 1)
+    {
+        NpyType type = typeList[0];
+        if (type.getType() != BaseType::CHAR) //strings work different
+            m_dim1 = type.getTypeLength();
+    }
+
+    if (!openFile(path))
+        return;
+    writeHeader(typeList);
 }
 
 NpyFile::NpyFile(String path, NpyType type, unsigned int dim)
 {
-	if (!openFile(path))
-		return;
+    if (!openFile(path))
+        return;
 
-	Array<NpyType> typeList;
-	typeList.add(type);
-	m_dim1 = dim;
-	m_dim2 = type.getTypeLength();
-	writeHeader(typeList);
+    Array<NpyType> typeList;
+    typeList.add(type);
+    m_dim1 = dim;
+    m_dim2 = type.getTypeLength();
+    writeHeader(typeList);
 }
 
 bool NpyFile::openFile(String path)
 {
-	File file(path);
-	Result res = file.create();
-	if (res.failed())
-	{
-		std::cerr << "Error creating file " << path << ":" << res.getErrorMessage()
-				  << std::endl;
-		return false;
-	}
-	file.deleteFile(); // overwrite, never append a new .npy file to end of an existing one
-	// output stream buffer size defaults to 32768 bytes, but is irrelevant because
-	// each updateHeader() call triggers a m_file->flush() to disk:
-	m_file = file.createOutputStream();
-	if (!m_file)
-		return false;
+    File file(path);
+    Result res = file.create();
+    if (res.failed())
+    {
+        std::cerr << "Error creating file " << path << ":" << res.getErrorMessage()
+                  << std::endl;
+        return false;
+    }
+    file.deleteFile(); // overwrite, never append a new .npy file to end of an existing one
+    // output stream buffer size defaults to 32768 bytes, but is irrelevant because
+    // each updateHeader() call triggers a m_file->flush() to disk:
+    m_file = file.createOutputStream();
+    if (!m_file)
+        return false;
 
-	m_okOpen = true;
-	return true;
+    m_okOpen = true;
+    return true;
 }
 
 String NpyFile::getShapeString()
 {
-	String shape;
-	shape.preallocateBytes(32);
-	shape = "(";
-	shape += String(m_recordCount) + ",";
-	if (m_dim1 > 1)
-	{
-		shape += " " + String(m_dim1) + ",";
-	}
-	if (m_dim2 > 1)
-		shape += " " + String(m_dim2);
-	shape += "), }";
-	return shape;
+    String shape;
+    shape.preallocateBytes(32);
+    shape = "(";
+    shape += String(m_recordCount) + ",";
+    if (m_dim1 > 1)
+    {
+        shape += " " + String(m_dim1) + ",";
+    }
+    if (m_dim2 > 1)
+        shape += " " + String(m_dim2);
+    shape += "), }";
+    return shape;
 }
 
 void NpyFile::writeHeader(const Array<NpyType>& typeList)
 {
-	uint8 magicNum = 0x93;
-	String magicStr = "NUMPY";
-	uint16 ver = 0x0001;
-	// magic = magic number + magic string + magic version
-	int magicLen = sizeof(uint8) + magicStr.getNumBytesAsUTF8() + sizeof(uint16);
-	int nbytesAlign = 64; // header should use an integer multiple of this many bytes
+    uint8 magicNum = 0x93;
+    String magicStr = "NUMPY";
+    uint16 ver = 0x0001;
+    // magic = magic number + magic string + magic version
+    int magicLen = sizeof(uint8) + magicStr.getNumBytesAsUTF8() + sizeof(uint16);
+    int nbytesAlign = 64; // header should use an integer multiple of this many bytes
 
-	bool multiValue = typeList.size() > 1;
-	String strHeader;
-	strHeader.preallocateBytes(128);
-	strHeader = "{'descr': ";
-	
-	if (multiValue)
-		strHeader += "[";
+    bool multiValue = typeList.size() > 1;
+    String strHeader;
+    strHeader.preallocateBytes(128);
+    strHeader = "{'descr': ";
 
-	int nTypes = typeList.size();
+    if (multiValue)
+        strHeader += "[";
 
-	for (int i = 0; i < nTypes; i++)
-	{
-		NpyType& type = typeList.getReference(i);
-		if (i > 0) strHeader += ", ";
-		if (multiValue)
-			strHeader += "('" + type.getName() + "', '" + type.getTypeString()
-					   + "', (" + String(type.getTypeLength()) + ",))";
-		else
-			strHeader += "'" + type.getTypeString() + "'";
-	}
-	if (multiValue)
-		strHeader += "]";
-	strHeader += ", 'fortran_order': False, 'shape': ";
+    int nTypes = typeList.size();
 
-	// save byte offset of shape field in .npy file
-	// magic + header length field + current string header length:
-	m_shapePos = magicLen + sizeof(uint16) + strHeader.length();
-	strHeader += getShapeString(); // inits to 0 records, i.e. 1st dim has length 0
-	int baseHeaderLen = magicLen + sizeof(uint16) + strHeader.length() + 1; // +1 for newline
-	int padlen = nbytesAlign - (baseHeaderLen % nbytesAlign);
-	strHeader = strHeader.paddedRight(' ', strHeader.length() + padlen);
-	strHeader += '\n';
-	uint16 strHeaderLen = strHeader.length();
+    for (int i = 0; i < nTypes; i++)
+    {
+        NpyType& type = typeList.getReference(i);
+        if (i > 0) strHeader += ", ";
+        if (multiValue)
+            strHeader += "('" + type.getName() + "', '" + type.getTypeString()
+                       + "', (" + String(type.getTypeLength()) + ",))";
+        else
+            strHeader += "'" + type.getTypeString() + "'";
+    }
+    if (multiValue)
+        strHeader += "]";
+    strHeader += ", 'fortran_order': False, 'shape': ";
 
-	m_file->write(&magicNum, sizeof(uint8));
-	m_file->write(magicStr.toUTF8(), magicStr.getNumBytesAsUTF8());
-	m_file->write(&ver, sizeof(uint16));
-	m_file->write(&strHeaderLen, sizeof(uint16));
-	m_file->write(strHeader.toUTF8(), strHeaderLen);
-	m_headerLen = m_file->getPosition(); // total header length
-	m_file->flush();
+    // save byte offset of shape field in .npy file
+    // magic + header length field + current string header length:
+    m_shapePos = magicLen + sizeof(uint16) + strHeader.length();
+    strHeader += getShapeString(); // inits to 0 records, i.e. 1st dim has length 0
+    int baseHeaderLen = magicLen + sizeof(uint16) + strHeader.length() + 1; // +1 for newline
+    int padlen = nbytesAlign - (baseHeaderLen % nbytesAlign);
+    strHeader = strHeader.paddedRight(' ', strHeader.length() + padlen);
+    strHeader += '\n';
+    uint16 strHeaderLen = strHeader.length();
+
+    m_file->write(&magicNum, sizeof(uint8));
+    m_file->write(magicStr.toUTF8(), magicStr.getNumBytesAsUTF8());
+    m_file->write(&ver, sizeof(uint16));
+    m_file->write(&strHeaderLen, sizeof(uint16));
+    m_file->write(strHeader.toUTF8(), strHeaderLen);
+    m_headerLen = m_file->getPosition(); // total header length
+    m_file->flush();
 }
 
 void NpyFile::updateHeader()
 {
-	// overwrite the shape part of the header - even without explicitly calling
-	// m_file->flush(), overwriting seems to trigger a flush to disk,
-	// while appending to end of file does not
-	int currentPos = m_file->getPosition();
-	if (m_file->setPosition(m_shapePos))
-	{
-		String newShape = getShapeString();
-		if (m_shapePos + newShape.getNumBytesAsUTF8() + 1 > m_headerLen) // +1 for newline
-		{
-			std::cerr << "Error. Header has grown too big to update in-place " << std::endl;
-		}
-		m_file->write(newShape.toUTF8(), newShape.getNumBytesAsUTF8());
-		//m_file->flush(); // doesn't seem to be necessary, already flushed due to overwrite
-		m_file->setPosition(currentPos); // restore position to end of file
-	}
-	else
-	{
-		std::cerr << "Error. Unable to seek to update file header"
-				  << m_file->getFile().getFullPathName() << std::endl;
-	}
+    // overwrite the shape part of the header - even without explicitly calling
+    // m_file->flush(), overwriting seems to trigger a flush to disk,
+    // while appending to end of file does not
+    int currentPos = m_file->getPosition();
+    if (m_file->setPosition(m_shapePos))
+    {
+        String newShape = getShapeString();
+        if (m_shapePos + newShape.getNumBytesAsUTF8() + 1 > m_headerLen) // +1 for newline
+        {
+            std::cerr << "Error. Header has grown too big to update in-place " << std::endl;
+        }
+        m_file->write(newShape.toUTF8(), newShape.getNumBytesAsUTF8());
+        //m_file->flush(); // doesn't seem to be necessary, already flushed due to overwrite
+        m_file->setPosition(currentPos); // restore position to end of file
+    }
+    else
+    {
+        std::cerr << "Error. Unable to seek to update file header"
+                  << m_file->getFile().getFullPathName() << std::endl;
+    }
 }
 
 NpyFile::~NpyFile()
 {
-	updateHeader();
+    updateHeader();
 }
 
 void NpyFile::writeData(const void* data, size_t size)
 {
-	m_file->write(data, size);
+    m_file->write(data, size);
 }
 
 void NpyFile::increaseRecordCount(int count)
 {
-	m_recordCount += count;
-	if (m_recordCount % recordBufferSize == 0)
-		updateHeader(); // also triggers a flush to disk
+    m_recordCount += count;
+    if (m_recordCount % recordBufferSize == 0)
+        updateHeader(); // also triggers a flush to disk
 }
 
 NpyType::NpyType(String n, BaseType t, size_t l)
-	: name(n), type(t), length(l)
+    : name(n), type(t), length(l)
 {
 }
 
 NpyType::NpyType(BaseType t, size_t l)
-	: name(String::empty), type(t), length(l)
+    : name(String::empty), type(t), length(l)
 {
 }
 
 NpyType::NpyType()
-	: name(String::empty), type(BaseType::INT8), length(1)
+    : name(String::empty), type(BaseType::INT8), length(1)
 {
 
 }
 
 String NpyType::getTypeString() const
 {
-	switch (type)
-	{
-	case BaseType::CHAR:
-		return "|S" + String(length + 1); // null-terminated bytes, account for null separator
-	case BaseType::INT8:
-		return "|i1";
-	case BaseType::UINT8:
-		return "|u1";
-	case BaseType::INT16:
-		return "<i2";
-	case BaseType::UINT16:
-		return "<u2";
-	case BaseType::INT32:
-		return "<i4";
-	case BaseType::UINT32:
-		return "<u4";
-	case BaseType::INT64:
-		return "<i8";
-	case BaseType::UINT64:
-		return "<u8";
-	case BaseType::FLOAT:
-		return "<f4";
-	case BaseType::DOUBLE:
-		return "<f8";
-	default:
-		return "|i1"; // signed byte
-	}
+    switch (type)
+    {
+    case BaseType::CHAR:
+        return "|S" + String(length + 1); // null-terminated bytes, account for null separator
+    case BaseType::INT8:
+        return "|i1";
+    case BaseType::UINT8:
+        return "|u1";
+    case BaseType::INT16:
+        return "<i2";
+    case BaseType::UINT16:
+        return "<u2";
+    case BaseType::INT32:
+        return "<i4";
+    case BaseType::UINT32:
+        return "<u4";
+    case BaseType::INT64:
+        return "<i8";
+    case BaseType::UINT64:
+        return "<u8";
+    case BaseType::FLOAT:
+        return "<f4";
+    case BaseType::DOUBLE:
+        return "<f8";
+    default:
+        return "|i1"; // signed byte
+    }
 }
 
 int NpyType::getTypeLength() const
 {
-	if (type == BaseType::CHAR)
-		return 1;
-	else
-		return length;
+    if (type == BaseType::CHAR)
+        return 1;
+    else
+        return length;
 }
 
 String NpyType::getName() const
 {
-	return name;
+    return name;
 }
 
 BaseType NpyType::getType() const
 {
-	return type;
+    return type;
 }

--- a/Source/Plugins/BinaryWriter/NpyFile.cpp
+++ b/Source/Plugins/BinaryWriter/NpyFile.cpp
@@ -159,7 +159,7 @@ void NpyFile::updateHeader()
     // overwrite the shape part of the header - even without explicitly calling
     // m_file->flush(), overwriting seems to trigger a flush to disk,
     // while appending to end of file does not
-    int currentPos = m_file->getPosition();
+    int64 currentPos = m_file->getPosition(); // returns int64, necessary for big files
     if (m_file->setPosition(m_shapePos))
     {
         String newShape = getShapeString();

--- a/Source/Plugins/BinaryWriter/NpyFile.cpp
+++ b/Source/Plugins/BinaryWriter/NpyFile.cpp
@@ -190,9 +190,10 @@ void NpyFile::writeData(const void* data, size_t size)
 
 void NpyFile::increaseRecordCount(int count)
 {
+    int64 old_recordCount = m_recordCount;
     m_recordCount += count;
-    if (m_recordCount % recordBufferSize == 0)
-        updateHeader(); // also triggers a flush to disk
+    if ((old_recordCount / recordBufferSize) != (m_recordCount / recordBufferSize))
+        updateHeader(); // crossed recordBufferSize threshold, update header
 }
 
 NpyType::NpyType(String n, BaseType t, size_t l)

--- a/Source/Plugins/BinaryWriter/NpyFile.h
+++ b/Source/Plugins/BinaryWriter/NpyFile.h
@@ -69,7 +69,7 @@ namespace BinaryRecordingEngine
         // Compile-time constants
 
         // flush file buffer to disk and update the .npy header every this many records:
-        const int recordBufferSize{ 128 };
+        const int recordBufferSize{ 1024 };
 
     };
 

--- a/Source/Plugins/BinaryWriter/NpyFile.h
+++ b/Source/Plugins/BinaryWriter/NpyFile.h
@@ -29,49 +29,49 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace BinaryRecordingEngine
 {
 
-	class NpyType
-	{
-	public:
-		NpyType(String, BaseType, size_t);
-		NpyType(BaseType, size_t);
-		NpyType();
-		String getName() const;
-		String getTypeString() const;
-		int getTypeLength() const;
-		BaseType getType() const;
-	private:
-		String name;
-		BaseType type;
-		size_t length;
-	};
+    class NpyType
+    {
+    public:
+        NpyType(String, BaseType, size_t);
+        NpyType(BaseType, size_t);
+        NpyType();
+        String getName() const;
+        String getTypeString() const;
+        int getTypeLength() const;
+        BaseType getType() const;
+    private:
+        String name;
+        BaseType type;
+        size_t length;
+    };
 
-	class NpyFile
-	{
-	public:
-		NpyFile(String path, const Array<NpyType>& typeList);
-		NpyFile(String path, NpyType type, unsigned int dim = 1);
-		~NpyFile();
-		void writeData(const void* data, size_t size);
-		void increaseRecordCount(int count = 1);
-	private:
-		bool openFile(String path);
-		String getShapeString();
-		void writeHeader(const Array<NpyType>& typeList);
-		void updateHeader();
-		ScopedPointer<FileOutputStream> m_file;
-		int64 m_headerLen; // total header length
-		bool m_okOpen{ false };
-		int64 m_recordCount{ 0 };
-		size_t m_shapePos;
-		unsigned int m_dim1;
-		unsigned int m_dim2;
+    class NpyFile
+    {
+    public:
+        NpyFile(String path, const Array<NpyType>& typeList);
+        NpyFile(String path, NpyType type, unsigned int dim = 1);
+        ~NpyFile();
+        void writeData(const void* data, size_t size);
+        void increaseRecordCount(int count = 1);
+    private:
+        bool openFile(String path);
+        String getShapeString();
+        void writeHeader(const Array<NpyType>& typeList);
+        void updateHeader();
+        ScopedPointer<FileOutputStream> m_file;
+        int64 m_headerLen; // total header length
+        bool m_okOpen{ false };
+        int64 m_recordCount{ 0 };
+        size_t m_shapePos;
+        unsigned int m_dim1;
+        unsigned int m_dim2;
 
-		// Compile-time constants
+        // Compile-time constants
 
-		// flush file buffer to disk and update the .npy header every this many records:
-		const int recordBufferSize{ 128 };
+        // flush file buffer to disk and update the .npy header every this many records:
+        const int recordBufferSize{ 128 };
 
-	};
+    };
 
 };
 #endif

--- a/Source/Plugins/BinaryWriter/OpenEphysLib.cpp
+++ b/Source/Plugins/BinaryWriter/OpenEphysLib.cpp
@@ -37,34 +37,34 @@ using namespace Plugin;
 
 extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
-	info->apiVersion = PLUGIN_API_VER;
-	info->name = "Binary recording";
-	info->libVersion = 1;
-	info->numPlugins = NUM_PLUGINS;
+    info->apiVersion = PLUGIN_API_VER;
+    info->name = "Binary recording";
+    info->libVersion = 1;
+    info->numPlugins = NUM_PLUGINS;
 }
 
 extern "C" EXPORT int getPluginInfo(int index, Plugin::PluginInfo* info)
 {
-	switch (index)
-	{
-	case 0:
-		info->type = Plugin::PLUGIN_TYPE_RECORD_ENGINE;
-		info->recordEngine.name = "Binary";
-		info->recordEngine.creator = &(Plugin::createRecordEngine<BinaryRecordingEngine::BinaryRecording>);
-		break;
-	default:
-		return -1;
-	}
+    switch (index)
+    {
+    case 0:
+        info->type = Plugin::PLUGIN_TYPE_RECORD_ENGINE;
+        info->recordEngine.name = "Binary";
+        info->recordEngine.creator = &(Plugin::createRecordEngine<BinaryRecordingEngine::BinaryRecording>);
+        break;
+    default:
+        return -1;
+    }
 
-	return 0;
+    return 0;
 }
 
 #ifdef WIN32
 BOOL WINAPI DllMain(IN HINSTANCE hDllHandle,
-	IN DWORD     nReason,
-	IN LPVOID    Reserved)
+    IN DWORD     nReason,
+    IN LPVOID    Reserved)
 {
-	return TRUE;
+    return TRUE;
 }
 
 #endif

--- a/Source/Plugins/BinaryWriter/SequentialBlockFile.cpp
+++ b/Source/Plugins/BinaryWriter/SequentialBlockFile.cpp
@@ -32,136 +32,136 @@ m_samplesPerBlock(samplesPerBlock),
 m_blockSize(nChannels*samplesPerBlock),
 m_lastBlockFill(0)
 {
-	m_memBlocks.ensureStorageAllocated(blockArrayInitSize);
-	for (int i = 0; i < nChannels; i++)
-		m_currentBlock.add(-1);
+    m_memBlocks.ensureStorageAllocated(blockArrayInitSize);
+    for (int i = 0; i < nChannels; i++)
+        m_currentBlock.add(-1);
 }
 
 SequentialBlockFile::~SequentialBlockFile()
 {
-	//Ensure that all remaining blocks are flushed in order. Keep the last one
-	int n = m_memBlocks.size();
-	for (int i = 0; i < n - 1; i++)
-	{
-		m_memBlocks.remove(0);
-	}
+    //Ensure that all remaining blocks are flushed in order. Keep the last one
+    int n = m_memBlocks.size();
+    for (int i = 0; i < n - 1; i++)
+    {
+        m_memBlocks.remove(0);
+    }
 
-	//manually flush the last one to avoid trailing zeroes
-	m_memBlocks[0]->partialFlush(m_lastBlockFill * m_nChannels);
+    //manually flush the last one to avoid trailing zeroes
+    m_memBlocks[0]->partialFlush(m_lastBlockFill * m_nChannels);
 }
 
 bool SequentialBlockFile::openFile(String filename)
 {
-	File file(filename);
-	Result res = file.create();
-	if (res.failed())
-	{
-		std::cerr << "Error creating file " << filename << ":" << res.getErrorMessage() << std::endl;
-		return false;
-	}
-	m_file = file.createOutputStream(streamBufferSize);
-	if (!m_file)
-		return false;
+    File file(filename);
+    Result res = file.create();
+    if (res.failed())
+    {
+        std::cerr << "Error creating file " << filename << ":" << res.getErrorMessage() << std::endl;
+        return false;
+    }
+    m_file = file.createOutputStream(streamBufferSize);
+    if (!m_file)
+        return false;
 
-	m_memBlocks.add(new FileBlock(m_file, m_blockSize, 0));
-	return true;
+    m_memBlocks.add(new FileBlock(m_file, m_blockSize, 0));
+    return true;
 }
 
 bool SequentialBlockFile::writeChannel(uint64 startPos, int channel, int16* data, int nSamples)
 {
-	if (!m_file)
-		return false;
-	
-	int bIndex = m_memBlocks.size() - 1;
-	if ((bIndex < 0) || (m_memBlocks[bIndex]->getOffset() + m_samplesPerBlock) < (startPos + nSamples))
-		allocateBlocks(startPos, nSamples);
+    if (!m_file)
+        return false;
 
-	for (bIndex = m_memBlocks.size() - 1; bIndex >= 0; bIndex--)
-	{
-		if (m_memBlocks[bIndex]->getOffset() <= startPos)
-			break;
-	}
-	if (bIndex < 0)
-	{
-		std::cerr << "BINARY WRITER: Memory block unloaded ahead of time for chan " << channel << " start " << startPos << " ns " << nSamples << " first " << m_memBlocks[0]->getOffset() <<std::endl;
-		for (int i = 0; i < m_nChannels; i++)
-			std::cout << "channel " << i << " last block " << m_currentBlock[i] << std::endl;
-		return false;
-	}
-	int writtenSamples = 0;
-	int startIdx = startPos - m_memBlocks[bIndex]->getOffset();
-	int startMemPos = startIdx*m_nChannels;
-	int dataIdx = 0;
-	int lastBlockIdx = m_memBlocks.size() - 1;
-	while (writtenSamples < nSamples)
-	{
-		int16* blockPtr = m_memBlocks[bIndex]->getData();
-		int samplesToWrite = jmin((nSamples - writtenSamples), (m_samplesPerBlock - startIdx));
-		for (int i = 0; i < samplesToWrite; i++)
-		{
-			//if (writtenSamples == 0 && *(data + dataIdx) == 0)
-			//{
-			//	std::cout << "Found a zero." << std::endl;
-			//	break;
-			//}
+    int bIndex = m_memBlocks.size() - 1;
+    if ((bIndex < 0) || (m_memBlocks[bIndex]->getOffset() + m_samplesPerBlock) < (startPos + nSamples))
+        allocateBlocks(startPos, nSamples);
 
-			*(blockPtr + startMemPos + channel + i*m_nChannels) = *(data + dataIdx);
-			dataIdx++;
-		}
-		writtenSamples += samplesToWrite;
+    for (bIndex = m_memBlocks.size() - 1; bIndex >= 0; bIndex--)
+    {
+        if (m_memBlocks[bIndex]->getOffset() <= startPos)
+            break;
+    }
+    if (bIndex < 0)
+    {
+        std::cerr << "BINARY WRITER: Memory block unloaded ahead of time for chan " << channel << " start " << startPos << " ns " << nSamples << " first " << m_memBlocks[0]->getOffset() <<std::endl;
+        for (int i = 0; i < m_nChannels; i++)
+            std::cout << "channel " << i << " last block " << m_currentBlock[i] << std::endl;
+        return false;
+    }
+    int writtenSamples = 0;
+    int startIdx = startPos - m_memBlocks[bIndex]->getOffset();
+    int startMemPos = startIdx*m_nChannels;
+    int dataIdx = 0;
+    int lastBlockIdx = m_memBlocks.size() - 1;
+    while (writtenSamples < nSamples)
+    {
+        int16* blockPtr = m_memBlocks[bIndex]->getData();
+        int samplesToWrite = jmin((nSamples - writtenSamples), (m_samplesPerBlock - startIdx));
+        for (int i = 0; i < samplesToWrite; i++)
+        {
+            //if (writtenSamples == 0 && *(data + dataIdx) == 0)
+            //{
+            //  std::cout << "Found a zero." << std::endl;
+            //  break;
+            //}
 
-		//Update the last block fill index
-		size_t samplePos = startIdx + samplesToWrite;
-		if (bIndex == lastBlockIdx && samplePos > m_lastBlockFill)
-		{
-			m_lastBlockFill = samplePos;
-		}
+            *(blockPtr + startMemPos + channel + i*m_nChannels) = *(data + dataIdx);
+            dataIdx++;
+        }
+        writtenSamples += samplesToWrite;
 
-		startIdx = 0;
-		startMemPos = 0;
-		bIndex++;
-	}
-	m_currentBlock.set(channel, bIndex - 1); //store the last block a channel was written in
-	return true;
+        //Update the last block fill index
+        size_t samplePos = startIdx + samplesToWrite;
+        if (bIndex == lastBlockIdx && samplePos > m_lastBlockFill)
+        {
+            m_lastBlockFill = samplePos;
+        }
+
+        startIdx = 0;
+        startMemPos = 0;
+        bIndex++;
+    }
+    m_currentBlock.set(channel, bIndex - 1); //store the last block a channel was written in
+    return true;
 }
 
 void SequentialBlockFile::allocateBlocks(uint64 startIndex, int numSamples)
 {
-	//First deallocate full blocks
-	//Search for the earliest unused block;
-	unsigned int minBlock = 0xFFFFFFFF; //large number;
-	for (int i = 0; i < m_nChannels; i++)
-	{
-		if (m_currentBlock[i] < minBlock)
-			minBlock = m_currentBlock[i];
-	}
+    //First deallocate full blocks
+    //Search for the earliest unused block;
+    unsigned int minBlock = 0xFFFFFFFF; //large number;
+    for (int i = 0; i < m_nChannels; i++)
+    {
+        if (m_currentBlock[i] < minBlock)
+            minBlock = m_currentBlock[i];
+    }
 
-	//Update block indexes
-	for (int i = 0; i < m_nChannels; i++)
-	{
-		m_currentBlock.set(i, m_currentBlock[i] - minBlock);
-	}
+    //Update block indexes
+    for (int i = 0; i < m_nChannels; i++)
+    {
+        m_currentBlock.set(i, m_currentBlock[i] - minBlock);
+    }
 
-	m_memBlocks.removeRange(0, minBlock);
+    m_memBlocks.removeRange(0, minBlock);
 
-	//for (int i = 0; i < minBlock; i++)
-	//{
-		//Not the most efficient way, as it has to move back all the elements, but it's a simple array of pointers, so it's quick enough
-	//	m_memBlocks.remove(0);
-	//}
-	
-	//Look for the last available position and calculate needed space
-	uint64 lastOffset = m_memBlocks.getLast()->getOffset();
-	uint64 maxAddr = lastOffset + m_samplesPerBlock - 1;
-	uint64 newSpaceNeeded = numSamples - (maxAddr - startIndex);
-	int newBlocks = (newSpaceNeeded + m_samplesPerBlock - 1) / m_samplesPerBlock; //Fast ceiling division
+    //for (int i = 0; i < minBlock; i++)
+    //{
+        //Not the most efficient way, as it has to move back all the elements, but it's a simple array of pointers, so it's quick enough
+    //  m_memBlocks.remove(0);
+    //}
 
-	for (int i = 0; i < newBlocks; i++)
-	{
-		lastOffset += m_samplesPerBlock;
-		m_memBlocks.add(new FileBlock(m_file, m_blockSize, lastOffset));
-	}
-	if (newBlocks > 0)
-		m_lastBlockFill = 0; //we've added some new blocks, so the last one will be empty
+    //Look for the last available position and calculate needed space
+    uint64 lastOffset = m_memBlocks.getLast()->getOffset();
+    uint64 maxAddr = lastOffset + m_samplesPerBlock - 1;
+    uint64 newSpaceNeeded = numSamples - (maxAddr - startIndex);
+    int newBlocks = (newSpaceNeeded + m_samplesPerBlock - 1) / m_samplesPerBlock; //Fast ceiling division
+
+    for (int i = 0; i < newBlocks; i++)
+    {
+        lastOffset += m_samplesPerBlock;
+        m_memBlocks.add(new FileBlock(m_file, m_blockSize, lastOffset));
+    }
+    if (newBlocks > 0)
+        m_lastBlockFill = 0; //we've added some new blocks, so the last one will be empty
 }
 

--- a/Source/Plugins/BinaryWriter/SequentialBlockFile.h
+++ b/Source/Plugins/BinaryWriter/SequentialBlockFile.h
@@ -29,34 +29,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 namespace BinaryRecordingEngine
 {
 
-	typedef FileMemoryBlock<int16> FileBlock;
+    typedef FileMemoryBlock<int16> FileBlock;
 
-	class SequentialBlockFile
-	{
-	public:
-		SequentialBlockFile(int nChannels, int samplesPerBlock);
-		~SequentialBlockFile();
+    class SequentialBlockFile
+    {
+    public:
+        SequentialBlockFile(int nChannels, int samplesPerBlock);
+        ~SequentialBlockFile();
 
-		bool openFile(String filename);
-		bool writeChannel(uint64 startPos, int channel, int16* data, int nSamples);
+        bool openFile(String filename);
+        bool writeChannel(uint64 startPos, int channel, int16* data, int nSamples);
 
-	private:
-		ScopedPointer<FileOutputStream> m_file;
-		const int m_nChannels;
-		const int m_samplesPerBlock;
-		const int m_blockSize;
-		OwnedArray<FileBlock> m_memBlocks;
-		Array<int> m_currentBlock;
-		size_t m_lastBlockFill;
+    private:
+        ScopedPointer<FileOutputStream> m_file;
+        const int m_nChannels;
+        const int m_samplesPerBlock;
+        const int m_blockSize;
+        OwnedArray<FileBlock> m_memBlocks;
+        Array<int> m_currentBlock;
+        size_t m_lastBlockFill;
 
-		void allocateBlocks(uint64 startIndex, int numSamples);
+        void allocateBlocks(uint64 startIndex, int numSamples);
 
 
-		//Compile-time parameters
-		const int streamBufferSize{ 0 };
-		const int blockArrayInitSize{ 128 };
+        //Compile-time parameters
+        const int streamBufferSize{ 0 };
+        const int blockArrayInitSize{ 128 };
 
-	};
+    };
 
 }
 


### PR DESCRIPTION
I found that for a long enough recording with enough spikes or digital input events, the `.npy` file would start to overwrite itself after 2 GiB. This was due to an int32 overflow error in the `currentPos` file position variable in `updateHeader()`. Changing it to int64 fixed it. I also included some other less important changes that I've made to our own internal [busselabbinary](https://github.com/mspacek/plugin-GUI/tree/busselabbinary) branch. I can split those off if need be.