### PR TITLE
Fix ports sometimes not being unbound in time when loading a signal chain

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -31,7 +31,7 @@ public:
 
     int getListeningPort() const;
     // returns 0 on success, else the errno value for the error that occurred.
-    int setListeningPort(int port, bool forceRestart = false);
+    int setListeningPort(int port, bool forceRestart = false, bool searchForPort = false, bool synchronous = true);
 
     void process (AudioSampleBuffer& continuousBuffer) override;
     void handleEvent (const EventChannel* channelInfo, const MidiMessage& event, int samplePosition = 0) override;
@@ -81,6 +81,14 @@ private:
     static CriticalSection sharedContextLock;
     
     ScopedPointer<ZMQSocket> zmqSocket;
+
+    struct 
+    {
+        int port;
+        bool forceRestart;
+        bool searchForPort;
+        Atomic<int> called{ 0 };
+    } asyncOptions;
 };
 
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.h
@@ -23,6 +23,7 @@
 #endif
 
 class EventBroadcaster : public GenericProcessor
+                       , private AsyncUpdater
 {
 public:
     EventBroadcaster();
@@ -73,19 +74,18 @@ private:
         SharedResourcePointer<ZMQContext> context;
     };
 
+    void handleAsyncUpdate() override; // to change port asynchronously
+
 	void sendEvent(const MidiMessage& event, float eventSampleRate) const;
 
     static String getEndpoint(int port);
     
     ScopedPointer<ZMQSocket> zmqSocket;
 
-    struct 
-    {
-        int port;
-        bool forceRestart;
-        bool searchForPort;
-        Atomic<int> called{ 0 };
-    } asyncOptions;
+    // for setting port asynchronously
+    int asyncPort;
+    bool asyncForceRestart;
+    bool asyncSearchForPort;
 };
 
 

--- a/Source/Plugins/NetworkEvents/NetworkEvents.h
+++ b/Source/Plugins/NetworkEvents/NetworkEvents.h
@@ -48,6 +48,7 @@
 */
 class NetworkEvents : public GenericProcessor
                     , public Thread
+                    , private AsyncUpdater
 {
 public:
     NetworkEvents();
@@ -76,7 +77,7 @@ public:
     void run() override;
 
     // passing 0 corresponds to wildcard ("*") and picks any available port
-    void setNewListeningPort (uint16 port);
+    void setNewListeningPort (uint16 port, bool synchronous = true);
 
     // gets a string for the editor's port input to reflect current urlport
     String getCurrPortString() const;
@@ -144,6 +145,8 @@ private:
         
         JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Responder);
     };
+
+    void handleAsyncUpdate() override; // to change port asynchronously
 
     void postTimestamppedStringToMidiBuffer(const StringTS& s);
     


### PR DESCRIPTION
This fixes the following bug: 
* You have a signal chain open with one or more Network Events or Event Broadcasters
* You try to load a new signal chain that has one or more Network Events* or Event Broadcasters bound to the same ports as plugins in the previous chain
* Those plugins in the new chain are unable to bind to the correct ports, even though they don't conflict with other plugins in the new chain.

\* I thought I had observed this happening with Network Events previously, but currently it seems to only affect Event Broadcasters.

This means loading a signal chain is sometimes not an idempotent operation (doing it multiple times does not produce the same result every time), which could be confusing.

The reason this happens is obscure. The ports that were bound in the old chain should be available again as soon as the old sockets are unbound, which happens as each processor is destroyed. Each processor is removed from the `ProcessorGraph` strictly before the new ones are created when loading a new signal chain. However, the `removeNode` function in `AudioProcessorGraph` does not necessarily destroy  the processor immediately; it asynchronously calls the function `buildRenderingSequence`, and only once this function returns are all the references to the reference-counted `Node` object that owns the processor instance deleted.

Basically this means that processors are destroyed asynchronously when clearing the chain. (Incidentally, I think this may also explain why loading a signal chain with Rhythm FPGA fails to find the board if there was an instance of the FPGA plugin in the old signal chain.) The solution is to only bind the ports of newly created instances asynchronously. These binding operations should then fall later in the message queue than destroying/unbinding the old instances. I've added `AsyncUpdater` functionality to Network Events and Event Broadcaster so that port changes happen asynchronously during initialization and when loading a signal chain.