### PR TITLE
Use SharedResourcePointers for ZeroMQ contexts

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -44,11 +44,11 @@ public:
 
 
 private:
-    class ZMQContext : public ReferenceCountedObject
+    class ZMQContext
     {
     public:
-        ZMQContext(const ScopedLock& lock);
-        ~ZMQContext() override;
+        ZMQContext();
+        ~ZMQContext();
         void* createZMQSocket();
     private:
         void* context;
@@ -62,7 +62,7 @@ private:
         ZMQSocketPtr();
         ~ZMQSocketPtr();
     private:
-        ReferenceCountedObjectPtr<ZMQContext> context;
+        SharedResourcePointer<ZMQContext> context;
     };
     
     int unbindZMQSocket();
@@ -73,11 +73,6 @@ private:
     // called from getListeningPort() depending on success/failure of ZMQ operations
     void reportActualListeningPort(int port);
 
-    // share a "dumb" pointer that doesn't take part in reference counting.
-    // want the context to be terminated by the time the static members are
-    // destroyed (see: https://github.com/zeromq/libzmq/issues/1708)
-    static ZMQContext* sharedContext;
-    static CriticalSection sharedContextLock;
     ZMQSocketPtr zmqSocket;
     int listeningPort;
 };

--- a/Source/Plugins/NetworkEvents/NetworkEvents.cpp
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.cpp
@@ -35,9 +35,6 @@ const int MAX_MESSAGE_LENGTH = 64000;
     #include <unistd.h>
 #endif
 
-NetworkEvents::ZMQContext* NetworkEvents::sharedContext = nullptr;
-CriticalSection NetworkEvents::sharedContextLock{};
-
 NetworkEvents::NetworkEvents()
     : GenericProcessor  ("Network Events")
     , Thread            ("NetworkThread")
@@ -79,6 +76,7 @@ String NetworkEvents::getCurrPortString() const
 
 void NetworkEvents::restartConnection()
 {
+    requestedPort = boundPort.load();
     makeNewSocket = true;
 }
 
@@ -430,21 +428,15 @@ String NetworkEvents::getPortString(uint16 port)
 
 /*** ZMQContext ***/
 
-NetworkEvents::ZMQContext::ZMQContext(const ScopedLock& lock)
+NetworkEvents::ZMQContext::ZMQContext()
 #ifdef ZEROMQ
     : context(zmq_ctx_new())
 #endif
-{
-    // sharedContextLock should already be held here
-    sharedContext = this;
-}
+{}
 
-// ZMQContext is a ReferenceCountedObject with a pointer in each instance's 
-// socket pointer, so this only happens when the last instance is destroyed.
+// only happens when the last SharedResourcePointer is destroyed.
 NetworkEvents::ZMQContext::~ZMQContext()
 {
-    ScopedLock lock(sharedContextLock);
-    sharedContext = nullptr;
 #ifdef ZEROMQ
     zmq_ctx_destroy(context);
 #endif
@@ -471,20 +463,6 @@ NetworkEvents::Responder::Responder(uint16 port)
     , boundPort (0)
     , lastErrno (0)
 {
-    {
-        ScopedLock lock(sharedContextLock);
-        if (sharedContext == nullptr)
-        {
-            // first one, create the context
-            context = new ZMQContext(lock);
-        }
-        else
-        {
-            // use already-created context
-            context = sharedContext;
-        }
-    }
-
 #ifdef ZEROMQ
     socket = context->createSocket();
     if (!socket)

--- a/Source/Plugins/NetworkEvents/NetworkEvents.h
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.h
@@ -90,15 +90,12 @@ private:
         int64 timestamp;
     };
 
-    class ZMQContext : public ReferenceCountedObject
+    class ZMQContext
     {
     public:
-        ZMQContext(const ScopedLock& lock);
-        ~ZMQContext() override;
+        ZMQContext();
+        ~ZMQContext();
         void* createSocket();
-
-        typedef ReferenceCountedObjectPtr<ZMQContext> Ptr;
-
     private:
         void* context;
 
@@ -134,7 +131,7 @@ private:
         int send(StringRef response);
 
     private:
-        ZMQContext::Ptr context;
+        SharedResourcePointer<ZMQContext> context;
         void* socket;
         bool valid;
         uint16 boundPort;
@@ -160,12 +157,6 @@ private:
 
     // get a representation of the given port for use on the editor
     static String getPortString(uint16 port);
-
-    // share a "dumb" pointer that doesn't take part in reference counting.
-    // want the context to be terminated by the time the static members are
-    // destroyed (see: https://github.com/zeromq/libzmq/issues/1708)
-    static ZMQContext* sharedContext;
-    static CriticalSection sharedContextLock;
 
     std::atomic<bool> makeNewSocket;   // port change or restart needed (depending on requestedPort)
     std::atomic<uint16> requestedPort; // never set by the thread; 0 means any free port


### PR DESCRIPTION
I was just browsing the JUCE library and I realized that this `SharedResourcePointer` class does exactly what we want for the ZeroMQ context, i.e. share a single instance among all owners automatically and also destroy it automatically when all the pointers are gone. So using this, we don't have to awkwardly set/read the static bare pointer to keep all instances using the same context. Looks nicer and the intent is clearer.

* As an aside, since these two plugins have a lot of duplicated functionality in their context and socket classes, maybe those should be pulled into a common library at some point.

* Also fixes a minor issue with the network events restart connection button not always trying to reconnect to the currently bound port.

* And yes I now have no life. Happy holidays everyone!