### PR TITLE
Add ability to disable record thread via recording options interface

### DIFF
--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -38,157 +38,169 @@ using namespace AccessClass;
 
 namespace CoreServices
 {
-void updateSignalChain(GenericEditor* source)
-{
-    getEditorViewport()->makeEditorVisible(source, false, true);
-}
+	void updateSignalChain(GenericEditor* source)
+	{
+		getEditorViewport()->makeEditorVisible(source, false, true);
+	}
 
-bool getRecordingStatus()
-{
-    return getControlPanel()->recordButton->getToggleState();
-}
+	bool getRecordingStatus()
+	{
+		return getControlPanel()->recordButton->getToggleState();
+	}
 
-void setRecordingStatus(bool enable)
-{
-    getControlPanel()->setRecordState(enable);
-}
+	void setRecordingStatus(bool enable)
+	{
+		getControlPanel()->setRecordState(enable);
+	}
 
-bool getAcquisitionStatus()
-{
-	return getControlPanel()->getAcquisitionState();
-}
+	bool getAcquisitionStatus()
+	{
+		return getControlPanel()->getAcquisitionState();
+	}
 
-void setAcquisitionStatus(bool enable)
-{
-    getControlPanel()->setAcquisitionState(enable);
-}
+	void setAcquisitionStatus(bool enable)
+	{
+		getControlPanel()->setAcquisitionState(enable);
+	}
 
-void sendStatusMessage(const String& text)
-{
-    getBroadcaster()->sendActionMessage(text);
-}
+	void sendStatusMessage(const String& text)
+	{
+		getBroadcaster()->sendActionMessage(text);
+	}
 
-void sendStatusMessage(const char* text)
-{
-    getBroadcaster()->sendActionMessage(text);
-}
+	void sendStatusMessage(const char* text)
+	{
+		getBroadcaster()->sendActionMessage(text);
+	}
 
-void highlightEditor(GenericEditor* ed)
-{
-    getEditorViewport()->makeEditorVisible(ed);
-}
+	void highlightEditor(GenericEditor* ed)
+	{
+		getEditorViewport()->makeEditorVisible(ed);
+	}
 
-juce::int64 getGlobalTimestamp()
-{
-	return getProcessorGraph()->getGlobalTimestamp(false);
-}
+	juce::int64 getGlobalTimestamp()
+	{
+		return getProcessorGraph()->getGlobalTimestamp(false);
+	}
 
-juce::int64 getSoftwareTimestamp()
-{
-	return getProcessorGraph()->getGlobalTimestamp(true);
-}
+	juce::int64 getSoftwareTimestamp()
+	{
+		return getProcessorGraph()->getGlobalTimestamp(true);
+	}
 
-float getGlobalSampleRate()
-{
-	return getProcessorGraph()->getGlobalSampleRate(false);
-}
+	float getGlobalSampleRate()
+	{
+		return getProcessorGraph()->getGlobalSampleRate(false);
+	}
 
-float getSoftwareSampleRate()
-{
-	return getProcessorGraph()->getGlobalSampleRate(true);
-}
+	float getSoftwareSampleRate()
+	{
+		return getProcessorGraph()->getGlobalSampleRate(true);
+	}
 
-void setRecordingDirectory(String dir)
-{
-    getControlPanel()->setRecordingDirectory(dir);
-}
+	void setRecordingDirectory(String dir)
+	{
+		getControlPanel()->setRecordingDirectory(dir);
+	}
 
-void createNewRecordingDir()
-{
-   getControlPanel()->labelTextChanged(NULL);
-}
+	void createNewRecordingDir()
+	{
+		getControlPanel()->labelTextChanged(NULL);
+	}
 
-void setPrependTextToRecordingDir(String text)
-{
-    getControlPanel()->setPrependText(text);
-}
+	void setPrependTextToRecordingDir(String text)
+	{
+		getControlPanel()->setPrependText(text);
+	}
 
-void setAppendTextToRecordingDir(String text)
-{
-    getControlPanel()->setAppendText(text);
-}
+	void setAppendTextToRecordingDir(String text)
+	{
+		getControlPanel()->setAppendText(text);
+	}
 
-String getSelectedRecordEngineId()
-{
-	return getControlPanel()->getSelectedRecordEngineId();
-}
+	String getSelectedRecordEngineId()
+	{
+		return getControlPanel()->getSelectedRecordEngineId();
+	}
 
-bool setSelectedRecordEngineId(String id)
-{
-	return getControlPanel()->setSelectedRecordEngineId(id);
-}
+	bool setSelectedRecordEngineId(String id)
+	{
+		return getControlPanel()->setSelectedRecordEngineId(id);
+	}
 
-namespace RecordNode
-{
-void createNewrecordingDir()
-{
-    getProcessorGraph()->getRecordNode()->createNewDirectory();
-}
+	namespace RecordNode
+	{
+		void createNewrecordingDir()
+		{
+			getProcessorGraph()->getRecordNode()->createNewDirectory();
+		}
 
-File getRecordingPath()
-{
-    return getProcessorGraph()->getRecordNode()->getDataDirectory();
-}
+		File getRecordingPath()
+		{
+			return getProcessorGraph()->getRecordNode()->getDataDirectory();
+		}
 
-int getRecordingNumber()
-{
-	return getProcessorGraph()->getRecordNode()->getRecordingNumber();
-}
+		int getRecordingNumber()
+		{
+			return getProcessorGraph()->getRecordNode()->getRecordingNumber();
+		}
 
-int getExperimentNumber()
-{
-	return getProcessorGraph()->getRecordNode()->getExperimentNumber();
-}
+		int getExperimentNumber()
+		{
+			return getProcessorGraph()->getRecordNode()->getExperimentNumber();
+		}
 
-void writeSpike(const SpikeEvent* spike, const SpikeChannel* chan)
-{
-    getProcessorGraph()->getRecordNode()->writeSpike(spike, chan);
-}
+		void writeSpike(const SpikeEvent* spike, const SpikeChannel* chan)
+		{
+			getProcessorGraph()->getRecordNode()->writeSpike(spike, chan);
+		}
 
-void registerSpikeSource(GenericProcessor* processor)
-{
-    getProcessorGraph()->getRecordNode()->registerSpikeSource(processor);
-}
+		void registerSpikeSource(GenericProcessor* processor)
+		{
+			getProcessorGraph()->getRecordNode()->registerSpikeSource(processor);
+		}
 
-int addSpikeElectrode(const SpikeChannel* elec)
-{
-    return getProcessorGraph()->getRecordNode()->addSpikeElectrode(elec);
-}
-};
+		int addSpikeElectrode(const SpikeChannel* elec)
+		{
+			return getProcessorGraph()->getRecordNode()->addSpikeElectrode(elec);
+		}
 
-const char* getApplicationResource(const char* name, int& size)
-{
-	return BinaryData::getNamedResource(name, size);
-}
-    
-File getDefaultUserSaveDirectory()
-{
+		void toggleRecordThread(bool status)
+		{
+			if (status)
+				getProcessorGraph()->getRecordNode()->setParameter(3, 1.0);
+			else
+				getProcessorGraph()->getRecordNode()->setParameter(3, 0.0);
+		}
+
+		bool getRecordThreadStatus()
+		{
+			return getProcessorGraph()->getRecordNode()->getRecordThreadStatus();
+		}
+	};
+
+	const char* getApplicationResource(const char* name, int& size)
+	{
+		return BinaryData::getNamedResource(name, size);
+	}
+
+	File getDefaultUserSaveDirectory()
+	{
 #if defined(__APPLE__)
-    File dir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("open-ephys");
-    if (!dir.isDirectory()) {
-        dir.createDirectory();
-    }
-    return std::move(dir);
+		File dir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("open-ephys");
+		if (!dir.isDirectory()) {
+			dir.createDirectory();
+		}
+		return std::move(dir);
 #else
-    return File::getCurrentWorkingDirectory();
+		return File::getCurrentWorkingDirectory();
 #endif
-}
+	}
 
-String getGUIVersion()
-{
+	String getGUIVersion()
+	{
 #define XSTR_DEF(s) #s
 #define STR_DEF(s) XSTR_DEF(s)
-	return STR_DEF(JUCE_APP_VERSION);
-}
-
+		return STR_DEF(JUCE_APP_VERSION);
+	}
 };

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -165,18 +165,6 @@ namespace CoreServices
 			return getProcessorGraph()->getRecordNode()->addSpikeElectrode(elec);
 		}
 
-		void toggleRecordThread(bool status)
-		{
-			if (status)
-				getProcessorGraph()->getRecordNode()->setParameter(3, 1.0);
-			else
-				getProcessorGraph()->getRecordNode()->setParameter(3, 0.0);
-		}
-
-		bool getRecordThreadStatus()
-		{
-			return getProcessorGraph()->getRecordNode()->getRecordThreadStatus();
-		}
 	};
 
 	const char* getApplicationResource(const char* name, int& size)

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -110,9 +110,6 @@ PLUGIN_API void writeSpike(const SpikeEvent* spike, const SpikeChannel* chan);
 PLUGIN_API void registerSpikeSource(GenericProcessor* processor);
 PLUGIN_API int addSpikeElectrode(const SpikeChannel* elec);
 
-/* Don't mess with this unless you know what you're doing.*/
-PLUGIN_API void toggleRecordThread(bool status);
-PLUGIN_API bool getRecordThreadStatus();
 };
 
 PLUGIN_API const char* getApplicationResource(const char* name, int& size);

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -109,6 +109,10 @@ PLUGIN_API int getExperimentNumber();
 PLUGIN_API void writeSpike(const SpikeEvent* spike, const SpikeChannel* chan);
 PLUGIN_API void registerSpikeSource(GenericProcessor* processor);
 PLUGIN_API int addSpikeElectrode(const SpikeChannel* elec);
+
+/* Don't mess with this unless you know what you're doing.*/
+PLUGIN_API void toggleRecordThread(bool status);
+PLUGIN_API bool getRecordThreadStatus();
 };
 
 PLUGIN_API const char* getApplicationResource(const char* name, int& size);

--- a/Source/Processors/RecordNode/EngineConfigWindow.cpp
+++ b/Source/Processors/RecordNode/EngineConfigWindow.cpp
@@ -150,7 +150,9 @@ EngineConfigComponent::EngineConfigComponent(RecordEngineManager* man, int heigh
     bool hasString = false;
     setName(man->getName()+" Recording Configuration");
 
-    for (int i = 0; i < man->getNumParameters(); i++)
+	int i;
+
+    for (i = 0; i < man->getNumParameters(); i++)
     {
         EngineParameterComponent* par = new EngineParameterComponent(man->getParameter(i));
         if (man->getParameter(i).type == EngineParameter::STR || man->getParameter(i).type == EngineParameter::MULTI)
@@ -159,14 +161,60 @@ EngineConfigComponent::EngineConfigComponent(RecordEngineManager* man, int heigh
         addAndMakeVisible(par);
         parameters.add(par);
     }
+
+	ToggleButton* but = new ToggleButton();
+	but->setToggleState(CoreServices::RecordNode::getRecordThreadStatus(), dontSendNotification);
+	but->setBounds(10, 10+40*(i+1), 100, 20);
+	but->addListener(this);
+	addAndMakeVisible(but);
+
+	Label* label = new Label();
+	label->setText("Is record thread enabled?", NotificationType::dontSendNotification);
+	label->setBounds(30, 10 + 40 * (i + 1), 240, 20);
+	addAndMakeVisible(label);
+
+	height = 10 + 40 * (i + 1) + 30;
+
     if (hasString)
-        this->setSize(300,height);
+        this->setSize(350,height);
     else
-        this->setSize(200,height);
+        this->setSize(350,height);
+
+
 }
 
 EngineConfigComponent::~EngineConfigComponent()
 {
+}
+
+void EngineConfigComponent::buttonClicked(Button* b)
+{
+
+	if (!CoreServices::getRecordingStatus())
+	{
+		if (b->getToggleState() == false)
+		{
+		
+			int response = AlertWindow::showOkCancelBox(AlertWindow::AlertIconType::WarningIcon,
+				"Disable record thread?",
+				"Are you sure you want to disable the record thread? You'll need to have a processor capable of recording data on its own.",
+				"Yes", "No");
+
+			if (response == 1)
+				CoreServices::RecordNode::toggleRecordThread(false);
+			else
+				b->setToggleState(true, false);
+
+
+		}
+		else {
+			CoreServices::RecordNode::toggleRecordThread(true);
+		}
+		
+	}
+	else {
+		CoreServices::sendStatusMessage("Cannot toggle record thread status while recording is active.");
+	}
 }
 
 void EngineConfigComponent::saveParameters()
@@ -193,7 +241,7 @@ EngineConfigWindow::EngineConfigWindow(RecordEngineManager* man)
     setResizable(false,false);
     setName(man->getName()+" recording configuration");
 
-    ui = new EngineConfigComponent(man,height);
+    ui = new EngineConfigComponent(man, height);
     setContentNonOwned(ui,true);
 }
 

--- a/Source/Processors/RecordNode/EngineConfigWindow.cpp
+++ b/Source/Processors/RecordNode/EngineConfigWindow.cpp
@@ -23,6 +23,8 @@
 
 #include "EngineConfigWindow.h"
 
+#include "../../AccessClass.h"
+
 EngineParameterComponent::EngineParameterComponent(EngineParameter& param)
     : Component(param.name), type(param.type), parameter(param)
 {
@@ -162,16 +164,17 @@ EngineConfigComponent::EngineConfigComponent(RecordEngineManager* man, int heigh
         parameters.add(par);
     }
 
-	ToggleButton* but = new ToggleButton();
-	but->setToggleState(CoreServices::RecordNode::getRecordThreadStatus(), dontSendNotification);
-	but->setBounds(10, 10+40*(i+1), 100, 20);
-	but->addListener(this);
-	addAndMakeVisible(but);
+	recordThreadToggleButton = new ToggleButton();
 
-	Label* label = new Label();
-	label->setText("Is record thread enabled?", NotificationType::dontSendNotification);
-	label->setBounds(30, 10 + 40 * (i + 1), 240, 20);
-	addAndMakeVisible(label);
+	recordThreadToggleButton->setToggleState(AccessClass::getProcessorGraph()->getRecordNode()->getRecordThreadStatus(), dontSendNotification);
+	recordThreadToggleButton->setBounds(10, 10 + 40 * (i + 1), 100, 20);
+	recordThreadToggleButton->addListener(this);
+	addAndMakeVisible(recordThreadToggleButton);
+
+	recordThreadToggleLabel = new Label();
+	recordThreadToggleLabel->setText("Is record thread enabled?", NotificationType::dontSendNotification);
+	recordThreadToggleLabel->setBounds(30, 10 + 40 * (i + 1), 240, 20);
+	addAndMakeVisible(recordThreadToggleLabel);
 
 	height = 10 + 40 * (i + 1) + 30;
 
@@ -201,14 +204,14 @@ void EngineConfigComponent::buttonClicked(Button* b)
 				"Yes", "No");
 
 			if (response == 1)
-				CoreServices::RecordNode::toggleRecordThread(false);
+				AccessClass::getProcessorGraph()->getRecordNode()->setParameter(3, 0.0);
 			else
 				b->setToggleState(true, false);
 
 
 		}
 		else {
-			CoreServices::RecordNode::toggleRecordThread(true);
+			AccessClass::getProcessorGraph()->getRecordNode()->setParameter(3, 1.0);
 		}
 		
 	}

--- a/Source/Processors/RecordNode/EngineConfigWindow.h
+++ b/Source/Processors/RecordNode/EngineConfigWindow.h
@@ -47,11 +47,12 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EngineParameterComponent);
 };
 
-class EngineConfigComponent : public Component
+class EngineConfigComponent : public Component, public Button::Listener
 {
 public:
     EngineConfigComponent(RecordEngineManager* man, int height);
     ~EngineConfigComponent();
+	void buttonClicked(Button*);
     void paint(Graphics& g) override;
     void saveParameters();
 

--- a/Source/Processors/RecordNode/EngineConfigWindow.h
+++ b/Source/Processors/RecordNode/EngineConfigWindow.h
@@ -26,6 +26,8 @@
 
 #include "../../../JuceLibraryCode/JuceHeader.h"
 #include "RecordEngine.h"
+#include "RecordNode.h"
+#include "../ProcessorGraph/ProcessorGraph.h"
 
 class EngineParameterComponent : public Component,
     public Label::Listener, public SettableTooltipClient
@@ -59,6 +61,9 @@ public:
 private:
     OwnedArray<EngineParameterComponent> parameters;
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EngineConfigComponent);
+	
+	ScopedPointer<ToggleButton> recordThreadToggleButton;
+	ScopedPointer<Label> recordThreadToggleLabel;
 };
 
 class EngineConfigWindow : public DocumentWindow

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -40,6 +40,7 @@ RecordNode::RecordNode()
 
     isProcessing = false;
     isRecording = false;
+	shouldRecord = true;
 	setFirstBlock = false;
 
     settings.numInputs = 2048;
@@ -264,41 +265,42 @@ int RecordNode::getRecordingNumber() const
 
 void RecordNode::setParameter(int parameterIndex, float newValue)
 {
-    //editor->updateParameterButtons(parameterIndex);
+	//editor->updateParameterButtons(parameterIndex);
 
-    // 0 = stop recording
-    // 1 = start recording
-    // 2 = toggle individual channel (0.0f = OFF, anything else = ON)
+	// 0 = stop recording
+	// 1 = start recording
+	// 2 = toggle individual channel (0.0f = OFF, anything else = ON)
+	// 3 = toggle record thread ON/OFF (use carefully!)
 
-    if (parameterIndex == 1)
-    {
+	if (parameterIndex == 1)
+	{
 
-		
+
 		// std::cout << "START RECORDING." << std::endl;
 
-        if (newDirectoryNeeded)
-        {
-            createNewDirectory();
-            recordingNumber = 0;
-            experimentNumber = 1;
-            settingsNeeded = true;
-            EVERY_ENGINE->directoryChanged();
-        }
-        else
-        {
-            recordingNumber++; // increment recording number within this directory
-        }
+		if (newDirectoryNeeded)
+		{
+			createNewDirectory();
+			recordingNumber = 0;
+			experimentNumber = 1;
+			settingsNeeded = true;
+			EVERY_ENGINE->directoryChanged();
+		}
+		else
+		{
+			recordingNumber++; // increment recording number within this directory
+		}
 
-        if (!rootFolder.exists())
-        {
-            rootFolder.createDirectory();
-        }
-        if (settingsNeeded)
-        {
-            String settingsFileName = rootFolder.getFullPathName() + File::separator + "settings" + ((experimentNumber > 1) ? "_" + String(experimentNumber) : String::empty) + ".xml";
-            AccessClass::getEditorViewport()->saveState(File(settingsFileName), m_lastSettingsText);
-            settingsNeeded = false;
-        }
+		if (!rootFolder.exists())
+		{
+			rootFolder.createDirectory();
+		}
+		if (settingsNeeded)
+		{
+			String settingsFileName = rootFolder.getFullPathName() + File::separator + "settings" + ((experimentNumber > 1) ? "_" + String(experimentNumber) : String::empty) + ".xml";
+			AccessClass::getEditorViewport()->saveState(File(settingsFileName), m_lastSettingsText);
+			settingsNeeded = false;
+		}
 
 		m_recordThread->setFileComponents(rootFolder, experimentNumber, recordingNumber);
 
@@ -327,7 +329,7 @@ void RecordNode::setParameter(int parameterIndex, float newValue)
 					procIndex++;
 					chanProcOrder = 0;
 				}
-				procInfo.getLast()->recordedChannels.add(channelMap.size()-1);
+				procInfo.getLast()->recordedChannels.add(channelMap.size() - 1);
 				chanProcessorMap.add(procIndex);
 				chanOrderinProc.add(chanProcOrder);
 				chanProcOrder++;
@@ -353,18 +355,18 @@ void RecordNode::setParameter(int parameterIndex, float newValue)
 		isRecording = true;
 		hasRecorded = true;
 
-    }
-    else if (parameterIndex == 0)
-    {
+	}
+	else if (parameterIndex == 0)
+	{
 
 
-        std::cout << "STOP RECORDING." << std::endl;
+		std::cout << "STOP RECORDING." << std::endl;
 
-        if (isRecording)
-        {
+		if (isRecording)
+		{
 			isRecording = false;
 
-            // close the writing thread.
+			// close the writing thread.
 			m_recordThread->signalThreadShouldExit();
 			m_recordThread->waitForThreadToExit(2000);
 			while (m_recordThread->isThreadRunning())
@@ -384,35 +386,63 @@ void RecordNode::setParameter(int parameterIndex, float newValue)
 				}
 			}
 
-        }
-    }
-    else if (parameterIndex == 2)
-    {
+		}
+	}
+	else if (parameterIndex == 2)
+	{
 
-        if (isProcessing)
-        {
+		if (isProcessing)
+		{
 
-            std::cout << "Toggling channel " << currentChannel << std::endl;
+			std::cout << "Toggling channel " << currentChannel << std::endl;
 
-            if (isRecording)
-            {
-                //Toggling channels while recording isn't allowed. Code shouldn't reach here.
-                //In case it does, display an error and exit.
-                CoreServices::sendStatusMessage("Toggling record channels while recording is not allowed");
-                std::cout << "ERROR: Wrong code section reached\n Toggling record channels while recording is not allowed." << std::endl;
-                return;
-            }
+			if (isRecording)
+			{
+				//Toggling channels while recording isn't allowed. Code shouldn't reach here.
+				//In case it does, display an error and exit.
+				CoreServices::sendStatusMessage("Toggling record channels while recording is not allowed");
+				std::cout << "ERROR: Wrong code section reached\n Toggling record channels while recording is not allowed." << std::endl;
+				return;
+			}
 
-            if (newValue == 0.0f)
-            {
-                dataChannelArray[currentChannel]->setRecordState(false);
-            }
-            else
-            {
-                dataChannelArray[currentChannel]->setRecordState(true);
-            }
-        }
-    }
+			if (newValue == 0.0f)
+			{
+				dataChannelArray[currentChannel]->setRecordState(false);
+			}
+			else
+			{
+				dataChannelArray[currentChannel]->setRecordState(true);
+			}
+		}
+	}
+	else if (parameterIndex == 3)
+	{
+
+		if (isRecording)
+		{
+			//Toggling thread status while recording isn't allowed.
+			//In case it does, display an error and exit.
+			CoreServices::sendStatusMessage("Changing record thread status while recording is not allowed");
+			return;
+		}
+
+		if (newValue == 0.0f)
+		{
+			CoreServices::sendStatusMessage("Turning record thread off.");
+			shouldRecord = false;
+			
+		}
+		else
+		{
+			CoreServices::sendStatusMessage("Turning record thread on.");
+			shouldRecord = true;
+		}
+	}
+}
+
+bool RecordNode::getRecordThreadStatus()
+{
+	return shouldRecord;
 }
 
 bool RecordNode::enable()
@@ -479,7 +509,7 @@ void RecordNode::process(AudioSampleBuffer& buffer)
 	// FIRST: cycle through events -- extract the TTLs and the timestamps
     checkForEvents();
 
-    if (isRecording)
+    if (isRecording && shouldRecord)
     {
         // SECOND: write channel data
 		int recordChans = channelMap.size();

--- a/Source/Processors/RecordNode/RecordNode.h
+++ b/Source/Processors/RecordNode/RecordNode.h
@@ -153,6 +153,7 @@ public:
     bool newDirectoryNeeded;
 
     std::atomic<bool> isRecording;
+	std::atomic<bool> shouldRecord;
 
     /** Generate a Matlab-compatible datestring */
     String generateDateString() const;
@@ -163,6 +164,8 @@ public:
 	//Called by ProcessorGraph
 	void updateRecordChannelIndexes();
 	void addSpecialProcessorChannels(Array<EventChannel*>& channels);
+
+	bool getRecordThreadStatus();
 
 private:
 

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1353,6 +1353,10 @@ const String EditorViewport::saveState(File fileToUse, String* xmlText)
     audioSettings->setAttribute("bufferSize", AccessClass::getAudioComponent()->getBufferSize());
     xml->addChildElement(audioSettings);
 
+	XmlElement* recordSettings = new XmlElement("RECORDING");
+	recordSettings->setAttribute("isRecordThreadEnabled", CoreServices::RecordNode::getRecordThreadStatus());
+	xml->addChildElement(recordSettings);
+
 	XmlElement* timestampSettings = new XmlElement("GLOBAL_TIMESTAMP");
 	int tsID, tsSubID;
 	AccessClass::getProcessorGraph()->getTimestampSources(tsID, tsSubID);
@@ -1615,7 +1619,12 @@ const String EditorViewport::loadState(File fileToLoad)
         {
             int bufferSize = element->getIntAttribute("bufferSize");
             AccessClass::getAudioComponent()->setBufferSize(bufferSize);
-        }
+		}
+		else if (element->hasTagName("RECORDING"))
+		{
+			bool recordThreadStatus = element->getBoolAttribute("isRecordThreadEnabled");
+			CoreServices::RecordNode::toggleRecordThread(recordThreadStatus);
+		}
 		else if (element->hasTagName("GLOBAL_TIMESTAMP"))
 		{
 			int tsID = element->getIntAttribute("selected_index", -1);
@@ -1633,9 +1642,9 @@ const String EditorViewport::loadState(File fileToLoad)
 
     AccessClass::getProcessorGraph()->restoreParameters();
 
-    AccessClass::getControlPanel()->loadStateFromXml(xml); // save the control panel settings
-    AccessClass::getProcessorList()->loadStateFromXml(xml);
-    AccessClass::getUIComponent()->loadStateFromXml(xml);  // save the UI settings
+    AccessClass::getControlPanel()->loadStateFromXml(xml); // load the control panel settings
+    AccessClass::getProcessorList()->loadStateFromXml(xml); // load the processor list settings
+    AccessClass::getUIComponent()->loadStateFromXml(xml);  // load the UI settings
 
     if (editorArray.size() > 0)
         signalChainManager->updateVisibleEditors(editorArray[0], 0, 0, UPDATE);

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1354,7 +1354,7 @@ const String EditorViewport::saveState(File fileToUse, String* xmlText)
     xml->addChildElement(audioSettings);
 
 	XmlElement* recordSettings = new XmlElement("RECORDING");
-	recordSettings->setAttribute("isRecordThreadEnabled", CoreServices::RecordNode::getRecordThreadStatus());
+	recordSettings->setAttribute("isRecordThreadEnabled", AccessClass::getProcessorGraph()->getRecordNode()->getRecordThreadStatus());
 	xml->addChildElement(recordSettings);
 
 	XmlElement* timestampSettings = new XmlElement("GLOBAL_TIMESTAMP");
@@ -1623,7 +1623,11 @@ const String EditorViewport::loadState(File fileToLoad)
 		else if (element->hasTagName("RECORDING"))
 		{
 			bool recordThreadStatus = element->getBoolAttribute("isRecordThreadEnabled");
-			CoreServices::RecordNode::toggleRecordThread(recordThreadStatus);
+
+			if (recordThreadStatus)
+				AccessClass::getProcessorGraph()->getRecordNode()->setParameter(3, 1.0f);
+			else
+				AccessClass::getProcessorGraph()->getRecordNode()->setParameter(3, 0.0f);
 		}
 		else if (element->hasTagName("GLOBAL_TIMESTAMP"))
 		{


### PR DESCRIPTION
Adds a toggle button to the recording options window, which can be unchecked to disable the RecordThread (i.e., the RecordNode won't write any data, but data can still be written through a plugin). This is currently necessary when recording >1 Neuropixels probe simultaneously, although hopefully it won't remain that way forever.

Some notes:
- The software opens a warning dialog before the thread can be disabled; user must click "yes" to continue
- The state of the RecordThread is saved via the EditorViewport

Closes #271 