### PR TITLE
Fix saving chains starting with splitter and simplify

### DIFF
--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -156,7 +156,7 @@ public:
     const String loadState(File filename);
 
     /** Converts information about a given editor to XML. */
-    XmlElement* createNodeXml(GenericEditor*, int);
+    XmlElement* createNodeXml(GenericProcessor*);
 
     /** Converts information about a splitter or merge to XML. */
     XmlElement* switchNodeXml(GenericProcessor*);


### PR DESCRIPTION
Currently, saving a signal chain that starts with a splitter only saves the first branch. The first processor in a chain isn't handled specially if it is a splitter, as splitters encountered later in the chain are. Even though chains that don't start with a source can't be played, I still think it's important to save and load any signal chain correctly to minimize frustration.

I also took the opportunity to make a couple simplifications to make the saving code easier to understand. For instance, mergers are never saved in `splitPoints` anymore, so all the special logic for when a processor in `splitPoints` is a merger was unreachable code and could be deleted.

And I know the signal chain is being revamped, so this would be a temporary fix.