### PR TITLE
Fix crash when loading signal chain with invalid file in File Reader

### DIFF
--- a/Source/Processors/FileReader/FileReader.cpp
+++ b/Source/Processors/FileReader/FileReader.cpp
@@ -233,7 +233,9 @@ bool FileReader::setFile (String fullpath)
 
 
 void FileReader::setActiveRecording (int index)
-{    
+{
+    if (!input) { return; }
+
     input->setActiveRecord (index);
 
     currentNumChannels  = input->getActiveNumChannels();


### PR DESCRIPTION
The GUI currently crashes due to a null pointer dereference when you try to load a signal chain that includes a File Reader with a file loaded that doesn't exist on your computer. This PR adds a guard to prevent the dereference, so instead the chain loads with no file open in the File Reader, as expected.