### PR TITLE
FilterNode: Make restoring high and low cut text work consistently

### DIFF
--- a/Source/Plugins/FilterNode/FilterEditor.cpp
+++ b/Source/Plugins/FilterNode/FilterEditor.cpp
@@ -94,6 +94,11 @@ void FilterEditor::setDefaults(double lowCut, double highCut)
     lastHighCutString = String(roundFloatToInt(highCut));
     lastLowCutString = String(roundFloatToInt(lowCut));
 
+    resetToSavedText();
+}
+
+void FilterEditor::resetToSavedText()
+{
     highCutValue->setText(lastHighCutString, dontSendNotification);
     lowCutValue->setText(lastLowCutString, dontSendNotification);
 }
@@ -219,8 +224,10 @@ void FilterEditor::loadCustomParameters(XmlElement* xml)
     {
         if (xmlNode->hasTagName("VALUES"))
         {
-            highCutValue->setText(xmlNode->getStringAttribute("HighCut"),dontSendNotification);
-            lowCutValue->setText(xmlNode->getStringAttribute("LowCut"),dontSendNotification);
+            lastHighCutString = xmlNode->getStringAttribute("HighCut", lastHighCutString);
+            lastLowCutString = xmlNode->getStringAttribute("LowCut", lastLowCutString);
+            resetToSavedText();
+
             applyFilterOnADC->setToggleState(xmlNode->getBoolAttribute("ApplyToADC",false), sendNotification);
         }
     }

--- a/Source/Plugins/FilterNode/FilterEditor.h
+++ b/Source/Plugins/FilterNode/FilterEditor.h
@@ -51,6 +51,7 @@ public:
     void loadCustomParameters(XmlElement* xml);
 
     void setDefaults(double lowCut, double highCut);
+    void resetToSavedText();
 
     void channelChanged (int chan, bool newState);
 

--- a/Source/Plugins/FilterNode/FilterNode.cpp
+++ b/Source/Plugins/FilterNode/FilterNode.cpp
@@ -310,6 +310,9 @@ void FilterNode::loadCustomChannelParametersFromXml(XmlElement* channelInfo, Inf
 
     if (channelType == InfoObjectCommon::DATA_CHANNEL)
     {
+        // restore high and low cut text in case they were changed by channelChanged
+        static_cast<FilterEditor*>(getEditor())->resetToSavedText();
+
         forEachXmlChildElement (*channelInfo, subNode)
         {
             if (subNode->hasTagName ("PARAMETERS"))

--- a/Source/Plugins/FilterNode/FilterNode.h
+++ b/Source/Plugins/FilterNode/FilterNode.h
@@ -50,8 +50,8 @@ public:
 
     void updateSettings() override;
 
-	void saveCustomChannelParametersToXml(XmlElement* channelInfo, int channelNumber, InfoObjectCommon::InfoObjectType channelTypel) override;
-	void loadCustomChannelParametersFromXml(XmlElement* channelInfo, InfoObjectCommon::InfoObjectType channelType)  override;
+    void saveCustomChannelParametersToXml(XmlElement* channelInfo, int channelNumber, InfoObjectCommon::InfoObjectType channelTypel) override;
+    void loadCustomChannelParametersFromXml(XmlElement* channelInfo, InfoObjectCommon::InfoObjectType channelType)  override;
 
     double getLowCutValueForChannel  (int chan) const;
     double getHighCutValueForChannel (int chan) const;


### PR DESCRIPTION
This fixes a bug where the last high cut and low cut values for the bandpass filter are not restored properly when loading a settings file (i.e. the text values of the labels; the actual passbands for each channel are already loaded correctly). This is a fairly minor issue, but it gets a little confusing if you've only selected some channels and changed their high and low cuts, and then when you load the settings back in you see the default values rather than the ones you put in.

The issue is that `channelChanged` updates the high and low cut text to correspond to the clicked channel, which is desired behavior except when it is called in the process of loading settings. The param selection states get restored after the editor settings, so `channelChanged` gets called for any channels that have been deselected after the high and low cut text have already been restored in `FilterEditor::loadCustomParameters`. To get around this, I set `lastLowCutString` and `lastHighCutString` when restoring the text, and then reset the labels to these values in `loadCustomChannelParametersFromXml` for each channel - counteracting `channelChanged` which gets called first.