### PR TITLE
Change some integers in OriginalRecording to more specific types

### DIFF
--- a/Source/Processors/RecordNode/OriginalRecording.cpp
+++ b/Source/Processors/RecordNode/OriginalRecording.cpp
@@ -432,7 +432,7 @@ void OriginalRecording::writeTTLEvent(int eventIndex, const MidiMessage& event)
 	*(data + 11) = static_cast<uint8>(ev->getSourceID());
 	*(data + 12) = (ev->getEventType() == EventChannel::TTL) ? (dynamic_cast<TTLEvent*>(ev.get())->getState() ? 1 : 0) : 0;
 	*(data + 13) = static_cast<uint8>(ev->getChannel());
-	*reinterpret_cast<uint16*>(data + 14) = static_cast<uint16>(recordingNumber);
+	*reinterpret_cast<uint16*>(data + 14) = recordingNumber;
     
 
     diskWriteLock.enter();

--- a/Source/Processors/RecordNode/OriginalRecording.h
+++ b/Source/Processors/RecordNode/OriginalRecording.h
@@ -77,7 +77,7 @@ private:
     bool separateFiles;
     Array<int> blockIndex;
     Array<int> samplesSinceLastTimestamp;
-    int recordingNumber;
+    uint16 recordingNumber;
     int experimentNumber;
 
     bool renameFiles;
@@ -96,7 +96,7 @@ private:
     //float* continuousDataFloatBuffer;
 
     /** Used to indicate the end of each record */
-	HeapBlock<char> recordMarker;
+	HeapBlock<uint8> recordMarker;
     //char* recordMarker;
 
     AudioSampleBuffer zeroBuffer;


### PR DESCRIPTION
A couple minor changes that probably won't have any effect. However, the line

`recordMarker[9] = 255;`

in the constructor was previously assigning to a (signed) char, which is _technically_ undefined behavior and caused a compiler warning. Also, the `recordingNumber` is written to the file assuming that it's two bytes whereas an int _officially_ could be longer than two bytes.