### PR TITLE
Fix audio node inconsistencies and allow playback of one channel

### DIFF
--- a/Source/Processors/AudioNode/AudioNode.cpp
+++ b/Source/Processors/AudioNode/AudioNode.cpp
@@ -31,9 +31,10 @@ AudioNode::AudioNode()
 
     settings.numInputs = 4096;
     settings.numOutputs = 2;
-    nextAvailableChannel = 2;
 
     updatePlaybackBuffer();
+
+    nextAvailableChannel = 2; // keep first two channels empty
 
     tempBuffer = new AudioSampleBuffer(16, 1024);
 
@@ -56,7 +57,8 @@ AudioProcessorEditor* AudioNode::createEditor()
 void AudioNode::resetConnections()
 {
     settings.numInputs = 2; // "dummy" inputs that are actually just outputs
-    nextAvailableChannel = 2;
+    nextAvailableChannel = 2; // start connections at channel 2
+    wasConnected = false;
 
     dataChannelArray.clear();
 

--- a/Source/Processors/AudioNode/AudioNode.cpp
+++ b/Source/Processors/AudioNode/AudioNode.cpp
@@ -29,12 +29,13 @@ AudioNode::AudioNode()
     : GenericProcessor("Audio Node"), audioEditor(0), volume(0.00001f), noiseGateLevel(0.0f)
 {
 
-    settings.numInputs = 4096;
+    // settings.numInputs = 4096;
     settings.numOutputs = 2;
 
-    updatePlaybackBuffer();
+    //updatePlaybackBuffer();
 
-    nextAvailableChannel = 2; // keep first two channels empty
+    //nextAvailableChannel = 2; // keep first two channels empty
+    resetConnections();
 
     tempBuffer = new AudioSampleBuffer(16, 1024);
 

--- a/Source/Processors/AudioNode/AudioNode.cpp
+++ b/Source/Processors/AudioNode/AudioNode.cpp
@@ -31,11 +31,9 @@ AudioNode::AudioNode()
 
     settings.numInputs = 4096;
     settings.numOutputs = 2;
+    nextAvailableChannel = 2;
 
-    // 128 inputs, 2 outputs (left and right channel)
-    setPlayConfigDetails(getNumInputs(), getNumOutputs(), 44100.0, 128);
-
-    nextAvailableChannel = 2; // keep first two channels empty
+    updatePlaybackBuffer();
 
     tempBuffer = new AudioSampleBuffer(16, 1024);
 
@@ -57,12 +55,18 @@ AudioProcessorEditor* AudioNode::createEditor()
 
 void AudioNode::resetConnections()
 {
-
-    nextAvailableChannel = 2; // start connections at channel 2
-    wasConnected = false;
+    settings.numInputs = 2; // "dummy" inputs that are actually just outputs
+    nextAvailableChannel = 2;
 
     dataChannelArray.clear();
 
+    updatePlaybackBuffer();
+}
+
+void AudioNode::registerProcessor(const GenericProcessor* sourceNode)
+{
+    settings.numInputs += sourceNode->getNumOutputs();
+    updatePlaybackBuffer();
 }
 
 void AudioNode::updateBufferSize()
@@ -94,7 +98,7 @@ void AudioNode::setChannel(const DataChannel* ch)
 void AudioNode::setChannelStatus(const DataChannel* chan, bool status)
 {
 
-    setChannel(chan); // add 2 to account for 2 output channels
+    setChannel(chan);
 
     enableCurrentChannel(status);
 
@@ -116,11 +120,7 @@ void AudioNode::enableCurrentChannel(bool state)
 
 void AudioNode::addInputChannel(GenericProcessor* sourceNode, int chan)
 {
-
-
     int channelIndex = getNextChannel(false);
-
-    //setPlayConfigDetails(channelIndex+1,0,44100.0,128);
 
     auto dataChannel = sourceNode->getDataChannel(chan);
     auto dataChannelCopy = new DataChannel(*dataChannel);
@@ -132,7 +132,7 @@ void AudioNode::addInputChannel(GenericProcessor* sourceNode, int chan)
 
 void AudioNode::updatePlaybackBuffer()
 {
-	setPlayConfigDetails(dataChannelArray.size(), 0, 44100.0, 128);
+	setPlayConfigDetails(getNumInputs(), 2, 44100.0, 128);
 }
 
 void AudioNode::setParameter(int parameterIndex, float newValue)
@@ -256,12 +256,13 @@ void AudioNode::process(AudioSampleBuffer& buffer)
         AudioSampleBuffer* overflowBuffer;
         AudioSampleBuffer* backupBuffer;
 
-        if (dataChannelArray.size() > 0) // we have some channels
+        int nInputs = dataChannelArray.size();
+        if (nInputs > 0) // we have some channels
         {
 
 //            tempBuffer->clear();
 
-            for (int i = 0; i < buffer.getNumChannels()-2; i++) // cycle through them all
+            for (int i = 0; i < nInputs; i++) // cycle through them all
             {
 
                 if (dataChannelArray[i]->isMonitored())

--- a/Source/Processors/AudioNode/AudioNode.h
+++ b/Source/Processors/AudioNode/AudioNode.h
@@ -129,6 +129,9 @@ public:
 	//Called by ProcessorGraph
 	void updateRecordChannelIndexes();
 
+    // expand # of inputs for each connected processor
+    void registerProcessor(const GenericProcessor* sourceNode);
+
 private:
 	void recreateBuffers();
 

--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -364,11 +364,15 @@ void GenericProcessor::update()
 
 		for (int i = 0; i < dataChannelArray.size(); i++)
 		{
-			if (i < m_recordStatus.size())
-				dataChannelArray[i]->setRecordState(m_recordStatus[i]);
-			else
-				if (isSource())
-					dataChannelArray[i]->setRecordState(true);
+            if (i < m_recordStatus.size())
+            {
+                dataChannelArray[i]->setRecordState(m_recordStatus[i]);
+                dataChannelArray[i]->setMonitored(m_monitorStatus[i]);
+            }
+            else if (isSource())
+            {
+                dataChannelArray[i]->setRecordState(true);
+            }
 		}
 	}
 

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -476,18 +476,13 @@ void ProcessorGraph::connectProcessorToAudioAndRecordNodes(GenericProcessor* sou
     if (source == nullptr)
         return;
 
+    getAudioNode()->registerProcessor(source);
     getRecordNode()->registerProcessor(source);
 
     for (int chan = 0; chan < source->getNumOutputs(); chan++)
     {
 
         getAudioNode()->addInputChannel(source, chan);
-
-        // THIS IS A HACK TO MAKE SURE AUDIO NODE KNOWS WHAT THE SAMPLE RATE SHOULD BE
-        // IT CAN CAUSE PROBLEMS IF THE SAMPLE RATE VARIES ACROSS PROCESSORS
-
-		//TODO: See if this causes problems with the newer architectures
-        //getAudioNode()->settings.sampleRate = source->getSampleRate();
 
         addConnection(source->getNodeId(),                   // sourceNodeID
                       chan,                                  // sourceNodeChannelIndex


### PR DESCRIPTION
This fixes the issue where the GUI crashes if you try to run acquisition with just one channel (e.g. from a recording). Since the solution involves making sure the Audio Node always has 2 outputs instead of 0 (which seems like it was an error?), it also might fix audio playback to some degree although I never actually tried that feature before so I don't know if it was broken.

Basically it makes sure the Audio Node always registers 2 more than its number of real inputs as its input degree, and 2 as its output degree. I also made one change in `GenericProcessor.cpp` so that the monitor status of channels in source nodes is maintained across updates (assuming that is what we want, since it seemed like a bug when that wasn't happening).