### PR TITLE
Prevent crash when recording again after recording session with thread turned off

### DIFF
--- a/Source/Processors/RecordNode/EventQueue.h
+++ b/Source/Processors/RecordNode/EventQueue.h
@@ -77,14 +77,14 @@ public:
 	void reset()
 	{
 		m_data.clear();
-        m_fifo.reset();
+		m_fifo.reset();
 		m_data.resize(m_fifo.getTotalSize());
 	}
 
 	void resize(int size)
 	{
-        m_fifo.setTotalSize(size);
-        reset();
+		m_fifo.setTotalSize(size);
+		reset();
 	}
 
 	void addEvent(const EventClass& ev, int64 t, int extra = 0)

--- a/Source/Processors/RecordNode/EventQueue.h
+++ b/Source/Processors/RecordNode/EventQueue.h
@@ -77,14 +77,14 @@ public:
 	void reset()
 	{
 		m_data.clear();
+        m_fifo.reset();
 		m_data.resize(m_fifo.getTotalSize());
 	}
 
 	void resize(int size)
 	{
-		m_data.clear();
-		m_fifo.setTotalSize(size);
-		m_data.resize(size);
+        m_fifo.setTotalSize(size);
+        reset();
 	}
 
 	void addEvent(const EventClass& ev, int64 t, int extra = 0)

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -476,7 +476,7 @@ void RecordNode::handleEvent(const EventChannel* eventInfo, const MidiMessage& e
 					eventIndex = getEventChannelIndex(Event::getSourceIndex(event), Event::getSourceID(event), Event::getSubProcessorIdx(event));
 				else
 					eventIndex = -1;
-				if (isRecording)
+				if (isRecording && shouldRecord)
 					m_eventQueue->addEvent(event, timestamp, eventIndex);
             }
     }
@@ -565,7 +565,7 @@ int RecordNode::addSpikeElectrode(const SpikeChannel* elec)
 
 void RecordNode::writeSpike(const SpikeEvent* spike, const SpikeChannel* spikeElectrode)
 {
-	if (isRecording)
+	if (isRecording && shouldRecord)
 	{
 		int electrodeIndex = getSpikeChannelIndex(spikeElectrode->getSourceIndex(), spikeElectrode->getSourceNodeID(), spikeElectrode->getSubProcessorIdx());
 		if (electrodeIndex >= 0)


### PR DESCRIPTION
The following sequence of actions currently crashes the GUI:

* Turn the record thread off in the recording options
* Make a recording (of course, the data doesn't get saved through the record thread, but maybe some plugin makes its own recording somehow)
* Turn the record thread on again
* Try to make a recording.

This happens because events and spikes are still getting added to the record thread's queues when it's not running, which are never being read. Then, when the queues get cleared when starting the real recording, the `AbstractFifo` doesn't get properly reset, so it reports that there are events and spikes available that have actually been cleared, resulting in a null pointer dereference.

It seems to me that both behaviors are wrong, i.e. the events and spikes shouldn't be added when the record thread is off, and also clearing the queues should reset the `AbstractFifo`. So that's what this PR does. 