### PR TITLE
Added continuous triggering option to pulse pal plugin

### DIFF
--- a/Source/Plugins/PulsePalOutput/PulsePalOutput.cpp
+++ b/Source/Plugins/PulsePalOutput/PulsePalOutput.cpp
@@ -65,6 +65,7 @@ PulsePalOutput::PulsePalOutput()
     m_linkTriggerChannel1 = vector<int>(PULSEPALCHANNELS, 0);
     m_linkTriggerChannel2 = vector<int>(PULSEPALCHANNELS, 0);
     m_triggerMode = vector<int>(PULSEPALCHANNELS, 0);
+	m_continuous = vector<int>(PULSEPALCHANNELS, 0);
 
     for (int i = 0; i < PULSEPALCHANNELS; ++i)
     {
@@ -194,6 +195,7 @@ bool PulsePalOutput::updatePulsePal(int chan)
         pulsePal.setTrigger1Link(actual_chan, m_linkTriggerChannel1[chan]);
         pulsePal.setTrigger2Link(actual_chan, m_linkTriggerChannel2[chan]);
         pulsePal.setTriggerMode(actual_chan, m_triggerMode[chan]);
+		pulsePal.setContinuousLoop(actual_chan, m_continuous[chan]);
         return true;
     }
     else
@@ -276,6 +278,11 @@ int PulsePalOutput::getLinkTriggerChannel2(int chan) const
 int PulsePalOutput::getTriggerMode(int chan) const
 {
     return m_triggerMode[chan];
+}
+
+int PulsePalOutput::getContinuous(int chan) const
+{
+	return m_continuous[chan];
 }
 
 uint32_t PulsePalOutput::getPulsePalVersion() const
@@ -361,6 +368,11 @@ void PulsePalOutput::setTriggerMode(int chan, int mode)
     m_triggerMode[chan] = mode;
 }
 
+void PulsePalOutput::setContinuous(int chan, int continued)
+{
+	m_continuous[chan] = continued;
+}
+
 void PulsePalOutput::setTTLsettings(int chan)
 {
     m_isBiphasic[chan] = 0;
@@ -443,6 +455,7 @@ void PulsePalOutput::saveCustomParametersToXml(XmlElement *parentElement)
         chan->setAttribute("link2trigger1", m_linkTriggerChannel1[i]);
         chan->setAttribute("link2trigger2", m_linkTriggerChannel2[i]);
         chan->setAttribute("triggermode", m_triggerMode[i]);
+		chan->setAttribute("continuous", m_continuous[i]);
         mainNode->addChildElement(chan);
     }
 }
@@ -473,6 +486,7 @@ void PulsePalOutput::loadCustomParametersFromXml ()
                     int link21 = chan->getIntAttribute("link2trigger1");
                     int link22 = chan->getIntAttribute("link2trigger2");
                     int trigger = chan->getIntAttribute("triggermode");
+					int contd = chan->getIntAttribute("continuous");
                     m_isBiphasic[id] = biphasic;
                     m_phase1Duration[id] = phase1;
                     m_phase2Duration[id] = phase2;
@@ -488,6 +502,7 @@ void PulsePalOutput::loadCustomParametersFromXml ()
                     m_linkTriggerChannel1[id] = link21;
                     m_linkTriggerChannel2[id] = link22;
                     m_triggerMode[id] = trigger;
+					m_continuous[id] = contd;
                 }
             }
         }

--- a/Source/Plugins/PulsePalOutput/PulsePalOutput.h
+++ b/Source/Plugins/PulsePalOutput/PulsePalOutput.h
@@ -121,6 +121,7 @@ public:
     int getLinkTriggerChannel1(int chan) const;
     int getLinkTriggerChannel2(int chan) const;
     int getTriggerMode(int chan) const;
+	int getContinuous(int chan) const;
     void setIsBiphasic(int chan, bool isBiphasic);
     void setNegFirst(int chan, bool negFirst);
     void setPhase1Duration(int chan, float phaseDuration);
@@ -136,7 +137,8 @@ public:
     void setTrainDelay(int chan, float trainDelay);
     void setLinkTriggerChannel1(int chan, int link);
     void setLinkTriggerChannel2(int chan, int link);
-    void setTriggerMode(int chan, int mode);    
+    void setTriggerMode(int chan, int mode);  
+	void setContinuous(int chan, int continued);
     /**
      * @brief setTTLsettings sets channel chan to TTL settings
      * @param chan: channel number (0-1-2-3)
@@ -190,6 +192,7 @@ private:
     vector<int> m_linkTriggerChannel1;
     vector<int> m_linkTriggerChannel2;
     vector<int> m_triggerMode;
+	vector<int> m_continuous;
     // Pulse Pal instance and version
     PulsePal pulsePal;
     uint32_t pulsePalVersion;

--- a/Source/Plugins/PulsePalOutput/PulsePalOutputCanvas.cpp
+++ b/Source/Plugins/PulsePalOutput/PulsePalOutputCanvas.cpp
@@ -122,7 +122,8 @@ void PulsePalOutputCanvas::resized()
         link2tr2Button[i]->setBounds(0.12*getWidth() + 0.25*i*getWidth(), 0.83*getHeight(), 0.11*getWidth(), 0.03*getHeight());
         biphasicButton[i]->setBounds(0.01*getWidth() + 0.25*i*getWidth(), 0.87*getHeight(), 0.11*getWidth(), 0.03*getHeight());
         burstButton[i]->setBounds(0.12*getWidth() + 0.25*i*getWidth(), 0.87*getHeight(), 0.11*getWidth(), 0.03*getHeight());
-        ttlButton[i]->setBounds(0.01*getWidth() + 0.25*i*getWidth(), 0.91*getHeight(), 0.22*getWidth(), 0.06*getHeight());
+        ttlButton[i]->setBounds(0.01*getWidth() + 0.25*i*getWidth(), 0.91*getHeight(), 0.11*getWidth(), 0.06*getHeight());
+		continuousButton[i]->setBounds(0.12*getWidth() + 0.25*i*getWidth(), 0.91*getHeight(), 0.11*getWidth(), 0.06*getHeight());
     }
 
     refresh();
@@ -220,6 +221,13 @@ void PulsePalOutputCanvas::buttonClicked(Button* button)
                 burstButton[i]->setToggleState(false, dontSendNotification);
             }
         }
+		else if (button == continuousButton[i])
+		{
+			if (button->getToggleState() == true)
+				processor->setContinuous(i, 1);
+			else if (button->getToggleState() == false)
+				processor->setContinuous(i, 0);
+		}
         if (!processor->checkParameterConsistency(i))
         {
             CoreServices::sendStatusMessage("Inconsistent parameters: set train duration first");
@@ -445,6 +453,14 @@ void PulsePalOutputCanvas::initButtons()
         ttl->addListener(this);
         ttlButton[i] = ttl;
         addAndMakeVisible(ttlButton[i]);
+
+		ScopedPointer<UtilityButton> continuous = new UtilityButton("continuous", Font("Small Text", 20, Font::plain));;
+		continuous->setRadius(3.0f);
+		continuous->addListener(this);
+		continuous->setClickingTogglesState(true);
+		continuousButton[i] = continuous;
+		addAndMakeVisible(continuousButton[i]);
+
 
         ScopedPointer<ComboBox> mode = new ComboBox();
         mode->addListener(this);

--- a/Source/Plugins/PulsePalOutput/PulsePalOutputCanvas.h
+++ b/Source/Plugins/PulsePalOutput/PulsePalOutputCanvas.h
@@ -90,6 +90,7 @@ private:
     ScopedPointer<UtilityButton> ttlButton[PULSEPALCHANNELS];
     ScopedPointer<UtilityButton> link2tr1Button[PULSEPALCHANNELS];
     ScopedPointer<UtilityButton> link2tr2Button[PULSEPALCHANNELS];
+	ScopedPointer<UtilityButton> continuousButton[PULSEPALCHANNELS];
     ScopedPointer<ComboBox> triggerMode[PULSEPALCHANNELS];
 
     ScopedPointer<Label> channelLabel[PULSEPALCHANNELS];


### PR DESCRIPTION
I added a button that lets users set the Pulse Pal's continuous triggering property from the pulse pal plugin canvas.  Clicking the new "continuous" button changes whether the channel's output is on continuously instead of being limited by a specified pulse train length. The new button is to the right of the TTL button at the bottom of each channel's control panel on the canvas.  The default is for continuous triggering to be off; it is turned on when the button is yellow.

I added this option because when the user fires up the open ephys pulse pal plugin, all of the options suggest a finite pulse train.  If continuous triggering has previously been set to "on" another way (on the Pulse Pal itself, through another program), it cannot be turned off through open ephys, and the user may wonder why their pulse train continues indefinitely.  The continuous on/off trigger state is also nice to have for debugging experimental setups.

Let me know if there's anything I need to do to clean up the code, or if there's another way you'd rather address the Pulse Pal's continuous triggering property. 