### PR TITLE
Fix only 8 channels saved correctly in first recording

### DIFF
--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -42,7 +42,6 @@ RecordNode::RecordNode()
     isRecording = false;
 	setFirstBlock = false;
 
-    settings.numInputs = 8;
     settings.numOutputs = 0;
 
     recordingNumber = -1;
@@ -53,8 +52,6 @@ RecordNode::RecordNode()
     hasRecorded = false;
     settingsNeeded = false;
 
-    // 128 inputs, 0 outputs
-    setPlayConfigDetails(getNumInputs(),getNumOutputs(),44100.0,128);
 	m_recordThread = new RecordThread(engineArray);
 	m_dataQueue = new DataQueue(WRITE_BLOCK_LENGTH, DATA_BUFFER_NBLOCKS);
 	m_eventQueue = new EventMsgQueue(EVENT_BUFFER_NEVENTS);
@@ -82,6 +79,7 @@ void RecordNode::resetConnections()
     nextAvailableChannel = 0;
     wasConnected = false;
     spikeElectrodeIndex = 0;
+    settings.numInputs = 0;
 
     dataChannelArray.clear();
     eventChannelArray.clear();
@@ -130,11 +128,10 @@ void RecordNode::addInputChannel(const GenericProcessor* sourceNode, int chan)
     {
         int channelIndex = getNextChannel(false);
 
-		const DataChannel* orig = sourceNode->getDataChannel(chan);
-		DataChannel* newChannel = new DataChannel(*orig);
-		newChannel->setRecordState(orig->getRecordState());
+        const DataChannel* orig = sourceNode->getDataChannel(chan);
+        DataChannel* newChannel = new DataChannel(*orig);
+        newChannel->setRecordState(orig->getRecordState());
         dataChannelArray.add(newChannel);
-        setPlayConfigDetails(channelIndex+1,0,44100.0,128);
 
 
         EVERY_ENGINE->addDataChannel(channelIndex,dataChannelArray[channelIndex]);
@@ -510,6 +507,9 @@ void RecordNode::process(AudioSampleBuffer& buffer)
 
 void RecordNode::registerProcessor(const GenericProcessor* sourceNode)
 {
+    settings.numInputs += sourceNode->getNumOutputs();
+    setPlayConfigDetails(getNumInputs(), getNumOutputs(), 44100.0, 128);
+
     EVERY_ENGINE->registerProcessor(sourceNode);
 }
 

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -42,7 +42,9 @@ RecordNode::RecordNode()
     isRecording = false;
 	setFirstBlock = false;
 
+    settings.numInputs = 0;
     settings.numOutputs = 0;
+    settings.originalSource = nullptr;
 
     recordingNumber = -1;
 


### PR DESCRIPTION
This fixes a recently-introduced bug where, after starting the GUI, the first recording only saves the first 8 channels correctly; any channels that are selected for recording but are not one of the first 8 _total_ channels are saved as all zeros. After the first recording, if the number of channels sent to the `RecordNode` increases by adding processors to the signal chain, these new higher-numbered channels are also not recorded properly during the first recording when they are in the signal chain.

This happens because the `RecordNode` does not properly set its number of input channels using `setPlayConfigDetails` before the `addConnection` call after the 8th total channel is added (all during `ProcessorGraph::connectProcessorToAudioAndRecordNodes`). This in turn is due to `settings.numInputs` now being initialized to 8, and not increased until the `addSpecialProcessorChannels` call after all the connections are supposed to have been made. The call to `getNextChannel` then erroneously returns -1 after 8 channels have been added.

To fix it, I used `registerProcessor` to update both `settings.numInputs` and the play config details before the channels coming from each processor are added.