### PR TITLE
Fix bug where PulsePal trigger and gate selections change on update

### DIFF
--- a/Source/Plugins/PulsePalOutput/PulsePalOutputEditor.cpp
+++ b/Source/Plugins/PulsePalOutput/PulsePalOutputEditor.cpp
@@ -160,8 +160,8 @@ void ChannelTriggerInterface::updateSources()
     EventSources s;
     String name;
     processor->clearEventSources();
-    triggerSelector->clear();
-    gateSelector->clear();
+    triggerSelector->clear(dontSendNotification);
+    gateSelector->clear(dontSendNotification);
     triggerSelector->addItem("Trigger", 1);
     gateSelector->addItem("Gate", 1);
     int nextItemTrig = 2;
@@ -189,17 +189,14 @@ void ChannelTriggerInterface::updateSources()
     if (m_triggerSelected > triggerSelector->getNumItems())
     {
         m_triggerSelected = triggerSelector->getNumItems();
-        triggerSelector->setSelectedId(m_triggerSelected);
     }    
-    else
-        triggerSelector->setSelectedId(m_triggerSelected);
+    triggerSelector->setSelectedId(m_triggerSelected);
+
     if (m_gateSelected > triggerSelector->getNumItems())
     {
         m_gateSelected = gateSelector->getNumItems();
-        gateSelector->setSelectedId(m_gateSelected);
     }
-    else
-        gateSelector->setSelectedId(m_gateSelected);
+    gateSelector->setSelectedId(m_gateSelected);
 }
 
 void ChannelTriggerInterface::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
@@ -208,19 +205,15 @@ void ChannelTriggerInterface::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
     {
         processor->setParameter(0, channelNumber);
         processor->setParameter(1, (float) comboBoxThatHasChanged->getSelectedId() - 2);
-        if (comboBoxThatHasChanged->getSelectedId() - 1 > 0)
-            m_triggerSelected = comboBoxThatHasChanged->getSelectedId() - 1;
-        else
-            m_triggerSelected = 1;
+        m_triggerSelected = comboBoxThatHasChanged->getSelectedId();
+
     }
     else if (comboBoxThatHasChanged == gateSelector)
     {
         processor->setParameter(0, channelNumber);
         processor->setParameter(2, (float) comboBoxThatHasChanged->getSelectedId() - 2);
-        if (comboBoxThatHasChanged->getSelectedId() - 1 > 0)
-            m_gateSelected = comboBoxThatHasChanged->getSelectedId() - 1;
-        else
-            m_gateSelected = 1;    }
+        m_gateSelected = comboBoxThatHasChanged->getSelectedId();
+    }
 }
 
 int ChannelTriggerInterface::getTriggerChannel()

--- a/Source/Plugins/PulsePalOutput/PulsePalOutputEditor.cpp
+++ b/Source/Plugins/PulsePalOutput/PulsePalOutputEditor.cpp
@@ -205,14 +205,14 @@ void ChannelTriggerInterface::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
     {
         processor->setParameter(0, channelNumber);
         processor->setParameter(1, (float) comboBoxThatHasChanged->getSelectedId() - 2);
-        m_triggerSelected = comboBoxThatHasChanged->getSelectedId();
+        m_triggerSelected = jmax(1, comboBoxThatHasChanged->getSelectedId());
 
     }
     else if (comboBoxThatHasChanged == gateSelector)
     {
         processor->setParameter(0, channelNumber);
         processor->setParameter(2, (float) comboBoxThatHasChanged->getSelectedId() - 2);
-        m_gateSelected = comboBoxThatHasChanged->getSelectedId();
+        m_gateSelected = jmax(1, comboBoxThatHasChanged->getSelectedId());
     }
 }
 


### PR DESCRIPTION
There was a bug in the PulsePal plugin where the selections in the editor ComboBoxes would decrease by one index every time there was a signal chain update (unless they were already at index 0).

To reproduce:
* Add a Rhythm FPGA source followed by a PulsePal output
* Select some TTL channels in the PulsePal editor ComboBoxes
* Click the "ADC 1-8" button on and off to trigger signal chain updates.
* Every time the button is clicked, the ComboBox selections will change until they're back to saying "Trigger" and "Gate".

The error was in the comboBoxChanged listener, where in lines 212 and 221, `m_triggerSelected` and `m_gateSelected` are assigned the selected ID minus 1, where elsewhere they're expected to contain the selected ID. I've changed it to always assign the selected ID to these variables, unless there is nothing selected (ID 0) in which case it assigns 1.