### PR TITLE
FileReader now starts from beginning of file

### DIFF
--- a/Source/Processors/FileReader/FileReader.cpp
+++ b/Source/Processors/FileReader/FileReader.cpp
@@ -168,7 +168,10 @@ bool FileReader::enable()
 	bufferA.malloc(currentNumChannels * m_bufferSize * BUFFER_WINDOW_CACHE_SIZE);
 	bufferB.malloc(currentNumChannels * m_bufferSize * BUFFER_WINDOW_CACHE_SIZE);
 
-	readAndFillBufferCache(bufferA); // pre-fill the front buffer with a blocking read
+        // reset stream to beginning
+        input->seekTo (startSample);
+        currentSample = startSample;
+        readAndFillBufferCache(bufferA); // pre-fill the front buffer with a blocking read
 
 	// set the backbuffer so that on the next call to process() we start with bufferA and buffer
 	// cache window id = 0


### PR DESCRIPTION
This is a small patch that makes the file reader start from the beginning of the input file whenever the "Play" button is pressed. I think that was the intended behavior, given that the timestamps reset when the "Play" button is pressed.