### PR TITLE
Allow loading signal chain from command line

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -61,12 +61,15 @@ public:
 
         StringArray parameters;
         parameters.addTokens(commandLine," ","\"");
+        parameters.removeEmptyStrings();
 
 #ifdef WIN32
         //glWinInit();
 
-        if (parameters.contains("--console",true))
+        int consoleArg = parameters.indexOf("--console", true);
+        if (consoleArg != -1)
         {
+            parameters.remove(consoleArg);
             if (AllocConsole())
             {
                 freopen("CONOUT$","w",stdout);
@@ -81,14 +84,20 @@ public:
 
 #endif
 
-
         customLookAndFeel = new CustomLookAndFeel();
         LookAndFeel::setDefaultLookAndFeel(customLookAndFeel);
 
-        mainWindow = new MainWindow();
 
-
-
+        // signal chain to load
+        if (!parameters.isEmpty())
+        {
+            File fileToLoad(File::getCurrentWorkingDirectory().getChildFile(parameters[0]));
+            mainWindow = new MainWindow(fileToLoad);
+        }
+        else
+        {
+            mainWindow = new MainWindow();
+        }
     }
 
     void shutdown() { }

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -39,7 +39,7 @@ static inline File getSavedStateDirectory() {
 #endif
 }
 
-	MainWindow::MainWindow()
+	MainWindow::MainWindow(const File& fileToLoad)
 : DocumentWindow(JUCEApplication::getInstance()->getApplicationName(),
 		Colour(Colours::black),
 		DocumentWindow::allButtons)
@@ -83,7 +83,11 @@ static inline File getSavedStateDirectory() {
 	// Constraining the window's size doesn't seem to work:
 	setResizeLimits(500, 500, 10000, 10000);
 
-	if (shouldReloadOnStartup)
+    if (!fileToLoad.getFullPathName().isEmpty())
+    {
+        ui->getEditorViewport()->loadState(fileToLoad);
+    }
+	else if (shouldReloadOnStartup)
 	{
 		File file = getSavedStateDirectory().getChildFile("lastConfig.xml");
 		ui->getEditorViewport()->loadState(file);

--- a/Source/MainWindow.h
+++ b/Source/MainWindow.h
@@ -46,7 +46,7 @@ public:
 
     /** Initializes the MainWindow, creates the AudioComponent, ProcessorGraph,
         and UIComponent, and sets the window boundaries. */
-    MainWindow();
+    MainWindow(const File& fileToLoad = File());
 
     /** Destroys the AudioComponent, ProcessorGraph, and UIComponent, and saves the window boundaries. */
     ~MainWindow();


### PR DESCRIPTION
This lets you specify an absolute or relative path for a signal chain to load as a command line argument. It will override the `lastConfig.xml` file, if any, and try to load this signal chain instead. Could be useful for operating Open Ephys automatically as part of other experimental frameworks, especially in conjunction with Network Events.