### PR TITLE
Revert change to the recording engine ID

### DIFF
--- a/Source/Plugins/BinaryWriter/BinaryRecording.cpp
+++ b/Source/Plugins/BinaryWriter/BinaryRecording.cpp
@@ -606,7 +606,7 @@ void BinaryRecording::increaseEventCounts(EventRecording* rec)
 
 RecordEngineManager* BinaryRecording::getEngineManager()
 {
-    RecordEngineManager* man = new RecordEngineManager("BUSSELABRAWBINARY", "Binary",
+    RecordEngineManager* man = new RecordEngineManager("RAWBINARY", "Binary",
                                                        &(engineFactory<BinaryRecording>));
     EngineParameter* param;
     param = new EngineParameter(EngineParameter::BOOL, 0, "Record TTL full words", true);


### PR DESCRIPTION
I don't know if this was a mistake, or what, but changing this broke some tools of mine.