### PR TITLE
Support on-the-fly sub-processor switching in LFP Viewer

### DIFF
--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -212,7 +212,9 @@ void LfpDisplayCanvas::endAnimation()
 
 void LfpDisplayCanvas::update()
 {
-    nChans = jmax(processor->getNumSubprocessorChannels(), 0);
+    displayBufferSize = displayBuffer->getNumSamples();
+
+	nChans = jmax(processor->getNumSubprocessorChannels(), 0);
 
     std::cout << "Num chans: " << nChans << std::endl;
 
@@ -631,6 +633,7 @@ void LfpDisplayCanvas::setDrawableSubprocessor(uint32 sp)
 {
 	drawableSubprocessor = sp;
 	std::cout << "Setting LFP canvas subprocessor to " << sp << std::endl;
+	displayBuffer = processor->getDisplayBufferAddress();
 	update();
 }
 
@@ -816,7 +819,7 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
 	selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] = 4;
 	rangeGain[DataChannel::HEADSTAGE_CHANNEL] = 1; //uV
 	rangeSteps[DataChannel::HEADSTAGE_CHANNEL] = 10;
-    rangeUnits.add("uV");
+    rangeUnits.add(CharPointer_UTF8("\xC2\xB5V"));
     typeNames.add("DATA");
 
     UtilityButton* tbut;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -182,7 +182,7 @@ private:
     //float waves[MAX_N_CHAN][MAX_N_SAMP*2]; // we need an x and y point for each sample
 
     LfpDisplayNode* processor;
-    AudioSampleBuffer* displayBuffer; // sample wise data buffer for display
+    std::shared_ptr<AudioSampleBuffer> displayBuffer; // sample wise data buffer for display
     ScopedPointer<AudioSampleBuffer> screenBuffer; // subsampled buffer- one int per pixel
 
     //'define 3 buffers for min mean and max for better plotting of spikes

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -58,12 +58,12 @@ LfpDisplayEditor::~LfpDisplayEditor()
 
 void LfpDisplayEditor::startAcquisition()
 {
-	subprocessorSelection->setEnabled(false);
+	//subprocessorSelection->setEnabled(false);
 }
 
 void LfpDisplayEditor::stopAcquisition()
 {
-	subprocessorSelection->setEnabled(true);
+	//subprocessorSelection->setEnabled(true);
 }
 
 Visualizer* LfpDisplayEditor::createNewCanvas()
@@ -168,6 +168,11 @@ void LfpDisplayEditor::updateSubprocessorSelectorOptions()
         subprocessorSampleRateLabel->setText(sampleRateLabelText, dontSendNotification);
         //setCanvasDrawableSubprocessor(-1);
     }
+}
+
+SortedSet<uint32> LfpDisplayEditor::getInputSubprocessors()
+{
+	return inputSubprocessors;
 }
 
 void LfpDisplayEditor::saveVisualizerParameters(XmlElement* xml)

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.h
@@ -77,6 +77,8 @@ public:
      */
     void updateSubprocessorSelectorOptions();
 
+	SortedSet<uint32> getInputSubprocessors();
+
 private:
     
     SortedSet<uint32> inputSubprocessors;

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -81,7 +81,10 @@ void LfpDisplayNode::updateSettings()
     
     numSubprocessors = numChannelsInSubprocessor.size();
 
-	displayBuffers.resize(numSubprocessors, std::make_shared<AudioSampleBuffer> (8, 100));
+	displayBuffers.clear();
+
+    for (int i = 0; i < numSubprocessors; i++)
+        displayBuffers.push_back(std::make_shared<AudioSampleBuffer> (8, 100));
 
 	displayBufferIndices.resize(numSubprocessors);
 

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.h
@@ -62,7 +62,7 @@ public:
 
 	void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int samplePosition = 0) override;
 
-    AudioSampleBuffer* getDisplayBufferAddress() const { return displayBuffers[allSubprocessors.indexOf(subprocessorToDraw)].get(); }
+    std::shared_ptr<AudioSampleBuffer> getDisplayBufferAddress() const { return displayBuffers[allSubprocessors.indexOf(subprocessorToDraw)]; }
 
     int getDisplayBufferIndex (int chan) const { return displayBufferIndices[allSubprocessors.indexOf(subprocessorToDraw)][chan]; }
 
@@ -81,10 +81,8 @@ private:
     void initializeEventChannels();
     void finalizeEventChannels();
 
-    std::unique_ptr<AudioSampleBuffer> displayBuffer;
 	std::vector<std::shared_ptr<AudioSampleBuffer>> displayBuffers;
 
-    Array<int> displayBufferIndex;
 	std::vector<std::vector<int>> displayBufferIndices;
 	Array<int> channelIndices;
 

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.h
@@ -62,9 +62,9 @@ public:
 
 	void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int samplePosition = 0) override;
 
-    AudioSampleBuffer* getDisplayBufferAddress() const { return displayBuffer; }
+    AudioSampleBuffer* getDisplayBufferAddress() const { return displayBuffers[allSubprocessors.indexOf(subprocessorToDraw)].get(); }
 
-    int getDisplayBufferIndex (int chan) const { return displayBufferIndex[chan]; }
+    int getDisplayBufferIndex (int chan) const { return displayBufferIndices[allSubprocessors.indexOf(subprocessorToDraw)][chan]; }
 
     CriticalSection* getMutex() { return &displayMutex; }
 
@@ -81,9 +81,13 @@ private:
     void initializeEventChannels();
     void finalizeEventChannels();
 
-    ScopedPointer<AudioSampleBuffer> displayBuffer;
+    std::unique_ptr<AudioSampleBuffer> displayBuffer;
+	std::vector<std::shared_ptr<AudioSampleBuffer>> displayBuffers;
 
     Array<int> displayBufferIndex;
+	std::vector<std::vector<int>> displayBufferIndices;
+	Array<int> channelIndices;
+
     Array<uint32> eventSourceNodes;
 
     float displayGain; //
@@ -100,6 +104,7 @@ private:
 
     int numSubprocessors;
 	uint32 subprocessorToDraw;
+	SortedSet<uint32> allSubprocessors; 
 	std::map<uint32, int> numChannelsInSubprocessor;
 	std::map<uint32, float> subprocessorSampleRate;
 


### PR DESCRIPTION
- This feature allows one to switch between different sub-processors in the LFP viewer while data acquisition is active. Sub-processors do not need to have the same channel count or same sample count.

- Works with two file readers merged into a single LFP viewer, as well as neuropix-pxi plugin with single or multiple probes connected to it (one can switch between AP & LFP bands of all connected probes). 