### PR TITLE
Event triggers in lfpdisplaynode

### DIFF
--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -43,8 +43,10 @@ LfpDisplayNode::LfpDisplayNode()
         arrayOfOnes[n] = 1;
     }
 
-	subprocessorToDraw = 0;
-	numSubprocessors = -1;
+    subprocessorToDraw = 0;
+    numSubprocessors = -1;
+    triggerSource = -1;
+    latestTrigger = -1;
 }
 
 
@@ -66,29 +68,29 @@ void LfpDisplayNode::updateSettings()
 
     std::cout << "Setting num inputs on LfpDisplayNode to " << getNumInputs() << std::endl;
 
-	numChannelsInSubprocessor.clear();
+    numChannelsInSubprocessor.clear();
     subprocessorSampleRate.clear();
 
-	for (int i = 0; i < getNumInputs(); i++)
-	{
+    for (int i = 0; i < getNumInputs(); i++)
+    {
         uint32 channelSubprocessor = getDataSubprocId(i);
 
         numChannelsInSubprocessor.insert({ channelSubprocessor, 0 }); // (if not already there)
         numChannelsInSubprocessor[channelSubprocessor]++;
 
         subprocessorSampleRate.insert({ channelSubprocessor, getDataChannel(i)->getSampleRate() });
-	}
+    }
     
     numSubprocessors = numChannelsInSubprocessor.size();
 
-	displayBuffers.clear();
+    displayBuffers.clear();
 
     for (int i = 0; i < numSubprocessors; i++)
         displayBuffers.push_back(std::make_shared<AudioSampleBuffer> (8, 100));
 
-	displayBufferIndices.resize(numSubprocessors);
+    displayBufferIndices.resize(numSubprocessors);
 
-	channelIndices.resize(numSubprocessors);
+    channelIndices.resize(numSubprocessors);
 
     if (numChannelsInSubprocessor.find(subprocessorToDraw) == numChannelsInSubprocessor.end())
     {
@@ -108,7 +110,7 @@ void LfpDisplayNode::updateSettings()
     int numChans = getNumSubprocessorChannels();
     int srate = getSubprocessorSampleRate(subprocessorToDraw);
 
-	std::cout << "Re-setting num inputs on LfpDisplayNode to " << numChans << std::endl;
+    std::cout << "Re-setting num inputs on LfpDisplayNode to " << numChans << std::endl;
     if (numChans > 0)
     {
         std::cout << "Sample rate = " << srate << std::endl;
@@ -117,19 +119,19 @@ void LfpDisplayNode::updateSettings()
     eventSourceNodes.clear();
     ttlState.clear();
 
-	for (int i = 0; i < eventChannelArray.size(); ++i)
-	{
-		uint32 sourceId = getEventSourceId(eventChannelArray[i]);
+    for (int i = 0; i < eventChannelArray.size(); ++i)
+    {
+        uint32 sourceId = getEventSourceId(eventChannelArray[i]);
  
-		if (!eventSourceNodes.contains(sourceId))
-		{
-			eventSourceNodes.add(sourceId);
-		}
-	}
+        if (!eventSourceNodes.contains(sourceId))
+        {
+            eventSourceNodes.add(sourceId);
+        }
+    }
 
     for (int i = 0; i < eventSourceNodes.size(); ++i)
     {
-		std::cout << "Adding channel " << numChans + i << " for event source node " << eventSourceNodes[i] << std::endl;
+        std::cout << "Adding channel " << numChans + i << " for event source node " << eventSourceNodes[i] << std::endl;
 
         ttlState[eventSourceNodes[i]] = 0;
     }
@@ -137,8 +139,8 @@ void LfpDisplayNode::updateSettings()
     resizeBuffer();
     
     // update the editor's subprocessor selection display and sample rate
-	LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
-	ed->updateSubprocessorSelectorOptions();
+    LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
+    ed->updateSubprocessorSelectorOptions();
 }
 
 uint32 LfpDisplayNode::getEventSourceId(const EventChannel* event)
@@ -164,9 +166,9 @@ uint32 LfpDisplayNode::getDataSubprocId(int chan) const
 void LfpDisplayNode::setSubprocessor(uint32 sp)
 {
 
-	subprocessorToDraw = sp;
+    subprocessorToDraw = sp;
     resizeBuffer();
-	std::cout << "LfpDisplayNode setting subprocessor to " << sp << std::endl;	
+    std::cout << "LfpDisplayNode setting subprocessor to " << sp << std::endl;    
 }
 
 uint32 LfpDisplayNode::getSubprocessor() const
@@ -195,44 +197,44 @@ float LfpDisplayNode::getSubprocessorSampleRate(uint32 subprocId)
 
 bool LfpDisplayNode::resizeBuffer()
 {
-	LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
-	allSubprocessors = ed->getInputSubprocessors();
-	
-	int totalResized = 0;
+    LfpDisplayEditor * ed = (LfpDisplayEditor*)getEditor();
+    allSubprocessors = ed->getInputSubprocessors();
+    
+    int totalResized = 0;
 
     if (true)
     {
-	    ScopedLock displayLock(displayMutex);
+        ScopedLock displayLock(displayMutex);
 
         for (int currSubproc = 0; currSubproc < numSubprocessors ; currSubproc++)
-	    {
-		    int nSamples = (int)getSubprocessorSampleRate(allSubprocessors[currSubproc]) * bufferLength;
-		    int nInputs = numChannelsInSubprocessor[allSubprocessors[currSubproc]];
+        {
+            int nSamples = (int)getSubprocessorSampleRate(allSubprocessors[currSubproc]) * bufferLength;
+            int nInputs = numChannelsInSubprocessor[allSubprocessors[currSubproc]];
 
-		    std::cout << "Resizing buffer for Subprocessor " << allSubprocessors[currSubproc] << ". Samples: " << nSamples << ", Inputs: " << nInputs << std::endl;
+            std::cout << "Resizing buffer for Subprocessor " << allSubprocessors[currSubproc] << ". Samples: " << nSamples << ", Inputs: " << nInputs << std::endl;
 
-		    if (nSamples > 0 && nInputs > 0)
-		    {
-			    abstractFifo.setTotalSize(nSamples);
-			    displayBuffers[currSubproc]->setSize(nInputs + 1, nSamples); // add extra channel for TTLs
-			    displayBuffers[currSubproc]->clear();
+            if (nSamples > 0 && nInputs > 0)
+            {
+                abstractFifo.setTotalSize(nSamples);
+                displayBuffers[currSubproc]->setSize(nInputs + 1, nSamples); // add extra channel for TTLs
+                displayBuffers[currSubproc]->clear();
 
-			    displayBufferIndices[currSubproc].clear();
-			    displayBufferIndices[currSubproc].insert(displayBufferIndices[currSubproc].end(), nInputs + 1, 0);
+                displayBufferIndices[currSubproc].clear();
+                displayBufferIndices[currSubproc].insert(displayBufferIndices[currSubproc].end(), nInputs + 1, 0);
 
-			    channelIndices.clear();
+                channelIndices.clear();
 
-			    totalResized++;
-		    }
-	    }
+                totalResized++;
+            }
+        }
     }
-	
-	if (totalResized == numSubprocessors)
-	{
-		return true;
-	}
+    
+    if (totalResized == numSubprocessors)
+    {
+        return true;
+    }
 
-	return false;
+    return false;
 
 }
 
@@ -240,16 +242,16 @@ bool LfpDisplayNode::resizeBuffer()
 bool LfpDisplayNode::enable()
 {
 
-	if (resizeBuffer())
-	{
-		LfpDisplayEditor* editor = (LfpDisplayEditor*)getEditor();
-		editor->enable();
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+    if (resizeBuffer())
+    {
+        LfpDisplayEditor* editor = (LfpDisplayEditor*)getEditor();
+        editor->enable();
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 
 }
 
@@ -298,19 +300,23 @@ void LfpDisplayNode::handleEvent(const EventChannel* eventInfo, const MidiMessag
             return;
         }
         
-		//std::cout << "Received event on channel " << eventChannel << std::endl;
-		//std::cout << "Copying to channel " << channelForEventSource[eventSourceNodeId] << std::endl;
+        //std::cout << "Received event on channel " << eventChannel << std::endl;
+        //std::cout << "Copying to channel " << channelForEventSource[eventSourceNodeId] << std::endl;
         
         if (eventId == 1)
         {
             ttlState[eventSourceNodeId] |= (1LL << eventChannel);
+            if (eventChannel==triggerSource)
+            {
+                latestCurrentTrigger = eventTime;
+            }
         }
         else
         {
             ttlState[eventSourceNodeId] &= ~(1LL << eventChannel);
         }
 
-		int subProcIndex = allSubprocessors.indexOf(eventSourceNodeId);
+        int subProcIndex = allSubprocessors.indexOf(eventSourceNodeId);
 
         const int chan          = numChannelsInSubprocessor[eventSourceNodeId];
         const int index         = (displayBufferIndices[subProcIndex][chan] + eventTime) % displayBuffers[subProcIndex]->getNumSamples();
@@ -353,62 +359,68 @@ void LfpDisplayNode::handleEvent(const EventChannel* eventInfo, const MidiMessag
 void LfpDisplayNode::initializeEventChannels()
 {
 
-	//std::cout << "Initializing events..." << std::endl
-    
-	for (int i = 0 ; i < numSubprocessors ; i++)
-	{
-		const int chan = numChannelsInSubprocessor[allSubprocessors[i]];
-		const int nSamples = getNumSourceSamples(allSubprocessors[i]);
-		const int samplesLeft   = displayBuffers[i]->getNumSamples() - displayBufferIndices[i][chan];
-		
-		if (nSamples < samplesLeft)
-		{
+    //std::cout << "Initializing events..." << std::endl
+    latestCurrentTrigger = -1;
+    for (int i = 0 ; i < numSubprocessors ; i++)
+    {
+        const int chan = numChannelsInSubprocessor[allSubprocessors[i]];
+        const int nSamples = getNumSourceSamples(allSubprocessors[i]);
+        const int samplesLeft   = displayBuffers[i]->getNumSamples() - displayBufferIndices[i][chan];
+        
+        if (nSamples < samplesLeft)
+        {
 
-			displayBuffers[i]->copyFrom (chan,                                      // destChannel
-									 displayBufferIndices[i][chan],             // destStartSample
-									 arrayOfOnes,                               // source
-									 nSamples,                                  // numSamples
-									 float (ttlState[subprocessorToDraw]));     // gain
-		}
-		else
-		{
-			int extraSamples = nSamples - samplesLeft;
+            displayBuffers[i]->copyFrom (chan,                                      // destChannel
+                                     displayBufferIndices[i][chan],             // destStartSample
+                                     arrayOfOnes,                               // source
+                                     nSamples,                                  // numSamples
+                                     float (ttlState[subprocessorToDraw]));     // gain
+        }
+        else
+        {
+            int extraSamples = nSamples - samplesLeft;
 
-			displayBuffers[i]->copyFrom (chan,                                      // destChannel
-									 displayBufferIndices[i][chan],             // destStartSample
-									 arrayOfOnes,                               // source
-									 samplesLeft,                               // numSamples
-									 float (ttlState[subprocessorToDraw]));     // gain
+            displayBuffers[i]->copyFrom (chan,                                      // destChannel
+                                     displayBufferIndices[i][chan],             // destStartSample
+                                     arrayOfOnes,                               // source
+                                     samplesLeft,                               // numSamples
+                                     float (ttlState[subprocessorToDraw]));     // gain
 
-			displayBuffers[i]->copyFrom (chan,                                      // destChannel
-									 0,                                         // destStartSample
-									 arrayOfOnes,                               // source
-									 extraSamples,                              // numSamples
-									 float (ttlState[subprocessorToDraw]));     // gain
-		}
-	}
+            displayBuffers[i]->copyFrom (chan,                                      // destChannel
+                                     0,                                         // destStartSample
+                                     arrayOfOnes,                               // source
+                                     extraSamples,                              // numSamples
+                                     float (ttlState[subprocessorToDraw]));     // gain
+        }
+    }
 }
 
 void LfpDisplayNode::finalizeEventChannels()
 {
-	for (int i = 0 ; i < numSubprocessors ; i++){	
-		const int chan          = numChannelsInSubprocessor[allSubprocessors[i]];
-		const int samplesLeft   = displayBuffers[i]->getNumSamples() - displayBufferIndices[i][chan];
-		const int nSamples      = getNumSourceSamples(allSubprocessors[i]);
+    for (int i = 0 ; i < numSubprocessors ; i++){    
+        const int chan          = numChannelsInSubprocessor[allSubprocessors[i]];
+        const int index = displayBufferIndices[i][chan];
+        const int samplesLeft   = displayBuffers[i]->getNumSamples() - index;
+        const int nSamples      = getNumSourceSamples(allSubprocessors[i]);
         
-		int newIdx = 0;
+        int newIdx = 0;
         
-		if (nSamples < samplesLeft)
-		{
-			newIdx = displayBufferIndices[i][chan] + nSamples;
-		}
-		else
-		{
-			newIdx = nSamples - samplesLeft;
-		}
+        if (nSamples < samplesLeft)
+        {
+            newIdx = displayBufferIndices[i][chan] + nSamples;
+        }
+        else
+        {
+            newIdx = nSamples - samplesLeft;
+        }
         
-		displayBufferIndices[i][chan] = newIdx;
-	}
+        displayBufferIndices[i][chan] = newIdx;
+        if (latestCurrentTrigger >= 0)
+        {
+            latestTrigger = latestCurrentTrigger + index;
+        }
+    }
+        
 }
 
 
@@ -417,68 +429,84 @@ void LfpDisplayNode::process (AudioSampleBuffer& buffer)
     // 1. place any new samples into the displayBuffer
     //std::cout << "Display node sample count: " << nSamples << std::endl; ///buffer.getNumSamples() << std::endl;
 
-	if (true)
-	{
-		ScopedLock displayLock(displayMutex);
+    if (true)
+    {
+        ScopedLock displayLock(displayMutex);
 
-		if (true)
-		{
-			initializeEventChannels();
-			checkForEvents(); // see if we got any TTL events
-			finalizeEventChannels();
-		}
+        if (true)
+        {
+            initializeEventChannels();
+            checkForEvents(); // see if we got any TTL events
+            finalizeEventChannels();
+        }
 
-		if (true)
-		{
-			int channelIndex = -1;
-			channelIndices.insertMultiple(0, -1, numSubprocessors);
-			uint32 subProcId = 0;
-			int currSubproc = -1;
+        if (true)
+        {
+            int channelIndex = -1;
+            channelIndices.insertMultiple(0, -1, numSubprocessors);
+            uint32 subProcId = 0;
+            int currSubproc = -1;
 
-			for (int chan = 0; chan < buffer.getNumChannels(); ++chan)
-			{
-				subProcId =  getDataSubprocId(chan);
-				currSubproc = allSubprocessors.indexOf(subProcId);
+            for (int chan = 0; chan < buffer.getNumChannels(); ++chan)
+            {
+                subProcId =  getDataSubprocId(chan);
+                currSubproc = allSubprocessors.indexOf(subProcId);
 
-				channelIndices.set(currSubproc, channelIndices[currSubproc] + 1);
+                channelIndices.set(currSubproc, channelIndices[currSubproc] + 1);
 
-				const int samplesLeft = displayBuffers[currSubproc]->getNumSamples() - displayBufferIndices[currSubproc][channelIndices[currSubproc]];
-				const int nSamples = getNumSamples(chan);
+                const int samplesLeft = displayBuffers[currSubproc]->getNumSamples() - displayBufferIndices[currSubproc][channelIndices[currSubproc]];
+                const int nSamples = getNumSamples(chan);
 
-				if (nSamples < samplesLeft)
-				{
-					displayBuffers[currSubproc]->copyFrom(channelIndices[currSubproc],                      // destChannel
-						displayBufferIndices[currSubproc][channelIndices[currSubproc]],  // destStartSample
-						buffer,                    // source
-						chan,                      // source channel
-						0,                         // source start sample
-						nSamples);                 // numSamples
+                if (nSamples < samplesLeft)
+                {
+                    displayBuffers[currSubproc]->copyFrom(channelIndices[currSubproc],                      // destChannel
+                        displayBufferIndices[currSubproc][channelIndices[currSubproc]],  // destStartSample
+                        buffer,                    // source
+                        chan,                      // source channel
+                        0,                         // source start sample
+                        nSamples);                 // numSamples
 
-					displayBufferIndices[currSubproc][channelIndices[currSubproc]] = displayBufferIndices[currSubproc][channelIndices[currSubproc]] + nSamples;
-				}
-				else
-				{
-					const int extraSamples = nSamples - samplesLeft;
+                    displayBufferIndices[currSubproc][channelIndices[currSubproc]] = displayBufferIndices[currSubproc][channelIndices[currSubproc]] + nSamples;
+                }
+                else
+                {
+                    const int extraSamples = nSamples - samplesLeft;
 
-					displayBuffers[currSubproc]->copyFrom(channelIndices[currSubproc],                      // destChannel
-						displayBufferIndices[currSubproc][channelIndices[currSubproc]],  // destStartSample
-						buffer,                    // source
-						chan,                      // source channel
-						0,                         // source start sample
-						samplesLeft);              // numSamples
+                    displayBuffers[currSubproc]->copyFrom(channelIndices[currSubproc],                      // destChannel
+                        displayBufferIndices[currSubproc][channelIndices[currSubproc]],  // destStartSample
+                        buffer,                    // source
+                        chan,                      // source channel
+                        0,                         // source start sample
+                        samplesLeft);              // numSamples
 
-					displayBuffers[currSubproc]->copyFrom(channelIndices[currSubproc],                      // destChannel
-						0,                         // destStartSample
-						buffer,                    // source
-						chan,                      // source channel
-						samplesLeft,               // source start sample
-						extraSamples);             // numSamples
+                    displayBuffers[currSubproc]->copyFrom(channelIndices[currSubproc],                      // destChannel
+                        0,                         // destStartSample
+                        buffer,                    // source
+                        chan,                      // source channel
+                        samplesLeft,               // source start sample
+                        extraSamples);             // numSamples
 
-					displayBufferIndices[currSubproc][channelIndices[currSubproc]] = extraSamples;
-				}
+                    displayBufferIndices[currSubproc][channelIndices[currSubproc]] = extraSamples;
+                }
 
-			}
-		}
-	}
+            }
+        }
+    }
 }
 
+void LfpDisplayNode::setTriggerSource(int ch) {
+  printf("Trigger source: %i\n", ch);
+  triggerSource = ch;
+}
+
+int LfpDisplayNode::getTriggerSource() const {
+  return triggerSource;
+}
+
+int64 LfpDisplayNode::getLatestTriggerTime() const {
+  return latestTrigger;
+}
+
+void LfpDisplayNode::acknowledgeTrigger() {
+  latestTrigger = -1;
+}

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.h
@@ -60,7 +60,7 @@ public:
     bool enable()   override;
     bool disable()  override;
 
-	void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int samplePosition = 0) override;
+    void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int samplePosition = 0) override;
 
     std::shared_ptr<AudioSampleBuffer> getDisplayBufferAddress() const { return displayBuffers[allSubprocessors.indexOf(subprocessorToDraw)]; }
 
@@ -68,23 +68,27 @@ public:
 
     CriticalSection* getMutex() { return &displayMutex; }
 
-	void setSubprocessor(uint32 sp);
+    void setSubprocessor(uint32 sp);
     uint32 getSubprocessor() const;
 
-	int getNumSubprocessorChannels();
+    int getNumSubprocessorChannels();
 
     float getSubprocessorSampleRate(uint32 subprocId);
 
     uint32 getDataSubprocId(int chan) const;
 
+    void setTriggerSource(int ch);
+    int getTriggerSource() const;
+    int64 getLatestTriggerTime() const;
+    void acknowledgeTrigger();
 private:
     void initializeEventChannels();
     void finalizeEventChannels();
 
-	std::vector<std::shared_ptr<AudioSampleBuffer>> displayBuffers;
+    std::vector<std::shared_ptr<AudioSampleBuffer>> displayBuffers;
 
-	std::vector<std::vector<int>> displayBufferIndices;
-	Array<int> channelIndices;
+    std::vector<std::vector<int>> displayBufferIndices;
+    Array<int> channelIndices;
 
     Array<uint32> eventSourceNodes;
 
@@ -97,14 +101,18 @@ private:
     std::map<uint32, uint64> ttlState;
     float* arrayOfOnes;
     int totalSamples;
+    int triggerSource;
+    int64 latestTrigger; // overall timestamp
+    int latestCurrentTrigger; // within current input buffer
+ 
 
     bool resizeBuffer();
 
     int numSubprocessors;
-	uint32 subprocessorToDraw;
-	SortedSet<uint32> allSubprocessors; 
-	std::map<uint32, int> numChannelsInSubprocessor;
-	std::map<uint32, float> subprocessorSampleRate;
+    uint32 subprocessorToDraw;
+    SortedSet<uint32> allSubprocessors; 
+    std::map<uint32, int> numChannelsInSubprocessor;
+    std::map<uint32, float> subprocessorSampleRate;
 
     CriticalSection displayMutex;
 

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -233,8 +233,12 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
     addAndMakeVisible(showHideOptionsButton);
 
     // init timebases options
-    timebases.add("0.25");
-    timebases.add("0.5");
+    timebases.add("0.010");
+    timebases.add("0.025");
+    timebases.add("0.050");
+    timebases.add("0.100");
+    timebases.add("0.250");
+    timebases.add("0.500");
     timebases.add("1.0");
     timebases.add("2.0");
     timebases.add("3.0");

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -72,21 +72,21 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
         addAndMakeVisible(lfpDisplay->getColourSchemePtr());
     
  //Ranges for neural data
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("25");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("50");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("100");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("250");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("400");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("500");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("750");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("1000");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("2000");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("5000");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("10000");
-	voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("15000");
-	selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] = 4;
-	rangeGain[DataChannel::HEADSTAGE_CHANNEL] = 1; //uV
-	rangeSteps[DataChannel::HEADSTAGE_CHANNEL] = 10;
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("25");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("50");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("100");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("250");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("400");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("500");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("750");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("1000");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("2000");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("5000");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("10000");
+    voltageRanges[DataChannel::HEADSTAGE_CHANNEL].add("15000");
+    selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] = 4;
+    rangeGain[DataChannel::HEADSTAGE_CHANNEL] = 1; //uV
+    rangeSteps[DataChannel::HEADSTAGE_CHANNEL] = 10;
     rangeUnits.add(CharPointer_UTF8("\xC2\xB5V"));
     typeNames.add("DATA");
 
@@ -102,19 +102,19 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
     typeButtons.add(tbut);
     
     //Ranges for AUX/accelerometer data
-	voltageRanges[DataChannel::AUX_CHANNEL].add("25");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("50");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("100");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("250");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("400");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("500");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("750");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("1000");
-	voltageRanges[DataChannel::AUX_CHANNEL].add("2000");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("25");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("50");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("100");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("250");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("400");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("500");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("750");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("1000");
+    voltageRanges[DataChannel::AUX_CHANNEL].add("2000");
     //voltageRanges[DataChannel::AUX_CHANNEL].add("5000");
-	selectedVoltageRange[DataChannel::AUX_CHANNEL] = 9;
-	rangeGain[DataChannel::AUX_CHANNEL] = 0.001f; //mV
-	rangeSteps[DataChannel::AUX_CHANNEL] = 10;
+    selectedVoltageRange[DataChannel::AUX_CHANNEL] = 9;
+    rangeGain[DataChannel::AUX_CHANNEL] = 0.001f; //mV
+    rangeSteps[DataChannel::AUX_CHANNEL] = 10;
     rangeUnits.add("mV");
     typeNames.add("AUX");
     
@@ -130,16 +130,16 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
 
     //Ranges for ADC data
      voltageRanges[DataChannel::ADC_CHANNEL].add("0.01");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("0.05");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("0.1");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("0.5");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("1.0");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("2.0");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("5.0");
-	 voltageRanges[DataChannel::ADC_CHANNEL].add("10.0");
-	 selectedVoltageRange[DataChannel::ADC_CHANNEL] = 8;
-	 rangeGain[DataChannel::ADC_CHANNEL] = 1; //V
-	 rangeSteps[DataChannel::ADC_CHANNEL] = 0.1; //in V
+     voltageRanges[DataChannel::ADC_CHANNEL].add("0.05");
+     voltageRanges[DataChannel::ADC_CHANNEL].add("0.1");
+     voltageRanges[DataChannel::ADC_CHANNEL].add("0.5");
+     voltageRanges[DataChannel::ADC_CHANNEL].add("1.0");
+     voltageRanges[DataChannel::ADC_CHANNEL].add("2.0");
+     voltageRanges[DataChannel::ADC_CHANNEL].add("5.0");
+     voltageRanges[DataChannel::ADC_CHANNEL].add("10.0");
+     selectedVoltageRange[DataChannel::ADC_CHANNEL] = 8;
+     rangeGain[DataChannel::ADC_CHANNEL] = 1; //V
+     rangeSteps[DataChannel::ADC_CHANNEL] = 0.1; //in V
     rangeUnits.add("V");
     typeNames.add("ADC");
 
@@ -153,9 +153,9 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
     addAndMakeVisible(tbut);
     typeButtons.add(tbut);
 
-	selectedVoltageRangeValues[DataChannel::HEADSTAGE_CHANNEL] = voltageRanges[DataChannel::HEADSTAGE_CHANNEL][selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] - 1];
-	selectedVoltageRangeValues[DataChannel::AUX_CHANNEL] = voltageRanges[DataChannel::AUX_CHANNEL][selectedVoltageRange[DataChannel::AUX_CHANNEL] - 1];
-	selectedVoltageRangeValues[DataChannel::ADC_CHANNEL] = voltageRanges[DataChannel::ADC_CHANNEL][selectedVoltageRange[DataChannel::ADC_CHANNEL] - 1];
+    selectedVoltageRangeValues[DataChannel::HEADSTAGE_CHANNEL] = voltageRanges[DataChannel::HEADSTAGE_CHANNEL][selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] - 1];
+    selectedVoltageRangeValues[DataChannel::AUX_CHANNEL] = voltageRanges[DataChannel::AUX_CHANNEL][selectedVoltageRange[DataChannel::AUX_CHANNEL] - 1];
+    selectedVoltageRangeValues[DataChannel::ADC_CHANNEL] = voltageRanges[DataChannel::ADC_CHANNEL][selectedVoltageRange[DataChannel::ADC_CHANNEL] - 1];
     
     // init channel display skipping options
     channelDisplaySkipOptions.add("All");
@@ -212,20 +212,20 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
     medianOffsetPlottingButton->setToggleState(false, sendNotification);
     addAndMakeVisible(medianOffsetPlottingButton);
 
-	//init channel name toggle
-	showChannelNumberLabel = new Label("showcChannelLabel", "Show channel number instead of name");
-	showChannelNumberLabel->setFont(labelFont);
-	showChannelNumberLabel->setColour(Label::textColourId, labelColour);
-	addAndMakeVisible(showChannelNumberLabel);
+    //init channel name toggle
+    showChannelNumberLabel = new Label("showcChannelLabel", "Show channel number instead of name");
+    showChannelNumberLabel->setFont(labelFont);
+    showChannelNumberLabel->setColour(Label::textColourId, labelColour);
+    addAndMakeVisible(showChannelNumberLabel);
 
-	showChannelNumberButton = new UtilityButton("0", labelFont);
-	showChannelNumberButton->setRadius(5.0f);
-	showChannelNumberButton->setEnabledState(true);
-	showChannelNumberButton->setCorners(true, true, true, true);
-	showChannelNumberButton->addListener(this);
-	showChannelNumberButton->setClickingTogglesState(true);
-	showChannelNumberButton->setToggleState(false, sendNotification);
-	addAndMakeVisible(showChannelNumberButton);
+    showChannelNumberButton = new UtilityButton("0", labelFont);
+    showChannelNumberButton->setRadius(5.0f);
+    showChannelNumberButton->setEnabledState(true);
+    showChannelNumberButton->setCorners(true, true, true, true);
+    showChannelNumberButton->addListener(this);
+    showChannelNumberButton->setClickingTogglesState(true);
+    showChannelNumberButton->setToggleState(false, sendNotification);
+    addAndMakeVisible(showChannelNumberButton);
 
     // init show/hide options button
     showHideOptionsButton = new ShowHideOptionsButton(this);
@@ -283,9 +283,15 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
     colorGroupings.add("8");
     colorGroupings.add("16");
 
+    triggerSources.add("none");
+    for (int k=1; k<=8; k++)
+    {
+        triggerSources.add(String(k));
+    }
+
     rangeSelection = new ComboBox("Voltage range");
-	rangeSelection->addItemList(voltageRanges[DataChannel::HEADSTAGE_CHANNEL], 1);
-	rangeSelection->setSelectedId(selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL], sendNotification);
+    rangeSelection->addItemList(voltageRanges[DataChannel::HEADSTAGE_CHANNEL], 1);
+    rangeSelection->setSelectedId(selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL], sendNotification);
     rangeSelection->setEditableText(true);
     rangeSelection->addListener(this);
     addAndMakeVisible(rangeSelection);
@@ -323,6 +329,12 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
     colorGroupingSelection->setSelectedId(1,sendNotification);
     colorGroupingSelection->addListener(this);
     addAndMakeVisible(colorGroupingSelection);
+
+    triggerSourceSelection = new ComboBox("Trigger Source");
+    triggerSourceSelection->addItemList(triggerSources, 1);
+    triggerSourceSelection->setSelectedId(1, sendNotification);
+    triggerSourceSelection->addListener(this);
+    addAndMakeVisible(triggerSourceSelection);
 
     invertInputButton = new UtilityButton("Invert", Font("Small Text", 13, Font::plain));
     invertInputButton->setRadius(5.0f);
@@ -425,12 +437,12 @@ LfpDisplayOptions::LfpDisplayOptions(LfpDisplayCanvas* canvas_, LfpTimescale* ti
 
     }
 
-	lfpDisplay->setRange(voltageRanges[DataChannel::HEADSTAGE_CHANNEL][selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] - 1].getFloatValue()*rangeGain[DataChannel::HEADSTAGE_CHANNEL]
-		, DataChannel::HEADSTAGE_CHANNEL);
-	lfpDisplay->setRange(voltageRanges[DataChannel::ADC_CHANNEL][selectedVoltageRange[DataChannel::ADC_CHANNEL] - 1].getFloatValue()*rangeGain[DataChannel::ADC_CHANNEL]
-		, DataChannel::ADC_CHANNEL);
-	lfpDisplay->setRange(voltageRanges[DataChannel::AUX_CHANNEL][selectedVoltageRange[DataChannel::AUX_CHANNEL] - 1].getFloatValue()*rangeGain[DataChannel::AUX_CHANNEL]
-		, DataChannel::AUX_CHANNEL);
+    lfpDisplay->setRange(voltageRanges[DataChannel::HEADSTAGE_CHANNEL][selectedVoltageRange[DataChannel::HEADSTAGE_CHANNEL] - 1].getFloatValue()*rangeGain[DataChannel::HEADSTAGE_CHANNEL]
+        , DataChannel::HEADSTAGE_CHANNEL);
+    lfpDisplay->setRange(voltageRanges[DataChannel::ADC_CHANNEL][selectedVoltageRange[DataChannel::ADC_CHANNEL] - 1].getFloatValue()*rangeGain[DataChannel::ADC_CHANNEL]
+        , DataChannel::ADC_CHANNEL);
+    lfpDisplay->setRange(voltageRanges[DataChannel::AUX_CHANNEL][selectedVoltageRange[DataChannel::AUX_CHANNEL] - 1].getFloatValue()*rangeGain[DataChannel::AUX_CHANNEL]
+        , DataChannel::AUX_CHANNEL);
     
 }
 
@@ -452,11 +464,12 @@ void LfpDisplayOptions::resized()
     drawSaturateWarningButton->setBounds(325, getHeight()-89, 20, 20);
     
     colorGroupingSelection->setBounds(400,getHeight()-90,60,25);
+    triggerSourceSelection->setBounds(375,getHeight()-30,60,25);
 
     invertInputButton->setBounds(35,getHeight()-190,100,22);
     drawMethodButton->setBounds(35,getHeight()-160,100,22);
 
-    pauseButton->setBounds(450,getHeight()-50,50,44);
+    pauseButton->setBounds(465,getHeight()-50,50,44);
     
     // Reverse Channels Display
     reverseChannelsDisplayButton->setBounds(pauseButton->getRight() + 5,
@@ -488,15 +501,15 @@ void LfpDisplayOptions::resized()
                                          150,
                                          22);
     
-	//Channel name toggle
-	showChannelNumberButton->setBounds(medianOffsetPlottingLabel->getRight() + 5,
-		medianOffsetPlottingLabel->getY(),
-		20,
-		20);
-	showChannelNumberLabel->setBounds(showChannelNumberButton->getRight(),
-		showChannelNumberButton->getY(),
-		200,
-		22);
+    //Channel name toggle
+    showChannelNumberButton->setBounds(medianOffsetPlottingLabel->getRight() + 5,
+        medianOffsetPlottingLabel->getY(),
+        20,
+        20);
+    showChannelNumberLabel->setBounds(showChannelNumberButton->getRight(),
+        showChannelNumberButton->getY(),
+        200,
+        22);
     
     // Spike raster plotting button
     spikeRasterSelection->setBounds(medianOffsetPlottingButton->getX(),
@@ -513,7 +526,7 @@ void LfpDisplayOptions::resized()
     
     for (int i = 0; i < 8; i++)
     {
-        eventDisplayInterfaces[i]->setBounds(300+(floor(i/2)*20), getHeight()-40+(i%2)*20, 40, 20); // arrange event channel buttons in two rows
+        eventDisplayInterfaces[i]->setBounds(270+(floor(i/2)*20), getHeight()-40+(i%2)*20, 40, 20); // arrange event channel buttons in two rows
         eventDisplayInterfaces[i]->repaint();
     }
     
@@ -524,7 +537,7 @@ void LfpDisplayOptions::resized()
     brightnessSliderB->setBounds(170,getHeight()-160,100,22);
     sliderBLabel->setBounds(270, getHeight()-160, 180, 22);
     brightnessSliderB->setValue(0.1); //set default value
-	
+    
     showHideOptionsButton->setBounds (getWidth() - 28, getHeight() - 28, 20, 20);
     
     int bh = 25/typeButtons.size();
@@ -572,7 +585,8 @@ void LfpDisplayOptions::paint(Graphics& g)
 
     g.drawText("Color grouping",365,getHeight()-row2,300,20,Justification::left, false);
 
-    g.drawText("Event disp.",300,getHeight()-row1,300,20,Justification::left, false);
+    g.drawText("Event disp.",270,getHeight()-row1,300,20,Justification::left, false);
+    g.drawText("Trigger",375,getHeight()-row1,300,20,Justification::left, false);
 
     if(canvas->drawClipWarning)
     {
@@ -606,7 +620,7 @@ bool LfpDisplayOptions::getInputInvertedState()
 
 bool LfpDisplayOptions::getChannelNameState()
 {
-	return showChannelNumberButton->getToggleState();
+    return showChannelNumberButton->getToggleState();
 }
 
 bool LfpDisplayOptions::getDisplaySpikeRasterizerState()
@@ -721,15 +735,15 @@ void LfpDisplayOptions::buttonClicked(Button* b)
         canvas->toggleOptionsDrawer(b->getToggleState());
     }
 
-	if (b == showChannelNumberButton)
-	{
-		int numChannels = lfpDisplay->channelInfo.size();
-		for (int i = 0; i < numChannels; ++i)
-		{
-			lfpDisplay->channelInfo[i]->repaint();
-		}
-		return;
-	}
+    if (b == showChannelNumberButton)
+    {
+        int numChannels = lfpDisplay->channelInfo.size();
+        for (int i = 0; i < numChannels; ++i)
+        {
+            lfpDisplay->channelInfo[i]->repaint();
+        }
+        return;
+    }
 
     int idx = typeButtons.indexOf((UtilityButton*)b);
 
@@ -1051,13 +1065,17 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
         canvas->redraw();
         //std::cout << "Setting spread to " << spreads[cb->getSelectedId()-1].getFloatValue() << std::endl;
     }
-
     else if (cb == colorGroupingSelection)
     {
         // set color grouping here
         lfpDisplay->setColorGrouping(colorGroupings[cb->getSelectedId()-1].getIntValue());// so that channel colors get re-assigned
         canvas->redraw();
     }
+    else if (cb == triggerSourceSelection)
+    {
+        processor->setTriggerSource(cb->getSelectedId() - 2);
+    }
+
 
     timescale->setTimebase(canvas->timebase);
 }
@@ -1138,6 +1156,7 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
     xmlNode->setAttribute("Timebase",timebaseSelection->getText());
     xmlNode->setAttribute("Spread",spreadSelection->getText());
     xmlNode->setAttribute("colorGrouping",colorGroupingSelection->getSelectedId());
+    xmlNode->setAttribute("triggerSource", triggerSourceSelection->getSelectedId());
     xmlNode->setAttribute("isInverted",invertInputButton->getToggleState());
     xmlNode->setAttribute("drawMethod",drawMethodButton->getToggleState());
 
@@ -1208,7 +1227,15 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
             {
                 colorGroupingSelection->setSelectedId(1);
             }
-
+            if (xmlNode->hasAttribute("triggerSource"))
+            {
+                triggerSourceSelection->setSelectedId(xmlNode->getIntAttribute("triggerSource"));
+            }
+            else
+            {
+                triggerSourceSelection->setSelectedId(1);
+            }
+              
             invertInputButton->setToggleState(xmlNode->getBoolAttribute("isInverted", true), sendNotification);
 
             drawMethodButton->setToggleState(xmlNode->getBoolAttribute("drawMethod", true), sendNotification);

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.h
@@ -185,6 +185,8 @@ private:
     ScopedPointer<Label> sliderALabel;
     ScopedPointer<Label> sliderBLabel;
 
+    ScopedPointer<ComboBox> triggerSourceSelection;
+
     ScopedPointer<ShowHideOptionsButton> showHideOptionsButton;
 
     // TODO: (kelly) consider moving these into a config singleton (meyers?) to clean up
@@ -193,6 +195,7 @@ private:
     StringArray timebases;
     StringArray spreads; // option for vertical spacing between channels
     StringArray colorGroupings; // option for coloring every N channels the same
+    StringArray triggerSources; // option for trigger source event channel
     StringArray overlaps; //
     StringArray saturationThresholds; //default values for when different amplifiers saturate
     

--- a/Plugins/LfpDisplayNode/LfpTimescale.cpp
+++ b/Plugins/LfpDisplayNode/LfpTimescale.cpp
@@ -186,7 +186,7 @@ void LfpTimescale::setTimebase(float t)
     labels.clear();
     
     const int minWidth = 60;
-    labelIncrement = 0.025f;
+    labelIncrement = 0.005f;
     
     while (getWidth() != 0 &&                                   // setTimebase can be called before LfpTimescale has width
            getWidth() / (timebase / labelIncrement) < minWidth) // so, if width is 0 then don't iterate for scale factor


### PR DESCRIPTION
This is the same feature I previously implemented for the LFPViewerNodeBeta, now in LFPViewerNode itself. User can select a trigger source to align display on events, just like on an oscilloscope. This is very useful in combination with TTL inputs on the "Rhythm FPGA." It can also be used fruitfully with my "FutureThreshold" plugin (https://github.com/wagenadl/open-ephys-plugins).

The "trigger" feature works with old-fashioned "event numbers" (1--8) rather than more modern "event sources." This can presumably be changed, but I do not yet have an understanding of the modern system.

I also added some shorter time scale choices to the "Timebase" combobox. These are useful for looking at fast events surrounding triggers.

Note that it is intentional that the trigger event is positioned at 1/3 of the display width; that way, some pre-trigger data is visible as well.