### PR TITLE
Add Event Broadcaster JSON option

### DIFF
--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -167,7 +167,7 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
         if (!newSocket->isValid())
         {
             status = zmq_errno();
-            std::cout << "Failed to open socket: " << zmq_strerror(status) << std::endl;
+            std::cout << "Failed to create socket: " << zmq_strerror(status) << std::endl;
         }
         else
         {
@@ -193,14 +193,13 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
         }
 #endif
     }
-    
+
     // update editor
     auto editor = static_cast<EventBroadcasterEditor*>(getEditor());
     if (editor != nullptr)
-    {   
+    {
         editor->setDisplayedPort(getListeningPort());
     }
-    std::cout << "Binded port :\t" << listeningPort << std::endl;
     return status;
 }
 

--- a/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcaster.cpp
@@ -19,7 +19,7 @@ EventBroadcaster::ZMQContext::ZMQContext()
 #endif
 {}
 
-// ZMQContext is a ReferenceCountedObject with a pointer in each instance's 
+// ZMQContext is a ReferenceCountedObject with a pointer in each instance's
 // socket pointer, so this only happens when the last instance is destroyed.
 EventBroadcaster::ZMQContext::~ZMQContext()
 {
@@ -118,6 +118,8 @@ String EventBroadcaster::getEndpoint(int port)
 
 EventBroadcaster::EventBroadcaster()
     : GenericProcessor  ("Event Broadcaster")
+    , listeningPort     (0)
+    , outputFormat      (RAW_BINARY)
 {
     setProcessorType (PROCESSOR_TYPE_SINK);
 
@@ -150,8 +152,8 @@ int EventBroadcaster::getListeningPort() const
 int EventBroadcaster::setListeningPort(int port, bool forceRestart)
 {
     int status = 0;
-    int currPort = getListeningPort();
-    if ((currPort != port) || forceRestart)
+    //int currPort = getListeningPort();
+    if ((listeningPort != port) || forceRestart)
     {
 #ifdef ZEROMQ
         // unbind current socket (if any) to free up port
@@ -165,7 +167,7 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
         if (!newSocket->isValid())
         {
             status = zmq_errno();
-            std::cout << "Failed to create socket: " << zmq_strerror(status) << std::endl;
+            std::cout << "Failed to open socket: " << zmq_strerror(status) << std::endl;
         }
         else
         {
@@ -179,68 +181,293 @@ int EventBroadcaster::setListeningPort(int port, bool forceRestart)
             {
                 // success
                 zmqSocket = newSocket;
+                listeningPort = getListeningPort();
             }
         }
+
 
         if (status != 0 && zmqSocket != nullptr)
         {
             // try to rebind current socket to previous port
-            zmqSocket->bind(currPort);
+            zmqSocket->bind(listeningPort);
         }
-
 #endif
     }
-
+    
     // update editor
     auto editor = static_cast<EventBroadcasterEditor*>(getEditor());
     if (editor != nullptr)
-    {
+    {   
         editor->setDisplayedPort(getListeningPort());
     }
+    std::cout << "Binded port :\t" << listeningPort << std::endl;
     return status;
 }
 
+int EventBroadcaster::getOutputFormat() const
+{
+    return outputFormat;
+}
+
+
+void EventBroadcaster::setOutputFormat(int format)
+{
+    outputFormat = format;
+}
 
 void EventBroadcaster::process(AudioSampleBuffer& continuousBuffer)
 {
     checkForEvents(true);
 }
 
-
-//IMPORTANT: The structure of the event buffers has changed drastically, so we need to find a better way of doing this
-void EventBroadcaster::sendEvent(const MidiMessage& event, float eventSampleRate) const
+void EventBroadcaster::sendEvent(const InfoObjectCommon* channel, const MidiMessage& msg) const
 {
 #ifdef ZEROMQ
-	double timestampSeconds = double(Event::getTimestamp(event)) / eventSampleRate;
-	uint16 type = Event::getBaseType(event);
+    // TODO Create a procotol that has outline for every type of event
+    int currFormat = outputFormat;
+    Array<MsgPart> message;
 
-    if (zmqSocket == nullptr)
+    // common info that isn't type-specific
+    EventType baseType = Event::getBaseType(msg);
+    const String& identifier = channel->getIdentifier();
+    float sampleRate = channel->getSampleRate();
+    int64 timestamp = Event::getTimestamp(msg);
+
+    if (currFormat == RAW_BINARY)
     {
-        std::cout << "Failed to send message: no socket" << std::endl;
+        uint16 baseType16 = static_cast<uint16>(baseType); // for backward compatability
+        double timestampSeconds = double(timestamp) / sampleRate;
+        const void* rawData = msg.getRawData();
+        size_t rawDataSize = msg.getRawDataSize();
+
+        message.add({ "base type", { &baseType16, sizeof(baseType16) } });
+        message.add({ "timestamp", { &timestampSeconds, sizeof(timestampSeconds) } });
+        message.add({ "raw data", { rawData, rawDataSize } });
     }
-	else if (-1 == zmqSocket->send(&type, sizeof(type), ZMQ_SNDMORE) ||
-		     -1 == zmqSocket->send(&timestampSeconds, sizeof(timestampSeconds), ZMQ_SNDMORE) ||
-		     -1 == zmqSocket->send(event.getRawData(), event.getRawDataSize(), 0))
-	{
-		std::cout << "Failed to send message: " << zmq_strerror(zmq_errno()) << std::endl;
-	}
+    else // deserialize the data, get metadata, etc.
+    {
+        // info to be assigned depending on the event type
+        String header;
+        DynamicObject::Ptr jsonObj = new DynamicObject();
+        EventBasePtr baseEvent;
+        const MetaDataEventObject* metaDataChannel;
+
+        // deserialize event and get type-specific information
+        switch (baseType)
+        {
+        case SPIKE_EVENT:
+        {
+            auto spikeChannel = static_cast<const SpikeChannel*>(channel);
+            metaDataChannel = static_cast<const MetaDataEventObject*>(spikeChannel);
+
+            baseEvent = SpikeEvent::deserializeFromMessage(msg, spikeChannel).release();
+            auto spike = static_cast<SpikeEvent*>(baseEvent.get());
+
+            // create header
+            uint16 sortedID = spike->getSortedID();
+            header = "spike/sortedid:" + String(sortedID) + "/id:" + identifier + "/ts:" + String(timestamp);
+
+            if (currFormat == HEADER_AND_JSON)
+            {
+                // add info to JSON
+                jsonObj->setProperty("type", "spike");
+                jsonObj->setProperty("sortedID", sortedID);
+
+                int spikeChannels = spikeChannel->getNumChannels();
+                jsonObj->setProperty("numChannels", spikeChannels);
+
+                Array<var> thresholds;
+                for (int i = 0; i < spikeChannels; ++i)
+                {
+                    thresholds.add(spike->getThreshold(i));
+                }
+                jsonObj->setProperty("threshold", thresholds);
+            }
+
+            break;  // case SPIKE_EVENT
+        }
+
+        case PROCESSOR_EVENT:
+        {
+            auto eventChannel = static_cast<const EventChannel*>(channel);
+            metaDataChannel = static_cast<const MetaDataEventObject*>(eventChannel);
+
+            baseEvent = Event::deserializeFromMessage(msg, eventChannel).release();
+            auto event = static_cast<Event*>(baseEvent.get());
+
+            uint16 channel = event->getChannel();
+
+            // for json
+            var type;
+            var data;
+
+            auto eventType = event->getEventType();
+            switch (eventType)
+            {
+            case EventChannel::EventChannelTypes::TTL:
+            {
+                bool state = static_cast<TTLEvent*>(event)->getState();
+
+                header = "ttl/channel:" + String(channel) + "/state:" + (state ? "1" : "0") +
+                    "/id:" + identifier + "/ts:" + String(timestamp);
+
+                type = "ttl";
+                data = state;
+                break;
+            }
+
+            case EventChannel::EventChannelTypes::TEXT:
+            {
+                const String& text = static_cast<TextEvent*>(event)->getText();
+
+                header = "text/channel:" + String(channel) + "/id:" + identifier +
+                    "/text:" + text + "/ts:" + String(timestamp);
+
+                type = "text";
+                data = text;
+                break;
+            }
+
+            default:
+            {
+                if (eventType < EventChannel::EventChannelTypes::BINARY_BASE_VALUE ||
+                    eventType >= EventChannel::EventChannelTypes::INVALID)
+                {
+                    jassertfalse;
+                    return;
+                }
+
+                // must have binary event
+
+                BaseType dataType = eventChannel->getEquivalentMetaDataType();
+                auto dataReader = getDataReader(dataType);
+                const void* rawData = static_cast<BinaryEvent*>(event)->getBinaryDataPointer();
+                unsigned int length = eventChannel->getLength();
+
+                type = "binary";
+                data = dataReader(rawData, length);
+
+                String dataString;
+                if (data.isArray()) // make comma-separated list of values
+                {
+                    int length = data.size();
+                    for (int i = 0; i < length; ++i)
+                    {
+                        if (i > 0) { dataString += ","; }
+                        dataString += data[i].toString();
+                    }
+                }
+                else
+                {
+                    dataString = data.toString();
+                }
+
+                header = "binary/channel:" + String(channel) + "/id:" + identifier +
+                    "/data:" + dataString + "/ts:" + String(timestamp);
+
+                break;
+            }
+            } // end switch(eventType)
+
+            if (currFormat == HEADER_AND_JSON)
+            {
+                jsonObj->setProperty("channel", channel);
+                jsonObj->setProperty("type", type);
+                jsonObj->setProperty("data", data);
+            }
+
+            break; // case PROCESSOR_EVENT
+        }
+
+        default:
+            jassertfalse; // should never happen
+            return;
+
+        } // end switch(baseType)
+        message.add({ "header", { header.toRawUTF8(), header.getNumBytesAsUTF8() } });
+
+        String jsonString; // must be outside the if-statement so it remains in scope when we send the message
+        if (currFormat == HEADER_AND_JSON)
+        {
+            // Add common info to JSON
+            // Still sending these guys as float/doubles for now. Might change in future.
+            DynamicObject::Ptr timing = new DynamicObject();
+            timing->setProperty("sampleRate", sampleRate);
+            timing->setProperty("timestamp", timestamp);
+            jsonObj->setProperty("timing", timing.get());
+
+            jsonObj->setProperty("identifier", identifier);
+            jsonObj->setProperty("name", channel->getName());
+
+            // Add metadata
+            DynamicObject::Ptr metaDataObj = new DynamicObject();
+            populateMetaData(metaDataChannel, baseEvent, metaDataObj);
+            jsonObj->setProperty("metaData", metaDataObj.get());
+
+            String jsonString = JSON::toString(var(jsonObj));
+            message.add({ "json", { jsonString.toRawUTF8(), jsonString.getNumBytesAsUTF8() } });
+        }
+    }
+
+    sendMessage(message);
 #endif
 }
 
+int EventBroadcaster::sendMessage(const Array<MsgPart>& parts) const
+{
+#ifdef ZEROMQ
+    int numParts = parts.size();
+    for (int i = 0; i < numParts; ++i)
+    {
+        const MsgPart& part = parts.getUnchecked(i);
+        int flags = (i < numParts - 1) ? ZMQ_SNDMORE : 0;
+        if (-1 == zmqSocket->send(part.data.getData(), part.data.getSize(), flags))
+        {
+            std::cout << "Error sending " << part.name << ": " << zmq_strerror(zmq_errno()) << std::endl;
+            return -1;
+        }
+    }
+#endif
+    return 0;
+}
+
+void EventBroadcaster::populateMetaData(const MetaDataEventObject* channel,
+    const EventBasePtr event, DynamicObject::Ptr dest)
+{
+    //Iterate through all event data and add to metadata object
+    int numMetaData = event->getMetadataValueCount();
+    for (int i = 0; i < numMetaData; i++)
+    {
+        //Get metadata name
+        const MetaDataDescriptor* metaDescPtr = channel->getEventMetaDataDescriptor(i);
+        const String& metaDataName = metaDescPtr->getName();
+
+        //Get metadata value
+        const MetaDataValue* valuePtr = event->getMetaDataValue(i);
+        const void* rawPtr = valuePtr->getRawValuePointer();
+        unsigned int length = valuePtr->getDataLength();
+
+        auto dataReader = getDataReader(valuePtr->getDataType());
+        dest->setProperty(metaDataName, dataReader(rawPtr, length));
+    }
+}
+
+
 void EventBroadcaster::handleEvent(const EventChannel* channelInfo, const MidiMessage& event, int samplePosition)
 {
-	sendEvent(event, channelInfo->getSampleRate());
+    sendEvent(channelInfo, event);
 }
 
 void EventBroadcaster::handleSpike(const SpikeChannel* channelInfo, const MidiMessage& event, int samplePosition)
 {
-	sendEvent(event, channelInfo->getSampleRate());
+    sendEvent(channelInfo, event);
 }
 
 void EventBroadcaster::saveCustomParametersToXml(XmlElement* parentElement)
 {
     XmlElement* mainNode = parentElement->createNewChildElement("EVENTBROADCASTER");
-    mainNode->setAttribute("port", getListeningPort());
+    mainNode->setAttribute("port", listeningPort);
+    mainNode->setAttribute("format", outputFormat);
 }
 
 
@@ -252,8 +479,81 @@ void EventBroadcaster::loadCustomParametersFromXml()
         {
             if (mainNode->hasTagName("EVENTBROADCASTER"))
             {
-                setListeningPort(mainNode->getIntAttribute("port", getListeningPort()));
+                setListeningPort(mainNode->getIntAttribute("port", listeningPort));
+
+                outputFormat = mainNode->getIntAttribute("format", outputFormat);
+                auto ed = static_cast<EventBroadcasterEditor*>(getEditor());
+                if (ed)
+                {
+                    ed->setDisplayedFormat(outputFormat);
+                }
             }
         }
     }
+}
+
+template <typename T>
+var EventBroadcaster::binaryValueToVar(const void* value, unsigned int dataLength)
+{
+    auto typedValue = reinterpret_cast<const T*>(value);
+
+    if (dataLength == 1)
+    {
+        return String(*typedValue);
+    }
+    else
+    {
+        Array<var> metaDataArray;
+        for (unsigned int i = 0; i < dataLength; ++i)
+        {
+            metaDataArray.add(String(typedValue[i]));
+        }
+        return metaDataArray;
+    }
+}
+
+var EventBroadcaster::stringValueToVar(const void* value, unsigned int dataLength)
+{
+    return String::createStringFromData(value, dataLength);
+}
+
+EventBroadcaster::DataToVarFcn EventBroadcaster::getDataReader(BaseType dataType)
+{
+    switch (dataType)
+    {
+    case BaseType::CHAR:
+        return &stringValueToVar;
+
+    case BaseType::INT8:
+        return &binaryValueToVar<int8>;
+
+    case BaseType::UINT8:
+        return &binaryValueToVar<uint8>;
+
+    case BaseType::INT16:
+        return &binaryValueToVar<int16>;
+
+    case BaseType::UINT16:
+        return &binaryValueToVar<uint16>;
+
+    case BaseType::INT32:
+        return &binaryValueToVar<int32>;
+
+    case BaseType::UINT32:
+        return &binaryValueToVar<uint32>;
+
+    case BaseType::INT64:
+        return &binaryValueToVar<int64>;
+
+    case BaseType::UINT64:
+        return &binaryValueToVar<uint64>;
+
+    case BaseType::FLOAT:
+        return &binaryValueToVar<float>;
+
+    case BaseType::DOUBLE:
+        return &binaryValueToVar<double>;
+    }
+    jassertfalse;
+    return nullptr;
 }

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.cpp
@@ -18,24 +18,38 @@ EventBroadcasterEditor::EventBroadcasterEditor(GenericProcessor* parentNode, boo
 {
     desiredWidth = 180;
 
-    urlLabel = new Label("Port", "Port:");
-    urlLabel->setBounds(20,80,140,25);
-    addAndMakeVisible(urlLabel);
     EventBroadcaster* p = (EventBroadcaster*)getProcessor();
 
     restartConnection = new UtilityButton("Restart Connection",Font("Default", 15, Font::plain));
-    restartConnection->setBounds(20,45,150,18);
+    restartConnection->setBounds(10,35,150,18);
     restartConnection->addListener(this);
     addAndMakeVisible(restartConnection);
 
+    urlLabel = new Label("Port", "Port:");
+    urlLabel->setBounds(20, 60, 140, 25);
+    addAndMakeVisible(urlLabel);
+
     portLabel = new Label("Port", String(p->getListeningPort()));
-    portLabel->setBounds(70,85,80,18);
+    portLabel->setBounds(70,65,80,18);
     portLabel->setFont(Font("Default", 15, Font::plain));
     portLabel->setColour(Label::textColourId, Colours::white);
     portLabel->setColour(Label::backgroundColourId, Colours::grey);
     portLabel->setEditable(true);
     portLabel->addListener(this);
     addAndMakeVisible(portLabel);
+
+    formatLabel = new Label("Format", "Format:");
+    formatLabel->setBounds(5, 100, 60, 25);
+    addAndMakeVisible(formatLabel);
+
+    formatBox = new ComboBox("FormatBox");
+    formatBox->setBounds(65, 100, 100, 20);
+    formatBox->addItem("Raw binary", EventBroadcaster::Format::RAW_BINARY);
+    formatBox->addItem("Header only", EventBroadcaster::Format::HEADER_ONLY);
+    formatBox->addItem("Header/JSON", EventBroadcaster::Format::HEADER_AND_JSON);
+    formatBox->setSelectedId(p->getOutputFormat());
+    formatBox->addListener(this);
+    addAndMakeVisible(formatBox);
 
     setEnabledState(false);
 }
@@ -76,7 +90,24 @@ void EventBroadcasterEditor::labelTextChanged(juce::Label* label)
     }
 }
 
+
+void EventBroadcasterEditor::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
+{
+    if (comboBoxThatHasChanged == formatBox)
+    {
+        auto p = static_cast<EventBroadcaster*>(getProcessor());
+        p->setOutputFormat(comboBoxThatHasChanged->getSelectedId());
+    }
+}
+
+
 void EventBroadcasterEditor::setDisplayedPort(int port)
 {
     portLabel->setText(String(port), dontSendNotification);
+}
+
+
+void EventBroadcasterEditor::setDisplayedFormat(int format)
+{
+    formatBox->setSelectedId(format, dontSendNotification);
 }

--- a/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.h
+++ b/Source/Plugins/EventBroadcaster/EventBroadcasterEditor.h
@@ -22,20 +22,27 @@
 
  */
 
-class EventBroadcasterEditor : public GenericEditor, public Label::Listener
+class EventBroadcasterEditor 
+    : public GenericEditor
+    , public Label::Listener
+    , public ComboBox::Listener
 {
 public:
     EventBroadcasterEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors);
 
     void buttonEvent(Button* button) override;
     void labelTextChanged(juce::Label* label) override;
+    void comboBoxChanged(ComboBox* comboBoxThatHasChanged) override;
 
     void setDisplayedPort(int port);
+    void setDisplayedFormat(int id);
 
 private:
     ScopedPointer<UtilityButton> restartConnection;
     ScopedPointer<Label> urlLabel;
     ScopedPointer<Label> portLabel;
+    ScopedPointer<Label> formatLabel;
+    ScopedPointer<ComboBox> formatBox;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EventBroadcasterEditor);
 


### PR DESCRIPTION
Event Broadcaster only sent the raw binary event data out. This made reading/understanding the outbound data difficult. This feature adds the ability to choose your output format (Raw Binary, Header, Header/JSON) from a drop down list on the plugin.

Here the Header was implemented as starting with the type of event (spike, text, binary, ttl) followed by some important information (id, channel, timestamp, etc). The JSON object holds all information about the event, including metadata.

Example Header: ```"spike/sortedid:1/id:spikesource/ts:23384"```
Example JSON: ```{'type': 'spike', 'sortedID': 1, 'numChannels': 2, 'threshold': [150, 160], 'timing': {'sampleRate': 40000, 'timestamp': 23384}, 'identifier': 'spikesource', 'name': 'ST  p112.0 n0', 'metaData': {'Color': ['255', '255', '0']}}```


It is a fairly big change, but nearly all of the additions involve parsing the event and building the JSON object to be sent. We found this very helpful so we could use the existing event class structure to get the event information instead of building our own parser after receiving the data!

### Overview of Implementation
```sendEvent()``` was heavily rewritten to now build a message object that holds all the information to be published. A JSON object was also made if the Header/JSON format is selected and then it's added to the message object. 

This message object was sent to a new ```sendMessage()``` function that iterated through all the message parts and published them on the ZMQ socket. 

The last few functions added ```getDataReader() , binaryValuetoVar() , stringValuetoVar()``` were used because JUCE has no built-in constructor for uint64/uint32 to Var which is needed to create the JSON object.

Let me know if you have any comments!
 