### PR TITLE
CAR fix because of xml being loaded twice

### DIFF
--- a/Plugins/CAR/CAR.cpp
+++ b/Plugins/CAR/CAR.cpp
@@ -135,7 +135,7 @@ void CAR::setAffectedChannelState (int channel, bool newState)
     if (! newState)
         m_affectedChannels.removeFirstMatchingValue (channel);
     else
-        m_affectedChannels.add (channel);
+        m_affectedChannels.addIfNotAlreadyThere (channel);
 }
 
 void CAR::saveCustomChannelParametersToXml(XmlElement* channelElement,

--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -1038,38 +1038,38 @@ void GenericProcessor::loadFromXml()
 	update(); // make sure settings are updated
 	if (parametersAsXml != nullptr)
 	{
-		if (!m_isParamsWereLoaded)
-		{
-			std::cout << "Loading parameters for " << m_name << std::endl;
+        if (!m_isParamsWereLoaded)
+        {
+            std::cout << "Loading parameters for " << m_name << std::endl;
 
-			// use parametersAsXml to restore state
-			loadCustomParametersFromXml();
+            // use parametersAsXml to restore state
+            loadCustomParametersFromXml();
 
-			// load editor parameters
-			forEachXmlChildElement(*parametersAsXml, xmlNode)
-			{
-				if (xmlNode->hasTagName("EDITOR"))
-				{
-					getEditor()->loadEditorParameters(xmlNode);
-				}
-			}
-		}
-		forEachXmlChildElement(*parametersAsXml, xmlNode)
-		{
-			if (xmlNode->hasTagName("CHANNEL"))
-			{
-				loadChannelParametersFromXml(xmlNode, InfoObjectCommon::DATA_CHANNEL);
-			}
-			else if (xmlNode->hasTagName("EVENTCHANNEL"))
-			{
-				loadChannelParametersFromXml(xmlNode, InfoObjectCommon::EVENT_CHANNEL);
-			}
-			else if (xmlNode->hasTagName("SPIKECHANNEL"))
-			{
-				loadChannelParametersFromXml(xmlNode, InfoObjectCommon::SPIKE_CHANNEL);
-			}
-		}
+            // load editor parameters
+            forEachXmlChildElement(*parametersAsXml, xmlNode)
+            {
+                if (xmlNode->hasTagName("EDITOR"))
+                {
+                    getEditor()->loadEditorParameters(xmlNode);
+                }
+            }
 
+            forEachXmlChildElement(*parametersAsXml, xmlNode)
+            {
+                if (xmlNode->hasTagName("CHANNEL"))
+                {
+                    loadChannelParametersFromXml(xmlNode, InfoObjectCommon::DATA_CHANNEL);
+                }
+                else if (xmlNode->hasTagName("EVENTCHANNEL"))
+                {
+                    loadChannelParametersFromXml(xmlNode, InfoObjectCommon::EVENT_CHANNEL);
+                }
+                else if (xmlNode->hasTagName("SPIKECHANNEL"))
+                {
+                    loadChannelParametersFromXml(xmlNode, InfoObjectCommon::SPIKE_CHANNEL);
+                }
+            }
+        }
 	}
 
 	m_isParamsWereLoaded = true;


### PR DESCRIPTION
Found a bug in how OE handles loading in .xml files. It seems since the upgrade to cmake, xml files are loaded in **twice**! Specifically in CAR this caused channels to get added to the reference list multiple times. The referenced average was then being subtracted from the channels twice. 

This PR is a quick fix that only adds channels to the list if not already present. I wanted to get this PR out ASAP as I'm sure others have been affected by this. A broader look should be had at other plugins that might be affected, or if the double load can/should be removed altogether.

Mark