### PR TITLE
Really view just one subprocessor in the LFP viewer, and also view events not corresponding to any data channels

### DIFF
--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -212,67 +212,34 @@ void LfpDisplayCanvas::endAnimation()
 
 void LfpDisplayCanvas::update()
 {
-	if (true)
-	{
     nChans = jmax(processor->getNumSubprocessorChannels(), 0);
 
-	std::cout << "Num chans: " << nChans << std::endl;
+    std::cout << "Num chans: " << nChans << std::endl;
 
     resizeSamplesPerPixelBuffer(nChans);
 
-    sampleRate.clear();
-    screenBufferIndex.clear();
-    lastScreenBufferIndex.clear();
-    displayBufferIndex.clear();
+    sampleRate = 30000; // default
+
+    for (auto* arr : { &screenBufferIndex, &lastScreenBufferIndex, &displayBufferIndex })
+    {
+        arr->clearQuick();
+        arr->insertMultiple(0, 0, nChans + 1); // extra channel for events
+    }
     
     options->setEnabled(nChans != 0);
     // must manually ensure that overlapSelection propagates up to canvas
     channelOverlapFactor = options->selectedOverlapValue.getFloatValue();
 
 	std::cout << "Checking channels: " << nChans << std::endl;
-	for (int i = 0; i < processor->getNumInputs() + 1; i++) // extra channel for events
+
+    for (int i = 0, nInputs = processor->getNumInputs(); i < nInputs; i++)
     {
-		//std::cout << i << std::endl;
-		if (processor->getNumInputs() > 0)
-		{
-			if (i < processor->getNumInputs())
-			{
-				if (processor->getDataChannel(i)->getSubProcessorIdx() == drawableSubprocessor)
-				{
-					sampleRate.add(processor->getDataChannel(i)->getSampleRate());
-					//std::cout << "Adding sample rate " << processor->getDataChannel(i)->getSampleRate() << std::endl;
-				}
-					
-			}
-			else
-			{
-				//Since for now the canvas only supports one event channel, find the first TTL one and use that as sampleRate.
-				//This is a bit hackish and should be fixed for proper multi-ttl-channel support
-
-				for (int c = 0; c < processor->getTotalEventChannels(); c++)
-				{
-					if (processor->getEventChannel(c)->getChannelType() == EventChannel::TTL)
-					{
-						sampleRate.add(processor->getEventChannel(c)->getSampleRate());
-						std::cout << "Sample rate = " << processor->getEventChannel(c)->getSampleRate() << std::endl;
-
-					}
-				}
-			}
-		}
-		else
+        if (processor->getDataSubprocId(i) == drawableSubprocessor)
         {
-			sampleRate.add(30000);
+            sampleRate = processor->getDataChannel(i)->getSampleRate();
+            break;
         }
-        
-       // std::cout << "Sample rate for ch " << i << " = " << sampleRate[i] << std::endl; 
-        displayBufferIndex.add(0);
-        screenBufferIndex.add(0);
-        lastScreenBufferIndex.add(0);
     }
-
-	lfpDisplay->setDisplayedSampleRate(sampleRate[0]); // only one sample rate possible for now
-	std::cout << "Setting display sample rate to " << sampleRate[0] << std::endl;
 
 	std::cout << "Checking channel alignment: " << nChans << std::endl;
     if (nChans != lfpDisplay->getNumChannels())
@@ -319,8 +286,6 @@ void LfpDisplayCanvas::update()
             lfpDisplay->rebuildDrawableChannelsList();
         }
     }
-    
-	}
 }
 
 
@@ -410,7 +375,7 @@ void LfpDisplayCanvas::updateScreenBuffer()
 			//     std::cout << channel << " " << sbi << " " << dbi << " " << nSamples << std::endl;
 
 
-			float ratio = sampleRate[channel] * timebase / float(getWidth() - leftmargin - scrollBarThickness); // samples / pixel
+			float ratio = sampleRate * timebase / float(getWidth() - leftmargin - scrollBarThickness); // samples / pixel
 			// this number is crucial: converting from samples to values (in px) for the screen buffer
 			int valuesNeeded = (int) float(nSamples) / ratio; // N pixels needed for this update
 
@@ -658,24 +623,16 @@ bool LfpDisplayCanvas::getDrawMethodState()
     return options->getDrawMethodState(); //drawMethodButton->getToggleState();
 }
 
-int LfpDisplayCanvas::getChannelSampleRate(int channel)
-{
-    return sampleRate[channel];
-}
-
 void LfpDisplayCanvas::setDrawableSampleRate(float samplerate)
 {
 //    std::cout << "setting the drawable sample rate in the canvas" << std::endl;
 	displayedSampleRate = samplerate;
-    lfpDisplay->setDisplayedSampleRate(samplerate);
 }
 
-void LfpDisplayCanvas::setDrawableSubprocessor(int idx)
+void LfpDisplayCanvas::setDrawableSubprocessor(uint32 sp)
 {
-	drawableSubprocessor = idx;
-    lfpDisplay->setDisplayedSubprocessor(idx);
-	std::cout << "Setting LFP canvas subprocessor to " << idx << std::endl;
-	processor->setSubprocessor(idx);
+	drawableSubprocessor = sp;
+	std::cout << "Setting LFP canvas subprocessor to " << sp << std::endl;
 	update();
 }
 
@@ -887,7 +844,7 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
 	voltageRanges[DataChannel::AUX_CHANNEL].add("2000");
     //voltageRanges[DataChannel::AUX_CHANNEL].add("5000");
 	selectedVoltageRange[DataChannel::AUX_CHANNEL] = 9;
-	rangeGain[DataChannel::AUX_CHANNEL] = 0.001; //mV
+	rangeGain[DataChannel::AUX_CHANNEL] = 0.001f; //mV
 	rangeSteps[DataChannel::AUX_CHANNEL] = 10;
     rangeUnits.add("mV");
     typeNames.add("AUX");
@@ -1493,7 +1450,7 @@ void LfpDisplayOptions::buttonClicked(Button* b)
 
     if ((idx >= 0) && (b->getToggleState()))
     {
-        for (int i = 0; i < processor->getNumInputs(); i++)
+        for (int i = 0; i < lfpDisplay->getNumChannels(); i++)
         {
             if (lfpDisplay->channels[i]->getSelected())
             {
@@ -2172,7 +2129,7 @@ void LfpTimescale::setTimebase(float t)
         if (labelIncrement < 0.2)
             labelIncrement *= 2;
         else
-            labelIncrement += 0.2;
+            labelIncrement += 0.2f;
     }
     
     for (float i = labelIncrement; i < timebase; i += labelIncrement)
@@ -2634,31 +2591,6 @@ void LfpDisplay::cacheNewChannelHeight(int r)
     cachedDisplayChannelHeight = r;
 }
 
-float LfpDisplay::getDisplayedSampleRate()
-{
-    return drawableSampleRate;
-}
-
-// Must manually call rebuildDrawableChannelsList after this is set, typically will happen
-// already as a result of some other procedure
-void LfpDisplay::setDisplayedSampleRate(float samplerate)
-{
-    std::cout << "Setting the displayed samplerate for LfpDisplayCanvas to " << samplerate << std::endl;
-    drawableSampleRate = samplerate;
-}
-
-int LfpDisplay::getDisplayedSubprocessor()
-{
-    return drawableSubprocessorIdx;
-}
-
-void LfpDisplay::setDisplayedSubprocessor(int subProcessorIdx)
-{
-    drawableSubprocessorIdx = subProcessorIdx;
-	refresh();
-
-}
-
 bool LfpDisplay::getChannelsReversed()
 {
     return channelsReversed;
@@ -2673,7 +2605,7 @@ void LfpDisplay::setChannelsReversed(bool state)
     if (getSingleChannelState()) return; // don't reverse if single channel
     
     // reverse channels that are currently in drawableChannels
-    for (size_t i = 0, j = drawableChannels.size() - 1, len = drawableChannels.size()/2;
+    for (int i = 0, j = drawableChannels.size() - 1, len = drawableChannels.size()/2;
          i < len;
          i++, j--)
     {
@@ -2708,7 +2640,7 @@ void LfpDisplay::setChannelsReversed(bool state)
     }
     
     // add the channels and channel info again
-    for (size_t i = 0, len = drawableChannels.size(); i < len; i++)
+    for (int i = 0, len = drawableChannels.size(); i < len; i++)
     {
         
         if (!drawableChannels[i].channel->getHidden())
@@ -2890,8 +2822,8 @@ void LfpDisplay::toggleSingleChannel(int chan)
         }
         
         // update drawableChannels, give only the single channel to focus on
-        Array<LfpChannelTrack> channelsToDraw{lfpChannelTrack};
-        drawableChannels = channelsToDraw;
+        drawableChannels.clearQuick();
+        drawableChannels.add(lfpChannelTrack);
         
         addAndMakeVisible(lfpChannelTrack.channel);
         addAndMakeVisible(lfpChannelTrack.channelInfo);
@@ -2940,7 +2872,7 @@ void LfpDisplay::rebuildDrawableChannelsList()
     drawableChannels = Array<LfpDisplay::LfpChannelTrack>();
     
     // iterate over all channels and select drawable ones
-    for (size_t i = 0, drawableChannelNum = 0; i < channels.size(); i++)
+    for (int i = 0, drawableChannelNum = 0; i < channels.size(); i++)
     {
 //        std::cout << "\tchannel " << i << " has subprocessor index of "  << channelInfo[i]->getSubprocessorIdx() << std::endl;
         // if channel[i] is not sourced from the correct subprocessor, then hide it and continue
@@ -3279,7 +3211,7 @@ void LfpChannelDisplay::pxPaint()
             //draw zero line
             int m = getY()+center;
             
-            if(m > 0 & m < display->lfpChannelBitmap.getHeight())
+            if(m > 0 && m < display->lfpChannelBitmap.getHeight())
             {
                 if ( bdLfpChannelBitmap.getPixelColour(i,m) == display->backgroundColour ) { // make sure we're not drawing over an existing plot from another channel
                     bdLfpChannelBitmap.setPixelColour(i,m,Colour(50,50,50));
@@ -3294,7 +3226,7 @@ void LfpChannelDisplay::pxPaint()
                 
                 for (m = start; m <= start + jump*4; m += jump)
                 {
-                    if (m > 0 & m < display->lfpChannelBitmap.getHeight())
+                    if (m > 0 && m < display->lfpChannelBitmap.getHeight())
                     {
                         if ( bdLfpChannelBitmap.getPixelColour(i,m) == display->backgroundColour ) // make sure we're not drawing over an existing plot from another channel
                             bdLfpChannelBitmap.setPixelColour(i, m, Colour(80,80,80));
@@ -3431,7 +3363,7 @@ void LfpChannelDisplay::pxPaint()
                     {
                         int clipmarker = jto_wholechannel_clip;
                         
-                        if(clipmarker>0 & clipmarker<display->lfpChannelBitmap.getHeight()){
+                        if(clipmarker>0 && clipmarker<display->lfpChannelBitmap.getHeight()){
                             bdLfpChannelBitmap.setPixelColour(i,clipmarker-j,Colour(255,255,255));
                         }
                     }
@@ -3442,7 +3374,7 @@ void LfpChannelDisplay::pxPaint()
                     {
                         int clipmarker = jfrom_wholechannel_clip;
                         
-                        if(clipmarker>0 & clipmarker<display->lfpChannelBitmap.getHeight()){
+                        if(clipmarker>0 && clipmarker<display->lfpChannelBitmap.getHeight()){
                             bdLfpChannelBitmap.setPixelColour(i,clipmarker+j,Colour(255,255,255));
                         }
                     }
@@ -3455,7 +3387,7 @@ void LfpChannelDisplay::pxPaint()
             if (spikeFlag) // draw spikes
             {
                 for (int k=jfrom_wholechannel; k<=jto_wholechannel; k++){ // draw line
-                    if(k>0 & k<display->lfpChannelBitmap.getHeight()){
+                    if(k>0 && k<display->lfpChannelBitmap.getHeight()){
                         bdLfpChannelBitmap.setPixelColour(i,k,lineColour);
                     }
                 };
@@ -3473,7 +3405,7 @@ void LfpChannelDisplay::pxPaint()
                         if (fmod((i+k),50)>25){
                             thiscolour=Colour(255,255,255);
                         }
-                        if(k>0 & k<display->lfpChannelBitmap.getHeight()){
+                        if(k>0 && k<display->lfpChannelBitmap.getHeight()){
                             bdLfpChannelBitmap.setPixelColour(i,k,thiscolour);
                         }
                     };
@@ -4059,7 +3991,7 @@ void SupersampledBitmapPlotter::plot(Image::BitmapData &bdLfpChannelBitmap, LfpB
 //    int sampleCountThisPixel = lfpDisplay->canvas->getSampleCountPerPixel(pInfo.samp);
     int sampleCountThisPixel = pInfo.sampleCountPerPixel;
     
-    if (pInfo.samplerange>0 & sampleCountThisPixel>0)
+    if (pInfo.samplerange>0 && sampleCountThisPixel>0)
     {
         
         //float localHist[samplerange]; // simple histogram
@@ -4113,7 +4045,7 @@ void SupersampledBitmapPlotter::plot(Image::BitmapData &bdLfpChannelBitmap, LfpB
             //Colour gradedColor =  Colour(0,255,0);
             
             int ploty = pInfo.from + s + pInfo.y;
-            if(ploty>0 & ploty < display->lfpChannelBitmap.getHeight()) {
+            if(ploty>0 && ploty < display->lfpChannelBitmap.getHeight()) {
                 bdLfpChannelBitmap.setPixelColour(pInfo.samp, pInfo.from + s + pInfo.y, gradedColor);
             }
         }

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -119,9 +119,9 @@ public:
     /** Returns the subprocessor index of the given channel */
     int getChannelSubprocessorIdx(int channel);
     
-    /** Delegates a subprocessor index for drawing to the LfpDisplay referenced by this
+    /** Delegates a subprocessor for drawing to the LfpDisplay referenced by this
         this canvas */
-    void setDrawableSubprocessor(int idx);
+    void setDrawableSubprocessor(uint32 sp);
 
     const float getXCoord(int chan, int samp);
     const float getYCoord(int chan, int samp);
@@ -168,7 +168,7 @@ public:
 
 private:
     
-    Array<float> sampleRate;
+    float sampleRate;
 
     bool optionsDrawerIsOpen;
     
@@ -176,7 +176,7 @@ private:
     float timeOffset;
     //int spread ; // vertical spacing between channels
 
-	int drawableSubprocessor;
+	uint32 drawableSubprocessor;
 	float displayedSampleRate;
     
     //float waves[MAX_N_CHAN][MAX_N_SAMP*2]; // we need an x and y point for each sample
@@ -502,24 +502,7 @@ public:
     int getChannelHeight();
     
     LfpChannelColourScheme * getColourSchemePtr();
-    
-    /** Returns the sample rate that is currently filtering the drawable channels */
-    float getDisplayedSampleRate();
-    
-    /** Sets the samplerate that displayed channels must be set to. No channels with
-        differing samplerates will be drawn to screen.
-     
-        This function does not automatically repopulate the drawableChannels list, so
-        rebuildDrawableChannelsList must be called before the screen is updated.
-     
-        @see LfpDisplayCanvas::setDrawableSampleRate, LfpDisplayNode::updateSettings
-     */
-    void setDisplayedSampleRate(float samplerate);
-    
-    int getDisplayedSubprocessor();
-    
-    void setDisplayedSubprocessor(int subProcessorIdx);
-    
+        
     /** Caches a new channel height without updating the channels */
     void cacheNewChannelHeight(int r);
     
@@ -647,7 +630,7 @@ private:
     int displaySkipAmt;
     int cachedDisplayChannelHeight;     // holds a channel height if reset during single channel focus
     float drawableSampleRate;
-    int drawableSubprocessorIdx;
+    uint32 drawableSubprocessor;
 
     int totalHeight;
 

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -105,11 +105,11 @@ void LfpDisplayEditor::comboBoxChanged(juce::ComboBox *cb)
 {
     if (cb == subprocessorSelection)
     {
-		std::cout << "Setting subprocessor to " << cb->getSelectedId() << std::endl;
+        std::cout << "Setting subprocessor to " << cb->getSelectedId() << std::endl;
         uint32 subproc = inputSubprocessors[cb->getSelectedId() - 1];
 		
         String sampleRateLabelText = "Sample Rate: ";
-		sampleRateLabelText += String(inputSampleRates[subproc]);
+		sampleRateLabelText += String(lfpProcessor->getSubprocessorSampleRate(subproc));
 		subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
         std::cout << sampleRateLabelText << std::endl;
 
@@ -125,7 +125,6 @@ void LfpDisplayEditor::updateSubprocessorSelectorOptions()
 {
     // clear out the old data
     inputSubprocessors.clear();
-    inputSampleRates.clear();
     subprocessorSelection->clear(dontSendNotification);
     
 	if (lfpProcessor->getTotalDataChannels() != 0)
@@ -140,12 +139,10 @@ void LfpDisplayEditor::updateSubprocessorSelectorOptions()
 			uint16 subProcessorIdx = ch->getSubProcessorIdx();
             uint32 subProcFullId = GenericProcessor::getProcessorFullId(sourceNodeId, subProcessorIdx);
 
-			bool success = inputSubprocessors.add(subProcFullId);
+			bool added = inputSubprocessors.add(subProcFullId);
 
-            if (success)
+            if (added)
             {
-                inputSampleRates.set(subProcFullId, ch->getSampleRate());
-                
                 String sourceName = ch->getSourceName();
                 subprocessorNames.set(subProcFullId,
                     sourceName + " " + String(sourceNodeId) + "/" + String(subProcessorIdx));

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -35,16 +35,14 @@ LfpDisplayEditor::LfpDisplayEditor(GenericProcessor* parentNode, bool useDefault
 
     desiredWidth = 180;
     
+    subprocessorSelectionLabel = new Label("Display subprocessor sample rate", "Display Subprocessor:");
+    subprocessorSelectionLabel->setBounds(10, 30, 130, 20);
+    addAndMakeVisible(subprocessorSelectionLabel);
+
     subprocessorSelection = new ComboBox("Subprocessor sample rate");
-//    subprocessorSelection->setBounds(subprocessorSelectionLabel->getX()+5, subprocessorSelectionLabel->getBottom(), 60, 22);
-    subprocessorSelection->setBounds(10, 30, 55, 22);
+    subprocessorSelection->setBounds(10, 55, 130, 22);
     subprocessorSelection->addListener(this);
     addAndMakeVisible(subprocessorSelection);
-    
-    subprocessorSelectionLabel = new Label("Display subprocessor sample rate", "Display Subproc.");
-    //    subprocessorSelectionLabel->setBounds(10, 25, 140, 20);
-    subprocessorSelectionLabel->setBounds(subprocessorSelection->getRight(), subprocessorSelection->getY(), 100, 20);
-    addAndMakeVisible(subprocessorSelectionLabel);
     
     subprocessorSampleRateLabel = new Label("Subprocessor sample rate label", "Sample Rate:");
     subprocessorSampleRateLabel->setFont(Font(Font::getDefaultSerifFontName(), 14, Font::plain));
@@ -107,85 +105,73 @@ void LfpDisplayEditor::comboBoxChanged(juce::ComboBox *cb)
 {
     if (cb == subprocessorSelection)
     {
-		std::cout << "Setting subprocessor to " << cb->getSelectedId() << std::endl; 
-        setCanvasDrawableSubprocessor(cb->getSelectedId() - 1);
-		String sampleRateLabelText = "Sample Rate: ";
-		sampleRateLabelText += String(inputSampleRates[cb->getSelectedId() - 1]);
+		std::cout << "Setting subprocessor to " << cb->getSelectedId() << std::endl;
+        uint32 subproc = inputSubprocessors[cb->getSelectedId() - 1];
+		
+        String sampleRateLabelText = "Sample Rate: ";
+		sampleRateLabelText += String(inputSampleRates[subproc]);
 		subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
+        std::cout << sampleRateLabelText << std::endl;
+
+        lfpProcessor->setSubprocessor(subproc);
+        if (canvas)
+        {
+            static_cast<LfpDisplayCanvas*>(canvas.get())->setDrawableSubprocessor(subproc);
+        }
     }
 }
 
 void LfpDisplayEditor::updateSubprocessorSelectorOptions()
 {
     // clear out the old data
-    inputSubprocessorIndices.clear();
+    inputSubprocessors.clear();
     inputSampleRates.clear();
     subprocessorSelection->clear(dontSendNotification);
     
 	if (lfpProcessor->getTotalDataChannels() != 0)
 
 	{
+        HashMap<int, String> subprocessorNames;
 
 		for (int i = 0, len = lfpProcessor->getTotalDataChannels(); i < len; ++i)
 		{
-			int subProcessorIdx = lfpProcessor->getDataChannel(i)->getSubProcessorIdx();
+            const DataChannel* ch = lfpProcessor->getDataChannel(i);
+            uint16 sourceNodeId = ch->getSourceNodeID();
+			uint16 subProcessorIdx = ch->getSubProcessorIdx();
+            uint32 subProcFullId = GenericProcessor::getProcessorFullId(sourceNodeId, subProcessorIdx);
 
-			bool success = inputSubprocessorIndices.add(subProcessorIdx);
+			bool success = inputSubprocessors.add(subProcFullId);
 
-			if (success) inputSampleRates.set(subProcessorIdx, lfpProcessor->getDataChannel(i)->getSampleRate());
-
+            if (success)
+            {
+                inputSampleRates.set(subProcFullId, ch->getSampleRate());
+                
+                String sourceName = ch->getSourceName();
+                subprocessorNames.set(subProcFullId,
+                    sourceName + " " + String(sourceNodeId) + "/" + String(subProcessorIdx));
+            }
 		}
 
-		for (int i = 0; i < inputSubprocessorIndices.size(); ++i)
+		for (int i = 0; i < inputSubprocessors.size(); ++i)
 		{
-			subprocessorSelection->addItem(String(*(inputSubprocessorIndices.begin() + i)), i + 1);
+			subprocessorSelection->addItem(subprocessorNames[inputSubprocessors[i]], i + 1);
 		}
 
-		if (defaultSubprocessor >= 0)
-		{
-			subprocessorSelection->setSelectedId(defaultSubprocessor + 1, sendNotification);
+        uint32 selectedSubproc = lfpProcessor->getSubprocessor();
+        int selectedSubprocId = (selectedSubproc ? inputSubprocessors.indexOf(selectedSubproc) : defaultSubprocessor) + 1;
 
-			String sampleRateLabelText = "Sample Rate: ";
-			sampleRateLabelText += String(inputSampleRates[*(inputSubprocessorIndices.begin() + defaultSubprocessor)]);
-
-			subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
-			//setCanvasDrawableSubprocessor(defaultSubprocessor);
-
-            return;
-		}
+		subprocessorSelection->setSelectedId(selectedSubprocId, sendNotification);
 	}
-
-    subprocessorSelection->addItem("None", 1);
-    subprocessorSelection->setSelectedId(1, dontSendNotification);
-
-    String sampleRateLabelText = "Sample Rate: <not available>";
-    subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
-    //setCanvasDrawableSubprocessor(-1);
-}
-
-void LfpDisplayEditor::setCanvasDrawableSubprocessor(int index)
-{
-    if (canvas)
+    else
     {
-		if (index >= 0)
-		{
-			((LfpDisplayCanvas *)canvas.get())->setDrawableSubprocessor(*(inputSubprocessorIndices.begin() + index));
-			float rate = lfpProcessor->getSubprocessorSampleRate();
+        subprocessorSelection->addItem("None", 1);
+        subprocessorSelection->setSelectedId(1, dontSendNotification);
 
-			String sampleRateLabelText = "Sample Rate: ";
-			sampleRateLabelText += String(rate);
-			subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
-
-			std::cout << sampleRateLabelText << std::endl;
-		}
-		else
-		{
-			((LfpDisplayCanvas *)canvas.get())->setDrawableSubprocessor(-1);
-		}
-            
+        String sampleRateLabelText = "Sample Rate: <not available>";
+        subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
+        //setCanvasDrawableSubprocessor(-1);
     }
 }
-
 
 void LfpDisplayEditor::saveVisualizerParameters(XmlElement* xml)
 {

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.h
@@ -79,7 +79,6 @@ public:
 
 private:
     
-    HashMap<int, float> inputSampleRates; // hold the possible subprocessor sample rates
     SortedSet<uint32> inputSubprocessors;
     
     LfpDisplayNode* lfpProcessor;

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.h
@@ -80,7 +80,7 @@ public:
 private:
     
     HashMap<int, float> inputSampleRates; // hold the possible subprocessor sample rates
-    SortedSet<int> inputSubprocessorIndices;
+    SortedSet<uint32> inputSubprocessors;
     
     LfpDisplayNode* lfpProcessor;
 
@@ -91,11 +91,6 @@ private:
     ScopedPointer<Label> subprocessorSampleRateLabel;
     
     bool hasNoInputs;
-    
-    /** Communicates the drawable subprocessor information to the canvas, if
-     one exists
-     */
-    void setCanvasDrawableSubprocessor(int index);
 
 	int defaultSubprocessor;
 

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -271,8 +271,8 @@ void LfpDisplayNode::handleEvent(const EventChannel* eventInfo, const MidiMessag
         const int eventTime = samplePosition;
         uint32 eventSourceNodeId = getEventSourceId(eventInfo);
         
-        // treat events with no source as occurring on the subprocessor being drawn.
-        if (eventSourceNodeId == 0)
+        // treat event channels with sample rate of 0 as occurring on the subprocessor being drawn.
+        if (eventInfo->getSampleRate() == 0)
         {
             eventSourceNodeId = subprocessorToDraw;
         }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -271,8 +271,8 @@ void LfpDisplayNode::handleEvent(const EventChannel* eventInfo, const MidiMessag
         const int eventTime = samplePosition;
         uint32 eventSourceNodeId = getEventSourceId(eventInfo);
         
-        // treat event channels with sample rate of 0 as occurring on the subprocessor being drawn.
-        if (eventInfo->getSampleRate() == 0)
+        // treat events with no source as occurring on the subprocessor being drawn.
+        if (eventSourceNodeId == 0)
         {
             eventSourceNodeId = subprocessorToDraw;
         }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -47,8 +47,6 @@ LfpDisplayNode::LfpDisplayNode()
 
 	subprocessorToDraw = 0;
 	numSubprocessors = -1;
-	numChannelsInSubprocessor = 0;
-	updateSubprocessorsFlag = true;
 }
 
 
@@ -70,66 +68,73 @@ void LfpDisplayNode::updateSettings()
 
     std::cout << "Setting num inputs on LfpDisplayNode to " << getNumInputs() << std::endl;
 
-	numChannelsInSubprocessor = 0;
-	int totalSubprocessors = 0;
-	int currentSubprocessor = -1;
+	numChannelsInSubprocessor.clear();
+    subprocessorSampleRate.clear();
 
 	for (int i = 0; i < getNumInputs(); i++)
 	{
-		int channelSubprocessor = getDataChannel(i)->getSubProcessorIdx();
+        uint32 channelSubprocessor = getDataSubprocId(i);
 
-		if (currentSubprocessor != channelSubprocessor)
-		{
-			totalSubprocessors++;
-			currentSubprocessor = channelSubprocessor;
-		}
+        numChannelsInSubprocessor.insert({ channelSubprocessor, 0 }); // (if not already there)
+        numChannelsInSubprocessor[channelSubprocessor]++;
 
-		if (channelSubprocessor == subprocessorToDraw)
-		{
-			numChannelsInSubprocessor++;
-			subprocessorSampleRate = getDataChannel(i)->getSampleRate();
-		}
+        subprocessorSampleRate.insert({ channelSubprocessor, getDataChannel(i)->getSampleRate() });
 	}
+    
+    numSubprocessors = numChannelsInSubprocessor.size();
 
-	std::cout << "Re-setting num inputs on LfpDisplayNode to " << numChannelsInSubprocessor << std::endl;
-	std::cout << "Sample rate = " << subprocessorSampleRate << std::endl;
+    if (numChannelsInSubprocessor.find(subprocessorToDraw) == numChannelsInSubprocessor.end())
+    {
+        // subprocessor to draw does not exist
+        if (numSubprocessors == 0)
+        {
+            subprocessorToDraw = 0;
+        }
+        else
+        {
+            // there are channels, but none on the current subprocessorToDraw
+            // default to the first subprocessor
+            subprocessorToDraw = getDataSubprocId(0);
+        }
+    }
 
-    channelForEventSource.clear();
+    int numChans = getNumSubprocessorChannels();
+    int srate = getSubprocessorSampleRate();
+
+	std::cout << "Re-setting num inputs on LfpDisplayNode to " << numChans << std::endl;
+    if (numChans > 0)
+    {
+        std::cout << "Sample rate = " << srate << std::endl;
+    }
+
     eventSourceNodes.clear();
     ttlState.clear();
 
 	for (int i = 0; i < eventChannelArray.size(); ++i)
 	{
-		uint32 sourceID = getChannelSourceID(eventChannelArray[i]);
-		if (!eventSourceNodes.contains(sourceID))
+		uint32 sourceId = getEventSourceId(eventChannelArray[i]);
+ 
+		if (!eventSourceNodes.contains(sourceId))
 		{
-			eventSourceNodes.add(sourceID);
-
+			eventSourceNodes.add(sourceId);
 		}
 	}
 
-    numEventChannels = eventSourceNodes.size();
-
-    std::cout << "Found " << numEventChannels << " event channels." << std::endl;
-
     for (int i = 0; i < eventSourceNodes.size(); ++i)
     {
-		std::cout << "Adding channel " << numChannelsInSubprocessor + i << " for event source node " << eventSourceNodes[i] << std::endl;
+		std::cout << "Adding channel " << numChans + i << " for event source node " << eventSourceNodes[i] << std::endl;
 
-		channelForEventSource[eventSourceNodes[i]] = numChannelsInSubprocessor + i;
         ttlState[eventSourceNodes[i]] = 0;
     }
 
-    displayBufferIndex.clear();
-	displayBufferIndex.insertMultiple(0, 0, numChannelsInSubprocessor + numEventChannels);
+    resizeBuffer();
     
     // update the editor's subprocessor selection display and sample rate
 	LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
 	ed->updateSubprocessorSelectorOptions();
-	numSubprocessors = totalSubprocessors;
 }
 
-uint32 LfpDisplayNode::getChannelSourceID(const EventChannel* event) const
+uint32 LfpDisplayNode::getEventSourceId(const EventChannel* event)
 {
 
 	if (event->getTimestampOrigin() == EventChannel::timestampsDerivedFromChannel)
@@ -138,45 +143,71 @@ uint32 LfpDisplayNode::getChannelSourceID(const EventChannel* event) const
 	}
 	else
 	{
-		return getProcessorFullId(event->getSourceNodeID(), event->getSubProcessorIdx());
+		return getChannelSourceId(event);
 	}
 }
 
-void LfpDisplayNode::setSubprocessor(int sp)
+uint32 LfpDisplayNode::getChannelSourceId(const InfoObjectCommon* chan)
+{
+    return getProcessorFullId(chan->getSourceNodeID(), chan->getSubProcessorIdx());
+}
+
+uint32 LfpDisplayNode::getDataSubprocId(int chan) const
+{
+    if (chan < 0 || chan >= getTotalDataChannels())
+    {
+        return 0;
+    }
+
+    return getChannelSourceId(getDataChannel(chan));
+}
+
+void LfpDisplayNode::setSubprocessor(uint32 sp)
 {
 
 	subprocessorToDraw = sp;
-	std::cout << "LfpDisplayNode setting subprocessor to " << sp << std::endl;
+    resizeBuffer();
+	std::cout << "LfpDisplayNode setting subprocessor to " << sp << std::endl;	
+}
 
-	updateSubprocessorsFlag = false;
-	
+uint32 LfpDisplayNode::getSubprocessor() const
+{
+    return subprocessorToDraw;
 }
 
 int LfpDisplayNode::getNumSubprocessorChannels()
 {
-	return numChannelsInSubprocessor;
+    if (subprocessorToDraw != 0)
+    {
+        return numChannelsInSubprocessor[subprocessorToDraw];
+    }
+    return 0;
 }
 
 float LfpDisplayNode::getSubprocessorSampleRate()
 {
-	return subprocessorSampleRate;
+    if (subprocessorToDraw != 0)
+    {
+        return subprocessorSampleRate[subprocessorToDraw];
+    }
+    return 0.0f;
 }
 
 bool LfpDisplayNode::resizeBuffer()
 {
-	int nSamples = (int)subprocessorSampleRate * bufferLength;
-	int nInputs = numChannelsInSubprocessor;
+	int nSamples = (int)getSubprocessorSampleRate() * bufferLength;
+	int nInputs = getNumSubprocessorChannels();
 
-	std::cout << "Resizing buffer. Samples: " << nSamples << ", Inputs: " << nInputs << ", event channels: " << numEventChannels << std::endl;
+	std::cout << "Resizing buffer. Samples: " << nSamples << ", Inputs: " << nInputs << std::endl;
 
 	if (nSamples > 0 && nInputs > 0)
 	{
 		abstractFifo.setTotalSize(nSamples);
-		displayBuffer->setSize(nInputs + numEventChannels, nSamples); // add extra channels for TTLs
+		displayBuffer->setSize(nInputs + 1, nSamples); // add extra channel for TTLs
 		displayBuffer->clear();
 
 		displayBufferIndex.clear();
-		displayBufferIndex.insertMultiple(0, 0, numChannelsInSubprocessor + numEventChannels);
+		displayBufferIndex.insertMultiple(0, 0, nInputs + 1);
 
 		return true;
 	}
@@ -238,50 +269,59 @@ void LfpDisplayNode::handleEvent(const EventChannel* eventInfo, const MidiMessag
         const int eventId = ttl->getState() ? 1 : 0;
         const int eventChannel = ttl->getChannel();
         const int eventTime = samplePosition;
-        const uint32 eventSourceNodeId = getChannelSourceID(eventInfo);
+        uint32 eventSourceNodeId = getEventSourceId(eventInfo);
+        
+        // treat events with no source as occurring on the subprocessor being drawn.
+        if (eventSourceNodeId == 0)
+        {
+            eventSourceNodeId = subprocessorToDraw;
+        }
         
 		//std::cout << "Received event on channel " << eventChannel << std::endl;
 		//std::cout << "Copying to channel " << channelForEventSource[eventSourceNodeId] << std::endl;
         
-        const int chan          = channelForEventSource[eventSourceNodeId];
-        const int index         = (displayBufferIndex[chan] + eventTime) % displayBuffer->getNumSamples();
-        const int samplesLeft   = displayBuffer->getNumSamples() - index;
-        const int nSamples = getNumSourceSamples(eventSourceNodeId) - eventTime;
-        
         if (eventId == 1)
         {
-            ttlState[eventSourceNodeId] |= (1L << eventChannel);
+            ttlState[eventSourceNodeId] |= (1LL << eventChannel);
         }
         else
         {
-            ttlState[eventSourceNodeId] &= ~(1L << eventChannel);
+            ttlState[eventSourceNodeId] &= ~(1LL << eventChannel);
         }
-        
-        if (nSamples < samplesLeft)
+
+        if (eventSourceNodeId == subprocessorToDraw)
         {
-            displayBuffer->copyFrom (channelForEventSource[eventSourceNodeId],  // destChannel
-                                     index,                               // destStartSample
-                                     arrayOfOnes,                               // source
-                                     nSamples,                             // numSamples
-                                     float (ttlState[eventSourceNodeId]));      // gain
+            const int chan          = numChannelsInSubprocessor[eventSourceNodeId];
+            const int index         = (displayBufferIndex[chan] + eventTime) % displayBuffer->getNumSamples();
+            const int samplesLeft   = displayBuffer->getNumSamples() - index;
+            const int nSamples      = getNumSourceSamples(eventSourceNodeId) - eventTime;
+
+            if (nSamples < samplesLeft)
+            {
+                displayBuffer->copyFrom(chan,                                 // destChannel
+                                        index,                                // destStartSample
+                                        arrayOfOnes,                          // source
+                                        nSamples,                             // numSamples
+                                        float(ttlState[eventSourceNodeId]));  // gain
+            }
+            else
+            {
+                int extraSamples = nSamples - samplesLeft;
+
+                displayBuffer->copyFrom(chan,                                 // destChannel
+                                        index,                                // destStartSample
+                                        arrayOfOnes,                          // source
+                                        samplesLeft,                          // numSamples
+                                        float(ttlState[eventSourceNodeId]));  // gain
+
+                displayBuffer->copyFrom(chan,                                 // destChannel
+                                        0,                                    // destStartSample
+                                        arrayOfOnes,                          // source
+                                        extraSamples,                         // numSamples
+                                        float(ttlState[eventSourceNodeId]));  // gain
+            }
         }
-        else
-        {
-            int extraSamples = nSamples - samplesLeft;
-            
-            displayBuffer->copyFrom (channelForEventSource[eventSourceNodeId],  // destChannel
-                                     index,                               // destStartSample
-                                     arrayOfOnes,                               // source
-                                     samplesLeft,                                // numSamples
-                                     float (ttlState[eventSourceNodeId]));      // gain
-            
-            displayBuffer->copyFrom (channelForEventSource[eventSourceNodeId],  // destChannel
-                                     0,                                         // destStartSample
-                                     arrayOfOnes,                               // source
-                                     extraSamples,                                // numSamples
-                                     float (ttlState[eventSourceNodeId]));      // gain
-        }
-        
+
         //         std::cout << "Received event from " << eventSourceNodeId
         //                   << " on channel " << eventChannel
         //                   << " with value " << eventId
@@ -295,65 +335,59 @@ void LfpDisplayNode::initializeEventChannels()
 
 	//std::cout << "Initializing events..." << std::endl;
 
-    for (int i = 0; i < eventSourceNodes.size(); ++i)
-    {
-        const int chan          = channelForEventSource[eventSourceNodes[i]];
-        const int index         = displayBufferIndex[chan];
-        const int samplesLeft   = displayBuffer->getNumSamples() - index;
-		const int nSamples = getNumSourceSamples(eventSourceNodes[i]);
+    const int chan          = numChannelsInSubprocessor[subprocessorToDraw];
+    const int index         = displayBufferIndex[chan];
+    const int samplesLeft   = displayBuffer->getNumSamples() - index;
+	const int nSamples      = getNumSourceSamples(subprocessorToDraw);
 
-		//std::cout << chan << " " << index << " " << samplesLeft << " " << nSamples << std::endl;
+	//std::cout << chan << " " << index << " " << samplesLeft << " " << nSamples << std::endl;
         
-        if (nSamples < samplesLeft)
-        {
+    if (nSamples < samplesLeft)
+    {
 
-            displayBuffer->copyFrom (chan,                                      // destChannel
-                                     index,                                     // destStartSample
-                                     arrayOfOnes,                               // source
-                                     nSamples,                                  // numSamples
-                                     float (ttlState[eventSourceNodes[i]]));    // gain
-        }
-        else
-        {
-            int extraSamples = nSamples - samplesLeft;
+        displayBuffer->copyFrom (chan,                                      // destChannel
+                                 index,                                     // destStartSample
+                                 arrayOfOnes,                               // source
+                                 nSamples,                                  // numSamples
+                                 float (ttlState[subprocessorToDraw]));     // gain
+    }
+    else
+    {
+        int extraSamples = nSamples - samplesLeft;
 
-            displayBuffer->copyFrom (chan,                                      // destChannel
-                                     index,                                     // destStartSample
-                                     arrayOfOnes,                               // source
-                                     samplesLeft,                               // numSamples
-                                     float (ttlState[eventSourceNodes[i]]));    // gain
+        displayBuffer->copyFrom (chan,                                      // destChannel
+                                 index,                                     // destStartSample
+                                 arrayOfOnes,                               // source
+                                 samplesLeft,                               // numSamples
+                                 float (ttlState[subprocessorToDraw]));     // gain
 
-            displayBuffer->copyFrom (chan,                                      // destChannel
-                                     0,                                         // destStartSample
-                                     arrayOfOnes,                               // source
-                                     extraSamples,                              // numSamples
-                                     float (ttlState[eventSourceNodes[i]]));    // gain
-        }
+        displayBuffer->copyFrom (chan,                                      // destChannel
+                                 0,                                         // destStartSample
+                                 arrayOfOnes,                               // source
+                                 extraSamples,                              // numSamples
+                                 float (ttlState[subprocessorToDraw]));     // gain
     }
 }
 
 void LfpDisplayNode::finalizeEventChannels()
 {
-    for (int i = 0; i < eventSourceNodes.size(); ++i)
+    const int chan          = numChannelsInSubprocessor[subprocessorToDraw];
+    const int index         = displayBufferIndex[chan];
+    const int samplesLeft   = displayBuffer->getNumSamples() - index;
+    const int nSamples      = getNumSourceSamples(subprocessorToDraw);
+        
+    int newIdx = 0;
+        
+    if (nSamples < samplesLeft)
     {
-        const int chan          = channelForEventSource[eventSourceNodes[i]];
-        const int index         = displayBufferIndex[chan];
-        const int samplesLeft   = displayBuffer->getNumSamples() - index;
-        const int nSamples = getNumSourceSamples(eventSourceNodes[i]);
-        
-        int newIdx = 0;
-        
-        if (nSamples < samplesLeft)
-        {
-            newIdx = index + nSamples;
-        }
-        else
-        {
-            newIdx = nSamples - samplesLeft;
-        }
-        
-        displayBufferIndex.set(chan, newIdx);
+        newIdx = index + nSamples;
     }
+    else
+    {
+        newIdx = nSamples - samplesLeft;
+    }
+        
+    displayBufferIndex.set(chan, newIdx);
 }
 
 
@@ -379,7 +413,7 @@ void LfpDisplayNode::process (AudioSampleBuffer& buffer)
 
 			for (int chan = 0; chan < buffer.getNumChannels(); ++chan)
 			{
-				if (getDataChannel(chan)->getSubProcessorIdx() == subprocessorToDraw)
+				if (getDataSubprocId(chan) == subprocessorToDraw)
 				{
 					channelIndex++;
 					const int samplesLeft = displayBuffer->getNumSamples() - displayBufferIndex[channelIndex];

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.h
@@ -73,7 +73,7 @@ public:
 
 	int getNumSubprocessorChannels();
 
-	float getSubprocessorSampleRate();
+    float getSubprocessorSampleRate(uint32 subprocId);
 
     uint32 getDataSubprocId(int chan) const;
 

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.h
@@ -27,6 +27,7 @@
 #include <ProcessorHeaders.h>
 #include "LfpDisplayEditor.h"
 
+#include <map>
 
 class DataViewport;
 
@@ -67,10 +68,14 @@ public:
 
     CriticalSection* getMutex() { return &displayMutex; }
 
-	void setSubprocessor(int sp);
+	void setSubprocessor(uint32 sp);
+    uint32 getSubprocessor() const;
+
 	int getNumSubprocessorChannels();
 
 	float getSubprocessorSampleRate();
+
+    uint32 getDataSubprocId(int chan) const;
 
 private:
     void initializeEventChannels();
@@ -80,9 +85,6 @@ private:
 
     Array<int> displayBufferIndex;
     Array<uint32> eventSourceNodes;
-    std::map<uint32, int> channelForEventSource;
-
-    int numEventChannels;
 
     float displayGain; //
     float bufferLength; // s
@@ -96,15 +98,15 @@ private:
 
     bool resizeBuffer();
 
-	int subprocessorToDraw;
-	int numChannelsInSubprocessor;
-	int numSubprocessors;
-	float subprocessorSampleRate;
+    int numSubprocessors;
+	uint32 subprocessorToDraw;
+	std::map<uint32, int> numChannelsInSubprocessor;
+	std::map<uint32, float> subprocessorSampleRate;
 
     CriticalSection displayMutex;
-	bool updateSubprocessorsFlag;
 
-	uint32 getChannelSourceID(const EventChannel* event) const;
+    static uint32 getEventSourceId(const EventChannel* event);
+    static uint32 getChannelSourceId(const InfoObjectCommon* chan);
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LfpDisplayNode);
 };

--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -1275,12 +1275,12 @@ uint32 GenericProcessor::getProcessorFullId(uint16 sid, uint16 subid)
 
 uint16 GenericProcessor::getNodeIdFromFullId(uint32 fid)
 {
-	return (fid && 0xFF00 ) >> 16;
+	return (fid & 0xFFFF0000 ) >> 16;
 }
 
 uint16 GenericProcessor::getSubProcessorFromFullId(uint32 fid)
 {
-	return (fid && 0x00FF);
+	return (fid & 0x0000FFFF);
 }
 
 int64 GenericProcessor::getLastProcessedsoftwareTime() const


### PR DESCRIPTION
This resolves #302. To summarize, the LFP viewer currently has the weird behavior of showing data from all subprocessors with a given index in their source nodes, rather than just one single subprocessor. This is convenient and works sometimes, but the incoming data from different sources could have different sample rates or different amounts of samples per buffer even with the same sample rate; dealing with this is complex and currently causes display glitches in some cases, and maybe instability.

This changes the combobox to let you choose a specific source node/subprocessor combination - for example, "File Reader 111/0" is the first subprocessor of the File Reader with node ID 111. Because there is now only one subprocessor being drawn, we only have to keep track of one current sample rate rather than an array of one per channel; however, I also added maps from subprocessor ID to sample rate and # of channels in the node, so that switching from one subproc to another works correctly.

As a side effect, we can now easily fix the issue brought up in #277 of Network Events TTLs not showing up, because we can use the information (i.e. # of samples) from the subprocessor that is being drawn to infer how to draw events with no associated continuous data. A simple way to do this is to treat any event channels with a sample rate of 0 as "standalone" events not corresponding to continuous data. I'm also making open-ephys-plugins/ZMQPlugins#2 that changes the Network Events event channels to have sample rate 0 so that this will work.

There are a bunch of changes, including some style things I did just to get rid of warnings in the process of working through the LFP Viewer code, so definitely ask if some parts don't look right/make sense!