### PR TITLE
Fix uninitialized use of numChannels in GenericEditor.cpp

### DIFF
--- a/Source/Processors/Editors/GenericEditor.cpp
+++ b/Source/Processors/Editors/GenericEditor.cpp
@@ -512,21 +512,24 @@ void GenericEditor::update()
 
     //std::cout << "Editor for ";
 
-    GenericProcessor* p = (GenericProcessor*) getProcessor();
+    GenericProcessor* p = (GenericProcessor*)getProcessor();
 
     // std::cout << p->getName() << " updating settings." << std::endl;
 
-    int numChannels;
+    updateSettings();
 
-	updateSettings();
+    int numChannels;
+    if (!p->isSink())
+    {
+        numChannels = p->getNumOutputs();
+    }
+    else
+    {
+        numChannels = p->getNumInputs();
+    }
 
     if (channelSelector != 0)
     {
-        if (!p->isSink())
-            numChannels = p->getNumOutputs();
-        else
-            numChannels = p->getNumInputs();
-
         channelSelector->setNumChannels(numChannels);
 
         for (int i = 0; i < numChannels; i++)


### PR DESCRIPTION
This is a tiny issue that I'm not sure why I haven't seen before.... There's a use of a local variable `numChannels` before it is initialized for processors that do not have a `channelSelector`, i.e. utilities. When I was running in debug mode and this happened, Windows gave me an error with a big red X saying this was a Bad Thing. Even though in this case I don't think it matters, it's good practice not to read uninitialized variables and I appreciate the strictness.