### PR TITLE
Fix crash when opening LFP Viewer Beta drawer before tab or window is opened

### DIFF
--- a/Source/Plugins/LfpDisplayNodeBeta/LfpDisplayCanvas.cpp
+++ b/Source/Plugins/LfpDisplayNodeBeta/LfpDisplayCanvas.cpp
@@ -1808,6 +1808,9 @@ void LfpDisplay::paint(Graphics& g)
 
 void LfpDisplay::refresh()
 {
+    // Ensure the lfpChannelBitmap has been initialized
+    if (lfpChannelBitmap.isNull()) { resized(); }
+
     // X-bounds of this update
     int fillfrom = canvas->lastScreenBufferIndex[0];
     int fillto = (canvas->screenBufferIndex[0]);

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -201,7 +201,7 @@ void VisualizerEditor::buttonClicked (Button* button)
     GenericEditor::buttonClicked (button);
 
     // Handle the buttons to open the canvas in a tab or window
-    if (canvas == nullptr)
+    if ((button == windowSelector || button == tabSelector) && canvas == nullptr)
     {
         canvas = createNewCanvas();
         canvas->update();

--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -201,7 +201,7 @@ void VisualizerEditor::buttonClicked (Button* button)
     GenericEditor::buttonClicked (button);
 
     // Handle the buttons to open the canvas in a tab or window
-    if ((button == windowSelector || button == tabSelector) && canvas == nullptr)
+    if (canvas == nullptr)
     {
         canvas = createNewCanvas();
         canvas->update();


### PR DESCRIPTION
Currently there's an assertion failure that happens sometimes when opening the LFP Viewer Beta's channel selector drawer. Steps to reproduce:

1. Add a new LFP Viewer Beta in a chain with at least 1 channel (so the drawer button exists).
2. Attempt to open the drawer (before ever clicking the tab or window button).

The bug is due to a step in the construction of a new `LfpDisplayCanvas` that attempts to create a `Graphics` context for the `lfpChannelBitmap`, which fails if the `LfpDisplay` component has never been resized, since `lfpChannelBitmap` is initialized in its `resized` method. Thus before this operation, I added a check for whether `lfpChannelBitmap` is valid and a call to `resized` if not.