### PR TITLE
Fix crash when clicking on LFP viewer canvas with no channels

### DIFF
--- a/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -3033,6 +3033,11 @@ bool LfpDisplay::getSingleChannelState()
 
 void LfpDisplay::mouseDown(const MouseEvent& event)
 {
+    if (drawableChannels.isEmpty())
+    {
+        return;
+    }
+
     //int y = event.getMouseDownY(); //relative to each channel pos
     MouseEvent canvasevent = event.getEventRelativeTo(viewport);
     int y = canvasevent.getMouseDownY() + viewport->getViewPositionY(); // need to account for scrolling


### PR DESCRIPTION
This fixes a crash due to an out-of-bounds array access when clicking on a (blank) LFP Viewer canvas with no input channels. Previously, the `LfpDisplay`'s `mouseDown` listener function would default to trying to select the 6th channel even though there are actually no channels to select. This function could probably be rewritten, which someone else is welcome to do before merging, but this is the minimal change to prevent this invalid behavior from happening.