### PR TITLE
Clean up and improve Network Events

### DIFF
--- a/Source/Plugins/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.cpp
@@ -35,67 +35,6 @@ const int MAX_MESSAGE_LENGTH = 64000;
     #include <unistd.h>
 #endif
 
-
-StringTS::StringTS()
-    : timestamp(0)
-{}
-
-
-StringTS::StringTS(String S, int64 ts_software)
-    : str(S)
-    , timestamp(ts_software)
-{}
-
-
-StringTS::StringTS(MidiMessage& event)
-    : timestamp(EventBase::getTimestamp(event))
-{
-    if (Event::getEventType(event) != EventChannel::EventChannelTypes::TEXT)
-    {
-        return; // only handles text events
-    }
-
-    const uint8* dataptr = event.getRawData();
-    // relying on null terminator to get end of string...
-    str = String::fromUTF8(reinterpret_cast<const char*>(dataptr + EVENT_BASE_SIZE));
-}
-
-
-std::vector<String> StringTS::splitString (char sep) const
-{
-    String curr;
-
-    std::list<String> ls;
-    for (int k = 0; k < str.length(); ++k)
-    {
-        if (str[k] != sep)
-        {
-            curr+=str[k];
-        }
-        else
-        {
-            ls.push_back (curr);
-            while (str[k] == sep && k < str.length())
-                ++k;
-
-            curr = "";
-            if (str[k] != sep && k < str.length())
-                curr += str[k];
-        }
-    }
-    if (str.length() > 0)
-    {
-        if (str[str.length() - 1] != sep)
-            ls.push_back (curr);
-    }
-
-    std::vector<String> Svec (ls.begin(), ls.end());
-    return Svec;
-}
-
-
-/*********************************************/
-
 NetworkEvents::NetworkEvents()
     : GenericProcessor  ("Network Events")
     , Thread            ("NetworkThread")
@@ -645,6 +584,66 @@ void NetworkEvents::updatePort(uint16 port)
     {
         ed->setPortString(String(port));
     }
+}
+
+
+/*** StringTS ***/
+
+NetworkEvents::StringTS::StringTS()
+    : timestamp(0)
+{}
+
+
+NetworkEvents::StringTS::StringTS(String S, int64 ts_software)
+    : str(S)
+    , timestamp(ts_software)
+{}
+
+
+NetworkEvents::StringTS::StringTS(MidiMessage& event)
+    : timestamp(EventBase::getTimestamp(event))
+{
+    if (Event::getEventType(event) != EventChannel::EventChannelTypes::TEXT)
+    {
+        return; // only handles text events
+    }
+
+    const uint8* dataptr = event.getRawData();
+    // relying on null terminator to get end of string...
+    str = String::fromUTF8(reinterpret_cast<const char*>(dataptr + EVENT_BASE_SIZE));
+}
+
+
+std::vector<String> NetworkEvents::StringTS::splitString(char sep) const
+{
+    String curr;
+
+    std::list<String> ls;
+    for (int k = 0; k < str.length(); ++k)
+    {
+        if (str[k] != sep)
+        {
+            curr += str[k];
+        }
+        else
+        {
+            ls.push_back(curr);
+            while (str[k] == sep && k < str.length())
+                ++k;
+
+            curr = "";
+            if (str[k] != sep && k < str.length())
+                curr += str[k];
+        }
+    }
+    if (str.length() > 0)
+    {
+        if (str[str.length() - 1] != sep)
+            ls.push_back(curr);
+    }
+
+    std::vector<String> Svec(ls.begin(), ls.end());
+    return Svec;
 }
 
 

--- a/Source/Plugins/NetworkEvents/NetworkEvents.h
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.h
@@ -37,21 +37,9 @@
 
 #include <ProcessorHeaders.h>
 
+#include <vector>
 #include <list>
 #include <queue>
-
-class StringTS
-{
-public:
-	StringTS();
-    StringTS(String S, int64 ts_software = CoreServices::getGlobalTimestamp());
-    StringTS(MidiMessage& event);
-
-	std::vector<String> splitString(char sep) const;
-
-	String str;
-	juce::int64 timestamp;
-};
 
 
 /**
@@ -108,6 +96,20 @@ public:
     uint16 urlport;
 
 private:
+    // combines a string and a timestamp
+    class StringTS
+    {
+    public:
+        StringTS();
+        StringTS(String S, int64 ts_software = CoreServices::getGlobalTimestamp());
+        StringTS(MidiMessage& event);
+
+        std::vector<String> splitString(char sep) const;
+
+        String str;
+        juce::int64 timestamp;
+    };
+
     void createZmqContext();
 
     void postTimestamppedStringToMidiBuffer(StringTS s);

--- a/Source/Plugins/NetworkEvents/NetworkEvents.h
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.h
@@ -37,7 +37,6 @@
 
 #include <ProcessorHeaders.h>
 
-#include <vector>
 #include <list>
 #include <queue>
 
@@ -60,8 +59,6 @@ public:
 
     void process (AudioSampleBuffer& buffer) override;
 
-    void setParameter (int parameterIndex, float newValue) override;
-
     void createEventChannels() override;
 
     void setEnabledState (bool newState) override;
@@ -76,18 +73,7 @@ public:
 
     // =========================================================================
 
-    int getDefaultNumOutputs() const;
-
-    //int64 getExtrapolatedHardwareTimestamp (int64 softwareTS) const;
-
-    std::vector<String> splitString (String S, char sep);
-
-    void initSimulation();
-    void simulateDesignAndTrials ();
-    void simulateSingleTrial();
-    void simulateStartRecord();
-    void simulateStopRecord();
-    void run();
+    void run() override;
 
     // passing 0 corresponds to wildcard ("*") and picks any available port
     // returns true on success, false on failure
@@ -99,20 +85,10 @@ public:
     void restartConnection();
 
 private:
-    // combines a string and a timestamp
-    class StringTS
+    struct StringTS
     {
-    public:
-        StringTS();
-        StringTS(String S, int64 ts_software = CoreServices::getGlobalTimestamp());
-        StringTS(MidiMessage& event);
-
-        std::vector<String> splitString(char sep) const;
-
         String str;
-        juce::int64 timestamp;
-
-        JUCE_LEAK_DETECTOR(StringTS);
+        int64 timestamp;
     };
 
     class ZMQContext : public ReferenceCountedObject
@@ -170,7 +146,7 @@ private:
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Responder);
     };
 
-    void postTimestamppedStringToMidiBuffer(StringTS s);
+    void postTimestamppedStringToMidiBuffer(const StringTS& s);
     
     String handleSpecialMessages(const String& s);
 
@@ -200,19 +176,9 @@ private:
 
     uint16 urlport;   // 0 indicates not connected
 
-    float threshold;
-    float bufferZone;
-
-    bool state;
-    bool firstTime;
-
     std::queue<StringTS> networkMessagesQueue;
-    std::queue<StringTS> simulation;
-
     CriticalSection queueLock;
     
-    int64 simulationStartTime;
-
 	const EventChannel* messageChannel{ nullptr };
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (NetworkEvents);

--- a/Source/Plugins/NetworkEvents/NetworkEvents.h
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.h
@@ -39,6 +39,7 @@
 
 #include <list>
 #include <queue>
+#include <memory>
 
 class StringTS
 {
@@ -123,13 +124,15 @@ public:
 private:
     void createZmqContext();
 
+    static void closeZmqSocket(void* socket);
+    typedef std::unique_ptr<void, decltype(&closeZmqSocket)> SocketPtr;
+
     //* Split network message into name/value pairs (name1=val1 name2=val2 etc) */
     StringPairArray parseNetworkMessage (String msg);
 
     StringTS createStringTS (String S, int64 t);
 
     static void* zmqcontext;
-    void* responder;
 
     float threshold;
     float bufferZone;

--- a/Source/Plugins/NetworkEvents/NetworkEvents.h
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.h
@@ -49,7 +49,6 @@
 */
 class NetworkEvents : public GenericProcessor
                     , public Thread
-                    , public Value::Listener
 {
 public:
     NetworkEvents();
@@ -98,9 +97,6 @@ public:
     String getPortString() const;
 
     void restartConnection();
-
-    // to update the port string from the thread
-    void valueChanged(Value& value) override;
 
 private:
     // combines a string and a timestamp
@@ -181,8 +177,7 @@ private:
     //* Split network message into name/value pairs (name1=val1 name2=val2 etc) */
     StringPairArray parseNetworkMessage(StringRef msg);
 
-    // updates urlport and the portString Value (controlling the port input on the editor)
-    // 0 indicates disconnected. should only be called from the thread!
+    // updates urlport and the port input on the editor (0 indicates not connected)
     void updatePort(uint16 port);
 
     // get an endpoint url for the given port (using 0 to represent *)
@@ -204,8 +199,6 @@ private:
     bool changeResponder;
 
     uint16 urlport;   // 0 indicates not connected
-    // thread can modify this to update editor's port text without acquiring MessageManagerLock
-    Value portString;
 
     float threshold;
     float bufferZone;

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
@@ -124,10 +124,16 @@ void NetworkEventsEditor::labelTextChanged(juce::Label *label)
 {
 	if (label == labelPort)
 	{
-	   Value val = label->getTextValue();
+	    int32 portInput = label->getText().getIntValue();
+        if (portInput < 0 || portInput > (1 << 16) - 1)
+        {
+            CoreServices::sendStatusMessage("Warning: port out of range; selecting one automatically");
+            portInput = 0;
+        }
+        auto port = static_cast<uint16>(portInput);
 
 		NetworkEvents *p= (NetworkEvents *)getProcessor();
-		p->setNewListeningPort(val.getValue());
+		p->setNewListeningPort(port);
 	}
 }
 

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
@@ -42,35 +42,11 @@ NetworkEventsEditor::NetworkEventsEditor(GenericProcessor* parentNode, bool useD
     restartConnection->addListener(this);
     addAndMakeVisible(restartConnection);
 
-	
-	/*
-	trialSimulation = new UtilityButton("Trial",Font("Default", 15, Font::plain));
-    trialSimulation->setBounds(20,25,80,18);
-    trialSimulation->addListener(this);
-    addAndMakeVisible(trialSimulation);
-
-	
-	startRecord = new UtilityButton("Start Record",Font("Default", 15, Font::plain));
-    startRecord->setBounds(20,55,100,18);
-    startRecord->addListener(this);
-    addAndMakeVisible(startRecord);
-	*/
-
 	labelPort = new Label("Port", p->getPortString());
     labelPort->setBounds(70,85,80,18);
     labelPort->setFont(Font("Default", 15, Font::plain));
     labelPort->setColour(Label::textColourId, Colours::white);
-
-
-
-//		NetworkEvents *processor  = (NetworkEvents*) getProcessor();
-
-	//if (processor->threadRunning)
-		labelPort->setColour(Label::backgroundColourId, Colours::grey);
-//	else
-//		labelPort->setColour(Label::backgroundColourId, Colours::red);
-
-
+    labelPort->setColour(Label::backgroundColourId, Colours::grey);
     labelPort->setEditable(true);
     labelPort->addListener(this);
     addAndMakeVisible(labelPort);
@@ -82,31 +58,11 @@ NetworkEventsEditor::NetworkEventsEditor(GenericProcessor* parentNode, bool useD
 
 void NetworkEventsEditor::buttonEvent(Button* button)
 {
-			//NetworkEvents *processor  = (NetworkEvents*) getProcessor();
 	if (button == restartConnection)
 	{
 		NetworkEvents *p= (NetworkEvents *)getProcessor();
 		p->restartConnection();
 	}
-			/*
-	if (button == trialSimulation)
-	{
-		processor->simulateSingleTrial();
-
-	} else if (button == startRecord)
-	{
-		if (startRecord->getLabel() == "Start Record") 
-		{
-			processor->simulateStartRecord();
-			startRecord->setLabel("Stop Record");
-		} else if (startRecord->getLabel() == "Stop Record") 
-		{
-			processor->simulateStopRecord();
-			startRecord->setLabel("Start Record");
-		}
-	}
-    */
-
 }
 
 void NetworkEventsEditor::setLabelColor(juce::Colour color)

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
@@ -115,6 +115,10 @@ void NetworkEventsEditor::setLabelColor(juce::Colour color)
 	labelPort->setColour(Label::backgroundColourId, color);
 }
 
+void NetworkEventsEditor::setPortString(const String& port)
+{
+    labelPort->setText(port, sendNotification);
+}
 
 void NetworkEventsEditor::labelTextChanged(juce::Label *label)
 {

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
@@ -42,7 +42,7 @@ NetworkEventsEditor::NetworkEventsEditor(GenericProcessor* parentNode, bool useD
     restartConnection->addListener(this);
     addAndMakeVisible(restartConnection);
 
-	labelPort = new Label("Port", p->getPortString());
+	labelPort = new Label("Port", p->getCurrPortString());
     labelPort->setBounds(70,85,80,18);
     labelPort->setFont(Font("Default", 15, Font::plain));
     labelPort->setColour(Label::textColourId, Colours::white);
@@ -82,21 +82,16 @@ void NetworkEventsEditor::labelTextChanged(juce::Label *label)
     if (label == labelPort)
     {
         NetworkEvents *p = (NetworkEvents *)getProcessor();
-        bool success = true;
         
         uint16 port;
         if (!portFromString(label->getText(), &port))
         {
             CoreServices::sendStatusMessage("NetworkEvents: Invalid port");
-            success = false;
+            setPortText(p->getCurrPortString());
+            return;
         }
 
-        success = success && p->setNewListeningPort(port);
-        if (!success)
-        {
-            // revert to reflect current port
-            setPortText(p->getPortString());
-        }
+        p->setNewListeningPort(port);
 	}
 }
 

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.cpp
@@ -117,7 +117,7 @@ void NetworkEventsEditor::setLabelColor(juce::Colour color)
 
 void NetworkEventsEditor::setPortString(const String& port)
 {
-    labelPort->setText(port, sendNotification);
+    labelPort->setText(port, dontSendNotification);
 }
 
 void NetworkEventsEditor::labelTextChanged(juce::Label *label)

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.h
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.h
@@ -47,6 +47,7 @@ public:
     void buttonEvent(Button* button);
 	void labelTextChanged(juce::Label *);
 	void setLabelColor(juce::Colour color);
+    void setPortString(const String& port);
 private:
 
 	ScopedPointer<UtilityButton> restartConnection;

--- a/Source/Plugins/NetworkEvents/NetworkEventsEditor.h
+++ b/Source/Plugins/NetworkEvents/NetworkEventsEditor.h
@@ -47,13 +47,17 @@ public:
     void buttonEvent(Button* button);
 	void labelTextChanged(juce::Label *);
 	void setLabelColor(juce::Colour color);
-    void setPortString(const String& port);
+    void setPortText(const String& text);
 private:
+
+    // interprets input string as a port number (1-65535); returns false if invalid
+    // or out of range, else sets *port to parsed value. as a special case, if portString
+    // is "*", sets *port to 0 and returns true.
+    static bool portFromString(const String& portString, uint16* port);
 
 	ScopedPointer<UtilityButton> restartConnection;
     ScopedPointer<Label> urlLabel;
 	ScopedPointer<Label> labelPort;
-
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(NetworkEventsEditor);
 


### PR DESCRIPTION
I started out just wanting to fix the port on the editor not updating when loading a signal chain. I found some more issues with the plugin though, so I decided to try fixing them. Sorry for the huge diffs... However, I think you'll find it resolves most of the instability issues that Network Events has suffered from. Also fixes #174.

Overview of changes:

* Uses RAII wrappers for the context and socket to avoid leaking memory. In particular, similar to the latest Event Broadcaster, the context is shared between instances via a raw pointer but "owned" jointly by all sockets using reference-counted pointers, so that it is destroyed after all instances of the plugin are destroyed. This avoids a crash with ZeroMQ on Windows that happens when a context is destroyed during unloading of a DLL.

* Avoids destroying the sockets in the main thread (or interacting with them at all except for creating them and passing them to the thread using a lock). ZMQ sockets are not thread-safe, and the call to `zmq_close` on restart, port change, and shutdown was causing some crashes - possibly the cause of #174.

* Doesn't block forever on `zmq_recv`; instead has a timeout of 100 ms. This means possibly some added latency while the thread checks whether it should exit, change port or restart between calls, but these checks should be extremely fast, and the upside is that we don't need to destroy the context each time we need to take one of these actions. The context  should typically persist for the lifetime of the program, and creating a new one has a high overhead. As a consequence:

    * When you have two instances of the plugin and then one is deleted, no longer gets into the unfortunate state where the context has been destroyed and there's no way to make a new one for the remaining instance to use. 

* Updates the port label to always show:
   * The actual bound port if connected
   * The string `<no cxn>` if not connected
   * The string `<no zeromq>` if it was not compiled with ZeroMQ

* Allows inputting a "*" as the port to use any available port. The label then updates to show what port was actually selected. 

* If a port change fails and a socket was connected on the previous port, keeps using that port and socket.

* Sends the status message when receiving an event from the thread rather than the process function, so that it shows up even if acquisition isn't running.

* Simplifies `StringTS` significantly - it doesn't really need to be more complicated than a `String` coupled with a timestamp. In fact, we could use `std::pair` instead, but having names for the members is nice.

* Deletes the code related to simulations, since it seemed to be unused. This is all in the last commit since I wasn't sure if it might still be used at some point (maybe for debugging?), so that can be reverted if necessary.

I realize this might take a while to look through, but I hope you get around to it at some point.