### PR TITLE
Fix bug where splitters don't always update their editors correctly

### DIFF
--- a/Source/Processors/Splitter/Splitter.h
+++ b/Source/Processors/Splitter/Splitter.h
@@ -55,16 +55,17 @@ public:
     /** Nothing happens here, because Splitters are not part of the ProcessorGraph. */
     void process(AudioSampleBuffer& buffer) override {}
 
-    bool isSplitter()
+    bool isSplitter() const override
     {
         return true;
     }
 
-    void switchIO(int);
-    void switchIO();
-    void setSplitterDestNode(GenericProcessor* dn);
+    void switchIO(int) override;
+    void switchIO() override;
+    
+    void setSplitterDestNode(GenericProcessor* dn) override;
 
-    void setPathToProcessor(GenericProcessor* processor);
+    void setPathToProcessor(GenericProcessor* processor) override;
 
     int getPath();
 

--- a/Source/Processors/Splitter/SplitterEditor.cpp
+++ b/Source/Processors/Splitter/SplitterEditor.cpp
@@ -100,23 +100,11 @@ void SplitterEditor::buttonEvent(Button* button)
 {
     if (button == pipelineSelectorA)
     {
-        pipelineSelectorA->setToggleState(true, dontSendNotification);
-        pipelineSelectorB->setToggleState(false, dontSendNotification);
-        Splitter* processor = (Splitter*) getProcessor();
-        processor->switchIO(0);
-
-		AccessClass::getEditorViewport()->makeEditorVisible(this, false);
-
+        switchDest(0);
     }
     else if (button == pipelineSelectorB)
     {
-        pipelineSelectorB->setToggleState(true, dontSendNotification);
-        pipelineSelectorA->setToggleState(false, dontSendNotification);
-        Splitter* processor = (Splitter*) getProcessor();
-        processor->switchIO(1);
-
-		AccessClass::getEditorViewport()->makeEditorVisible(this, false);
-
+        switchDest(1);
     }
 }
 
@@ -126,20 +114,38 @@ void SplitterEditor::switchDest(int dest)
     {
         pipelineSelectorA->setToggleState(true, dontSendNotification);
         pipelineSelectorB->setToggleState(false, dontSendNotification);
-        Splitter* processor = (Splitter*) getProcessor();
-        processor->switchIO(0);
+        getProcessor()->switchIO(0);
 
     }
     else if (dest == 1)
     {
         pipelineSelectorB->setToggleState(true, dontSendNotification);
         pipelineSelectorA->setToggleState(false, dontSendNotification);
-        Splitter* processor = (Splitter*) getProcessor();
-        processor->switchIO(1);
+        getProcessor()->switchIO(1);
 
     }
 
 	AccessClass::getEditorViewport()->makeEditorVisible(this, false);
+}
+
+void SplitterEditor::switchDest()
+{
+    Splitter* processor = (Splitter*)getProcessor();
+    processor->switchIO();
+
+    int path = processor->getPath();
+
+    if (path == 0)
+    {
+        pipelineSelectorA->setToggleState(true, dontSendNotification);
+        pipelineSelectorB->setToggleState(false, dontSendNotification);
+
+    }
+    else if (path == 1)
+    {
+        pipelineSelectorB->setToggleState(true, dontSendNotification);
+        pipelineSelectorA->setToggleState(false, dontSendNotification);
+    }
 }
 
 void SplitterEditor::switchIO(int dest)
@@ -188,25 +194,4 @@ Array<GenericEditor*> SplitterEditor::getConnectedEditors()
 
     return editors;
 
-}
-
-void SplitterEditor::switchDest()
-{
-    Splitter* processor = (Splitter*) getProcessor();
-    processor->switchIO();
-
-    int path = processor->getPath();
-
-    if (path == 0)
-    {
-        pipelineSelectorA->setToggleState(true, dontSendNotification);
-        pipelineSelectorB->setToggleState(false, dontSendNotification);
-
-    }
-    else if (path == 1)
-    {
-        pipelineSelectorB->setToggleState(true,dontSendNotification);
-        pipelineSelectorA->setToggleState(false, dontSendNotification);
-
-    }
 }

--- a/Source/Processors/Splitter/SplitterEditor.h
+++ b/Source/Processors/Splitter/SplitterEditor.h
@@ -42,15 +42,15 @@ public:
     SplitterEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors);
     virtual ~SplitterEditor();
 
-    void buttonEvent(Button* button);
+    void buttonEvent(Button* button) override;
 
-    void switchDest(int);
-    void switchDest();
+    void switchDest(int dest);
+    void switchDest() override;
 
-    void switchIO(int i);
+    void switchIO(int) override;
 
-    int getPathForEditor(GenericEditor* editor);
-    Array<GenericEditor*> getConnectedEditors();
+    int getPathForEditor(GenericEditor* editor) override;
+    Array<GenericEditor*> getConnectedEditors() override;
 
 
 private:

--- a/Source/UI/SignalChainManager.cpp
+++ b/Source/UI/SignalChainManager.cpp
@@ -376,23 +376,30 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
         // std::cout << "Inserting " << editorToAdd->getName() << " at point 0." << std::endl;
 
         editorArray.insert(0,editorToAdd);
-        GenericProcessor* currentProcessor = (GenericProcessor*) editorToAdd->getProcessor();
+        GenericProcessor* currentProcessor = editorToAdd->getProcessor();
         GenericProcessor* source = currentProcessor->getSourceNode();
 
         if (source != nullptr)
         {
             //   std::cout << "Source: " << source->getName() << std::endl;
 
+            GenericEditor* sourceEditor = source->getEditor();
+
             // need to switch the splitter somehow
             if (action == ACTIVATE || action == UPDATE)
             {
-                if (source->isSplitter())
+                if (source->isSplitter() && sourceEditor != nullptr)
                 {
-                    source->setPathToProcessor(currentProcessor);
+                    // a little hacky - switch editor (including buttons)
+                    // to path with current editor without calling makeEditorVisible
+                    int path = sourceEditor->getPathForEditor(editorToAdd);
+                    jassert(path == 0 || path == 1);
+                    source->switchIO(1 - path);
+                    sourceEditor->switchDest();
                 }
             }
 
-            editorToAdd = (GenericEditor*) source->getEditor();
+            editorToAdd = sourceEditor;
 
         }
         else


### PR DESCRIPTION
Currently, there's a bug where sometimes a splitter editor will have the wrong branch selected until you manually switch it to the other branch and back and it gets in sync with the visible destination processor(s). As far as I can tell, this happens sometimes when loading a signal chain, and when selecting a processor on the processor graph that requires a switch in a splitter that comes before it in the chain in order to become visible. This can be particularly annoying when you have a chain with multiple splitters that you're loading often.

The problem seems to occur when calling `updateVisibleEditors` with action ACTIVATE or UPDATE. In these calls, `Splitter::setPathToProcessor` is used to switch splitters in step 4 if necessary, but this function doesn't actually update the editor, just the splitter's `activePath` and `destNode`. I didn't want to modify this function because it's also used in `ProcessorGraph::updateConnections`, where I'm guessing we might not want to change any of the editors. Instead, I used what's shown here as a workaround. It's pretty indirect though, and it would be good to do a more through refactoring of `Splitter` and `SplitterEditor` since there are a lot of mysterious differences between functions that sound like they should do the same thing.

Also includes some minor cleanup of `Splitter` and `SplitterEditor`.