### PR TITLE
Fixes 3 bugs when loading or updating signal chain

### DIFF
--- a/Source/Processors/Merger/Merger.cpp
+++ b/Source/Processors/Merger/Merger.cpp
@@ -70,6 +70,11 @@ void Merger::setMergerSourceNode(GenericProcessor* sn)
 
     if (sn != nullptr)
     {
+        // attempt to choose the right path if source is a splitter
+        if (sn->isSplitter() && sn->getDestNode() != nullptr && sn->getDestNode() != this)
+        {
+            sn->switchIO();
+        }
         sn->setDestNode(this);
     }
 }

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1498,12 +1498,14 @@ const String EditorViewport::loadState(File fileToLoad)
 
     GenericProcessor* p;
 
+    bool startNewTab;
+
     forEachXmlChildElement(*xml, element)
     {
 
         if (element->hasTagName("SIGNALCHAIN"))
         {
-
+            startNewTab = true;
             forEachXmlChildElement(*element, processor)
             {
 
@@ -1517,7 +1519,15 @@ const String EditorViewport::loadState(File fileToLoad)
 
                     if (insertionPt == 1)
                     {
-                        insertionPoint = editorArray.size();
+                        if (startNewTab)
+                        {
+                            insertionPoint = -1;
+                            startNewTab = false;
+                        }
+                        else
+                        {
+                            insertionPoint = editorArray.size();
+                        }
                     }
                     else
                     {

--- a/Source/UI/SignalChainManager.cpp
+++ b/Source/UI/SignalChainManager.cpp
@@ -168,6 +168,18 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     // Step 1: update the editor array
     if (action == ADD)
     {
+        if (insertionPoint == -1)
+        {
+            // insert in new signal chain
+            for (int n = 0; n < editorArray.size(); n++)
+            {
+                editorArray[n]->setVisible(false);
+            }
+
+            editorArray.clear();
+
+            insertionPoint = 0;
+        }
         //std::cout << "    Adding editor." << std::endl;
         editorArray.insert(insertionPoint, activeEditor);
 
@@ -370,6 +382,7 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     // std::cout << "Cleared editor array." << std::endl;
 
     GenericEditor* editorToAdd = activeEditor;
+    GenericEditor* sourceEditor;
 
     while (editorToAdd != 0)
     {
@@ -383,17 +396,24 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
         {
             //   std::cout << "Source: " << source->getName() << std::endl;
 
+            sourceEditor = (GenericEditor*)source->getEditor();
+
             // need to switch the splitter somehow
             if (action == ACTIVATE || action == UPDATE)
             {
                 if (source->isSplitter())
                 {
-                    source->setPathToProcessor(currentProcessor);
+                    sourceEditor->getPathForEditor(editorToAdd);
+
+                    // hack: calling getPathForEditor switches the splitter node
+                    // to point at editorToAdd, so call switchDest twice to align
+                    // the editor with the correct path.
+                    sourceEditor->switchDest();
+                    sourceEditor->switchDest();
                 }
             }
 
-            editorToAdd = (GenericEditor*) source->getEditor();
-
+            editorToAdd = sourceEditor;
         }
         else
         {


### PR DESCRIPTION
This is an attempt to fix some of the UI issues with the signal chain, particularly when loading a saved chain. Although I tried to change as little code as possible in the interest of avoiding unintended consequences, some of the code, particularly pertaining to mergers and splitters, is getting pretty messy and should probably be rewritten at some point.

#### Issue 1: Loading a second or higher signal chain tab that does not start with a source node fails.
Example: 
```
A: Serial Input -\
                  >-- Merger (...)
B: Filter Node --/
```
Problem: After dropping the first editor of the second tab, the `updateVisibleEditors` function normally creates the new tab in step 3, but this only works if the first editor is a source node. Then when the merger loads its parameters, this editor ends up with the merger as both source and dest, resulting in an infinite loop.

Solution (in `loadState` and `updateVisibleEditors`): when starting to read in a new `SIGNALCHAIN` XML node, mark the first processor as needing a new tab by setting the `insertionPoint` to -1. If an editor is being added with `insertionPoint == -1`, clear the `editorArray` first so it doesn't get connected to already-added editors.

#### Issue 2: Nodes after a splitter can get disconnected when the other destination of the splitter is a merger.
Example:
```
A: File Reader ---------------\
                               >-- Merger (...)
B: Serial Input -- Splitter --<
                               \-- LFP Viewer
```
Problem: After saving and reloading this chain, the LFP viewer is detached, with the splitter's first dest NULL and second pointing to the merger. This happens because the splitter is switched to the second output after loading the chain, and it's not switched before the merger loads its params and gets connected to the splitter. Thus the merger gets connected to the wrong output of the splitter.

Solution (in `setMergerSourceNode`): Check whether the source node is a splitter and attempt to switch to the right output before a merger connects with it.

#### Issue 3: After loading a signal chain, splitter editors can have the wrong output selected (doesn't match the editors shown to the right in the viewport). As far as I can tell this happens in any signal chain with a splitter (so this is the most common of the issues).

Problem: When inserting editors in the `editorArray` previous to the selected one in `updateVisibleEditors` (step 4), only the internal source of each splitter is switched if necessary; the arrow buttons on the editor itself are not switched.

Solution (in `updateVisibleEditors`): use `sourceEditor->switchDest()` to switch the destination instead. `switchDest(dest)` doesn't work because of the call to `makeEditorVisible` at the end, which seems to mess things up. The way I did this involving a call to `getPathForEditor` for the side effect is pretty hacky.

#### So, overall, this is still a messy part of the code, but these changes seem to improve things for now.