### PR TITLE
Improve Event Broadcaster robustness and feedback on error

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -22,6 +22,29 @@ std::shared_ptr<void> EventBroadcaster::getZMQContext() {
     return ctx;
 }
 
+int EventBroadcaster::unbindZMQSocket()
+{
+#ifdef ZEROMQ
+    void* socket = zmqSocket.get();
+    if (socket != nullptr && listeningPort != 0)
+    {
+        return zmq_unbind(socket, getEndpoint(listeningPort).toRawUTF8());
+    }
+#endif
+    return 0;
+}
+
+int EventBroadcaster::rebindZMQSocket()
+{
+#ifdef ZEROMQ
+    void* socket = zmqSocket.get();
+    if (socket != nullptr && listeningPort != 0)
+    {
+        return zmq_bind(socket, getEndpoint(listeningPort).toRawUTF8());
+    }
+#endif
+    return 0;
+}
 
 void EventBroadcaster::closeZMQSocket(void* socket)
 {
@@ -30,16 +53,35 @@ void EventBroadcaster::closeZMQSocket(void* socket)
 #endif
 }
 
+String EventBroadcaster::getEndpoint(int port)
+{
+    return (String("tcp://*:") + String(port));
+}
+
+void EventBroadcaster::reportActualListeningPort(int port)
+{
+    listeningPort = port;
+    auto editor = static_cast<EventBroadcasterEditor*>(getEditor());
+    if (editor)
+    {
+        editor->setDisplayedPort(port);
+    }
+}
 
 EventBroadcaster::EventBroadcaster()
     : GenericProcessor  ("Event Broadcaster")
     , zmqContext        (getZMQContext())
-    , zmqSocket         (nullptr, &closeZMQSocket)
+    , zmqSocket         (nullptr)
     , listeningPort     (0)
 {
     setProcessorType (PROCESSOR_TYPE_SINK);
 
-    setListeningPort(5557);
+    int portToTry = 5557;
+    while (setListeningPort(portToTry) == EADDRINUSE)
+    {
+        // try the next port, looking for one not in use
+        portToTry++;
+    }
 }
 
 
@@ -56,27 +98,53 @@ int EventBroadcaster::getListeningPort() const
 }
 
 
-void EventBroadcaster::setListeningPort(int port, bool forceRestart)
+int EventBroadcaster::setListeningPort(int port, bool forceRestart)
 {
     if ((listeningPort != port) || forceRestart)
     {
 #ifdef ZEROMQ
-        zmqSocket.reset(zmq_socket(zmqContext.get(), ZMQ_PUB));
-        if (!zmqSocket)
+        // unbind current socket (if any) to free up port
+        unbindZMQSocket();
+        zmqSocketPtr newSocket(zmq_socket(zmqContext.get(), ZMQ_PUB));
+        auto editor = static_cast<EventBroadcasterEditor*>(getEditor());
+        int status = 0;
+
+        if (!newSocket.get())
         {
-            std::cout << "Failed to create socket: " << zmq_strerror(zmq_errno()) << std::endl;
-            return;
+            status = zmq_errno();
+            std::cout << "Failed to create socket: " << zmq_strerror(status) << std::endl;
+        }
+        else
+        {
+            if (0 != zmq_bind(newSocket.get(), getEndpoint(port).toRawUTF8()))
+            {
+                status = zmq_errno();
+                std::cout << "Failed to open socket: " << zmq_strerror(status) << std::endl;
+            }
+            else
+            {
+                // success
+                zmqSocket.swap(newSocket);
+                reportActualListeningPort(port);
+                return status;
+            }
         }
 
-        String url = String("tcp://*:") + String(port);
-        if (0 != zmq_bind(zmqSocket.get(), url.toRawUTF8()))
+        // failure, try to rebind current socket to previous port
+        if (0 == rebindZMQSocket())
         {
-            std::cout << "Failed to open socket: " << zmq_strerror(zmq_errno()) << std::endl;
-            return;
+            reportActualListeningPort(listeningPort);
         }
+        else
+        {
+            reportActualListeningPort(0);
+        }
+        return status;
+
+#else
+        reportActualListeningPort(port);
+        return 0;
 #endif
-
-        listeningPort = port;
     }
 }
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
@@ -46,7 +46,14 @@ void EventBroadcasterEditor::buttonEvent(Button* button)
     if (button == restartConnection)
     {
         EventBroadcaster* p = (EventBroadcaster*)getProcessor();
-        p->setListeningPort(p->getListeningPort(), true);
+        int status = p->setListeningPort(p->getListeningPort(), true);
+
+#ifdef ZEROMQ
+        if (status != 0)
+        {
+            CoreServices::sendStatusMessage(String("Restart failed: ") + zmq_strerror(status));
+        }
+#endif
     }
 }
 
@@ -58,6 +65,18 @@ void EventBroadcasterEditor::labelTextChanged(juce::Label* label)
         Value val = label->getTextValue();
 
         EventBroadcaster* p = (EventBroadcaster*)getProcessor();
-        p->setListeningPort(val.getValue());
+        int status = p->setListeningPort(val.getValue());
+
+#ifdef ZEROMQ
+        if (status != 0)
+        {
+            CoreServices::sendStatusMessage(String("Port change failed: ") + zmq_strerror(status));
+        }
+#endif
     }
+}
+
+void EventBroadcasterEditor::setDisplayedPort(int port)
+{
+    portLabel->setText(String(port), dontSendNotification);
 }

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.h
@@ -30,6 +30,8 @@ public:
     void buttonEvent(Button* button) override;
     void labelTextChanged(juce::Label* label) override;
 
+    void setDisplayedPort(int port);
+
 private:
     ScopedPointer<UtilityButton> restartConnection;
     ScopedPointer<Label> urlLabel;


### PR DESCRIPTION
This incorporates a few changes to try to make the Event Broadcaster more predictable and less frustrating to use:

* Previously, the socket would silently fail to bind to the port every other time you clicked "Restart connection" (at least on my machine), due to the old socket not actually closing and freeing the port immediately. This also caused race conditions when loading a signal chain. The issue is discussed here (for the Node.js version): https://github.com/JustinTulloss/zeromq.node/issues/214. To solve, as suggested there, I added a call to `zmq_unbind` which frees the port immediately. The old socket then only gets closed if the new one is bound successfully; otherwise, it gets rebound to the original port.

* When loading a signal chain, previously the editor would not be updated to show the loaded port. Fixed this by adding a method in the editor to update the displayed port and calling this whenever the port is set.

* If 5557 was already in use, a new Event Broadcaster would default to port 0 (invalid), which is not ideal. Instead, changed the constructor to keep looking for a free port if it receives the `EADDRINUSE` error from `setListeningPort`.

* Made the editor report errors in the status bar if they occur when changing the port or restarting the connection.

I briefly looked at the Network Events plugin as well, but it looks like the code there is substantially different even though the editor's appearance is similar to Event Broadcaster. So I didn't want to get involved with that too given that this is already a medium-sized PR.