### PR TITLE
Warnings fixs

### DIFF
--- a/JuceLibraryCode/modules/juce_gui_basics/juce_gui_basics.h
+++ b/JuceLibraryCode/modules/juce_gui_basics/juce_gui_basics.h
@@ -174,7 +174,6 @@ class DrawableButton;
 #include "mouse/juce_DragAndDropContainer.h"
 #include "mouse/juce_FileDragAndDropTarget.h"
 #include "mouse/juce_SelectedItemSet.h"
-#include "mouse/juce_LassoComponent.h"
 #include "mouse/juce_MouseInactivityDetector.h"
 #include "mouse/juce_TextDragAndDropTarget.h"
 #include "mouse/juce_TooltipClient.h"
@@ -280,6 +279,7 @@ class DrawableButton;
 #include "lookandfeel/juce_LookAndFeel_V2.h"
 #include "lookandfeel/juce_LookAndFeel_V1.h"
 #include "lookandfeel/juce_LookAndFeel_V3.h"
+#include "mouse/juce_LassoComponent.h"
 
 }
 

--- a/Plugins/EvntTrigAvg/EvntTrigAvg.cpp
+++ b/Plugins/EvntTrigAvg/EvntTrigAvg.cpp
@@ -400,7 +400,7 @@ uint64 EvntTrigAvg::binDataPoint(uint64 startBin, uint64 endBin, uint64 binSize,
         return binDataPoint(startBin+(binsToSearch),endBin,binSize,dataPoint);
     }
     else{
-        return NULL;
+        return (uint64) NULL;
     }
 }
 
@@ -442,7 +442,7 @@ float EvntTrigAvg::findMin(uint64* data_)
 {
     const ScopedLock myScopedLock(mut);
     //uint64 min = UINT64_MAX;
-    uint64 min = 18446744073709551614;
+    uint64 min = 18446744073709551614U;
     for (int i = 0 ; i < windowSize/binSize ; i++){
         if(data_[i]<min){
             min=data_[i];

--- a/Plugins/IntanRecordingController/rhythm-api/okFrontPanelDLL.h
+++ b/Plugins/IntanRecordingController/rhythm-api/okFrontPanelDLL.h
@@ -1087,7 +1087,7 @@ public:
 	okCFrontPanelManager_HANDLE h;
 };
 
-typedef std::auto_ptr<OpalKellyLegacy::okCFrontPanel> FrontPanelPtr;
+typedef std::unique_ptr<OpalKellyLegacy::okCFrontPanel> FrontPanelPtr;
 
 /// \brief Allows to easily open devices in any realms.
 class FrontPanelDevices

--- a/Plugins/RhythmNode/rhythm-api/okFrontPanelDLL.h
+++ b/Plugins/RhythmNode/rhythm-api/okFrontPanelDLL.h
@@ -1087,7 +1087,7 @@ public:
 	okCFrontPanelManager_HANDLE h;
 };
 
-typedef std::auto_ptr<OpalKellyLegacy::okCFrontPanel> FrontPanelPtr;
+typedef std::unique_ptr<OpalKellyLegacy::okCFrontPanel> FrontPanelPtr;
 
 /// \brief Allows to easily open devices in any realms.
 class FrontPanelDevices

--- a/Source/Processors/RecordNode/EngineConfigWindow.cpp
+++ b/Source/Processors/RecordNode/EngineConfigWindow.cpp
@@ -206,7 +206,7 @@ void EngineConfigComponent::buttonClicked(Button* b)
 			if (response == 1)
 				AccessClass::getProcessorGraph()->getRecordNode()->setParameter(3, 0.0);
 			else
-				b->setToggleState(true, false);
+				b->setToggleState(true, juce::NotificationType::dontSendNotification);
 
 
 		}


### PR DESCRIPTION
This commits fix all the warnings that are shown during compiling (tested only in Linux).

- Warnings in  juce_LassoComponent.h
warning: invalid use of incomplete type ‘class juce::LookAndFeel’ getLookAndFeel().drawLasso (g, *this);

was fixed followinf latest JUCE library versiob
https://github.com/WeAreROLI/JUCE/blob/cabcbde0e2ed17cb98299f04b91f7af19f86b6f5/modules/juce_gui_basics/juce_gui_basics.h#L298

- Warnings in okFrontPanelDLL.h
 warning: ‘template<class> class std::auto_ptr’ is deprecated [-Wdeprecated-declarations]
 typedef std::auto_ptr<OpalKellyLegacy::okCFrontPanel> FrontPanelPtr;

was fixed following
https://stackoverflow.com/questions/45053626/error-templateclass-class-stdauto-ptr-is-deprecated
 auto_ptr -> unique_ptr

- Warning in EngineConfigWindow.cpp
warning: ‘void juce::Button::setToggleState(bool, bool)’ is deprecated [-Wdeprecated-declarations]
     b->setToggleState(true, false);

was fixed using the note
https://github.com/yagui/plugin-GUI/blob/56aa112f8b6160b7cf184b280cf2c3d338441fc9/JuceLibraryCode/modules/juce_gui_basics/buttons/juce_Button.h#L349

The new version is
https://github.com/yagui/plugin-GUI/blob/56aa112f8b6160b7cf184b280cf2c3d338441fc9/JuceLibraryCode/modules/juce_gui_basics/buttons/juce_Button.h#L95

Should be NotificationType instead of bool.
I asume that 'false' should be  juce::NotificationType::dontSendNotification
Not sure if that is the right choice

(This one is not present anymore)
- Warnings in PracticalSocket cpp/h
warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated] throw(SocketException) 

was fixed following 
https://docs.microsoft.com/en-us/cpp/cpp/exception-specifications-throw-cpp?view=vs-2019
throw() -> noexcept(true)
throw(type) -> noexcept(false)

