### PR TITLE
Make latency text consistent and remove code repetition

### DIFF
--- a/Source/Processors/AudioNode/AudioEditor.cpp
+++ b/Source/Processors/AudioNode/AudioEditor.cpp
@@ -219,6 +219,7 @@ void AudioEditor::buttonClicked (Button* button)
             {
                 audioConfigurationWindow = new AudioConfigurationWindow (AccessClass::getAudioComponent()->deviceManager,
                                                                          audioWindowButton);
+                audioConfigurationWindow->addComponentListener(this);
             }
 
             AccessClass::getAudioComponent()->restartDevice();
@@ -226,9 +227,7 @@ void AudioEditor::buttonClicked (Button* button)
         }
         else
         {
-            updateBufferSizeText();
             audioConfigurationWindow->setVisible (false);
-            AccessClass::getAudioComponent()->stopDevice();
         }
     }
 
@@ -243,6 +242,14 @@ void AudioEditor::sliderValueChanged (Slider* slider)
         getAudioProcessor()->setParameter (2, slider->getValue());
 }
 
+void AudioEditor::componentVisibilityChanged(Component& component)
+{
+    if (component.getName() == audioConfigurationWindow->getName() && !component.isVisible())
+    {
+        updateBufferSizeText();
+        AccessClass::getAudioComponent()->stopDevice();
+    }
+}
 
 void AudioEditor::paint (Graphics& g)
 {
@@ -318,11 +325,6 @@ AudioConfigurationWindow::~AudioConfigurationWindow()
 void AudioConfigurationWindow::closeButtonPressed()
 {
     controlButton->setToggleState (false, dontSendNotification);
-
-    String t = String (AccessClass::getAudioComponent()->getBufferSizeMs());
-    t += " ms";
-    controlButton->setText (t);
-    AccessClass::getAudioComponent()->stopDevice();
     setVisible (false);
 }
 

--- a/Source/Processors/AudioNode/AudioEditor.h
+++ b/Source/Processors/AudioNode/AudioEditor.h
@@ -99,6 +99,7 @@ private:
 class AudioEditor : public AudioProcessorEditor
                   , public Button::Listener
                   , public Slider::Listener
+                  , public ComponentListener
 {
 public:
     AudioEditor (AudioNode* owner);
@@ -122,6 +123,7 @@ private:
 
     void sliderValueChanged (Slider* slider) override;
 
+    void componentVisibilityChanged(Component& component) override;
 
     float lastValue;
 


### PR DESCRIPTION
Super minor fix, just something that was slightly bothering me. Previously if you closed the Audio Settings with the close button rather than by clicking the `AudioWindowButton`, the text of the button changed from "Latency: xx ms" to just "xx ms". This makes it so the same function is called to update the text regardless of which button is pressed to close the window.