### PR TITLE
Event Broadcaster socket reorganization

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -59,19 +59,20 @@ private:
         ~ZMQSocket();
 
         bool isValid() const;
+        int getBoundPort() const;
 
         int send(const void* buf, size_t len, int flags);
         int bind(int port);
-        int unbind(int port);
+        int unbind();
     private:
+        int boundPort;
         void* socket;
         ReferenceCountedObjectPtr<ZMQContext> context;
     };
 
 	void sendEvent(const MidiMessage& event, float eventSampleRate) const;
+
     static String getEndpoint(int port);
-    // called from getListeningPort() depending on success/failure of ZMQ operations
-    void reportActualListeningPort(int port);
 
     // share a "dumb" pointer that doesn't take part in reference counting.
     // want the context to be terminated by the time the static members are
@@ -80,7 +81,6 @@ private:
     static CriticalSection sharedContextLock;
     
     ScopedPointer<ZMQSocket> zmqSocket;
-    int listeningPort;
 };
 
 


### PR DESCRIPTION
This changes the socket in Event Broadcaster from being a derived class of `std::unique_ptr` (something I did before that was weird) to a plain object that does cleanup in its destructor and is held in a `ScopedPointer`. This is more like Network Events and generally more in line with the style of the rest of the codebase. Also changes most actions involving the socket to be methods of the socket object, which I think is cleaner and is also similar to Network Events.

(Sorry to keep revisiting the ZeroMQ plugins...at this point I'm just trying to organize some changes I made a while ago into reasonable-sized PRs.)