### PR TITLE
Fix crash when opening LFP Viewer drawer

### DIFF
--- a/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Source/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -2449,8 +2449,12 @@ void LfpDisplay::paint(Graphics& g)
 
 void LfpDisplay::refresh()
 {
-	if (true)
-	{ 
+    // Ensure the lfpChannelBitmap has been initialized
+    if (lfpChannelBitmap.isNull())
+    {
+        resized();
+    }
+
     // X-bounds of this update
     int fillfrom = canvas->lastScreenBufferIndex[0];
     int fillto = (canvas->screenBufferIndex[0]);
@@ -2523,8 +2527,6 @@ void LfpDisplay::refresh()
     }
     
     canvas->fullredraw = false;
-	}
-    
 }
 
 


### PR DESCRIPTION
Exact same as #257, but for the new LFP viewer.