### PR TITLE
Lift requirement that sinks terminate a signal chain

### DIFF
--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -176,30 +176,30 @@ void GenericProcessor::setSourceNode(GenericProcessor* sn)
 		{
 			//	std::cout << " The source is not blank." << std::endl;
 
-			if (!sn->isSink())
-			{
+			//if (!sn->isSink())
+			//{
 				//		std::cout << " The source is not a sink." << std::endl;
-				if (sourceNode != sn)
-				{
-					//			std::cout << " The source is new and named " << sn->getName() << std::endl;
+            if (sourceNode != sn)
+            {
+                //			std::cout << " The source is new and named " << sn->getName() << std::endl;
 
-					if (this->isMerger())
-						setMergerSourceNode(sn);
-					else
-						sourceNode = sn;
+                if (this->isMerger())
+                    setMergerSourceNode(sn);
+                else
+                    sourceNode = sn;
 
-					sn->setDestNode(this);
-				}
-				else
-				{
-					//			std::cout << "  The source node is not new." << std::endl;
-				}
-			}
-			else
-			{
+                sn->setDestNode(this);
+            }
+            //else
+            //{
+                //			std::cout << "  The source node is not new." << std::endl;
+            //}
+			//}
+			//else
+			//{
 				//		std::cout << " The source is a sink." << std::endl;
-				sourceNode = 0;
-			}
+			//	sourceNode = 0;
+			//}
 
 		}
 		else
@@ -222,8 +222,8 @@ void GenericProcessor::setDestNode(GenericProcessor* dn)
 {
 	//	std::cout << "My name is " << getName() << ". Setting dest node." << std::endl;
 
-	if (!isSink())
-	{
+	//if (!isSink())
+	//{
 		//	std::cout << "  I am not a sink." << std::endl;
 
 		if (dn != 0)
@@ -262,13 +262,13 @@ void GenericProcessor::setDestNode(GenericProcessor* dn)
 
 			destNode = 0;
 		}
-	}
-	else
-	{
+	//}
+	//else
+	//{
 		//std::cout << "  I am a sink, I can't have a dest node." << std::endl;
 		//if (dn != 0)
 		//	dn->setSourceNode(this);
-	}
+	//}
 }
 
 
@@ -381,10 +381,10 @@ void GenericProcessor::update()
 	createSpikeChannels();
 	createConfigurationObjects();
 
-	if (this->isSink())
-	{
-		settings.numOutputs = 0;
-	}
+	//if (this->isSink())
+	//{
+	//	settings.numOutputs = 0;
+	//}
 
 	updateSettings(); // allow processors to change custom settings
 

--- a/Source/Processors/Merger/Merger.cpp
+++ b/Source/Processors/Merger/Merger.cpp
@@ -64,8 +64,8 @@ void Merger::setMergerSourceNode(GenericProcessor* sn)
     }
     else
     {
-        sourceNodeB = sn;
         std::cout << "Setting source node B." << std::endl;
+        sourceNodeB = sn;
     }
 
     if (sn != nullptr)
@@ -225,30 +225,23 @@ void Merger::updateSettings()
     {
         std::cout << "   Merger source A found." << std::endl;
         addSettingsFromSourceNode(sourceNodeA);
+    } else {
+        mergeEventsA = true;
+        mergeContinuousA = true;
     }
 
     if (sourceNodeB != 0)
     {
         std::cout << "   Merger source B found." << std::endl;
         addSettingsFromSourceNode(sourceNodeB);
+    } else {
+        mergeEventsB = true;
+        mergeContinuousB = true;
     }
 
     if (sourceNodeA == 0 && sourceNodeB == 0)
     {
-
-
 		settings.numOutputs = getNumOutputs();
-
-    /*    for (int i = 0; i < getNumOutputs(); i++)
-        {
-            Channel* ch = new Channel(this, i, HEADSTAGE_CHANNEL);
-            ch->sampleRate = getDefaultSampleRate();
-            ch->bitVolts = getDefaultBitVolts();
-
-            channels.add(ch);
-        }*/
-
-        //generateDefaultChannelNames(settings.outputChannelNames);
     }
 
     std::cout << "Number of merger outputs: " << getNumInputs() << std::endl;

--- a/Source/Processors/Merger/Merger.h
+++ b/Source/Processors/Merger/Merger.h
@@ -77,10 +77,10 @@ public:
 
     bool mergeEventsA, mergeContinuousA, mergeEventsB, mergeContinuousB;
 
-private:
-
     GenericProcessor* sourceNodeA;
     GenericProcessor* sourceNodeB;
+
+private:
 
     int activePath;
 

--- a/Source/Processors/Merger/MergerEditor.cpp
+++ b/Source/Processors/Merger/MergerEditor.cpp
@@ -138,7 +138,7 @@ void MergerEditor::mouseDown(const MouseEvent& e)
 
         for (i = 0; i < availableProcessors.size(); i++)
         {
-            if (!availableProcessors[i]->isSink() &&
+            if (//!availableProcessors[i]->isSink() &&
                 !availableProcessors[i]->isMerger() &&
                 !availableProcessors[i]->isSplitter() &&
                 availableProcessors[i]->getDestNode() != getProcessor())

--- a/Source/Processors/Merger/MergerEditor.cpp
+++ b/Source/Processors/Merger/MergerEditor.cpp
@@ -179,7 +179,7 @@ void MergerEditor::mouseDown(const MouseEvent& e)
 
         PopupMenu menu;
         int menuItemIndex = 1;
-        int eventMergeIndexA, eventMergeIndexB, continuousMergeIndexA, continuousMergeIndexB = -1;
+        int continuousMergeIndexA, continuousMergeIndexB = -1;
         int inputSelectionIndexA, inputSelectionIndexB = -1;
         
         Array<GenericProcessor*> selectableProcessors = getSelectableProcessors();
@@ -190,13 +190,7 @@ void MergerEditor::mouseDown(const MouseEvent& e)
             "Input A: " + getNameString(merger->sourceNodeA), // message
             false); // isSelectable
             
-            eventMergeIndexA = ++menuItemIndex;
             continuousMergeIndexA = ++menuItemIndex;
-            
-            menu.addItem(eventMergeIndexA,
-                         "Merge event data",
-                         !acquisitionIsActive,
-                         merger->mergeEventsA);
             
             menu.addItem(continuousMergeIndexA,
                          "Merge continuous data",
@@ -236,13 +230,7 @@ void MergerEditor::mouseDown(const MouseEvent& e)
             "Input B: " + getNameString(merger->sourceNodeB), // message
             false); // isSelectable
             
-            eventMergeIndexB = ++menuItemIndex;
             continuousMergeIndexB = ++menuItemIndex;
-            
-            menu.addItem(eventMergeIndexB,
-                         "Merge event data",
-                         !acquisitionIsActive,
-                         merger->mergeEventsB);
             
             menu.addItem(continuousMergeIndexB,
                          "Merge continuous data",
@@ -276,19 +264,9 @@ void MergerEditor::mouseDown(const MouseEvent& e)
         std::cout << "Selection: " << result << std::endl;
 
         
-        if (result == eventMergeIndexA)
-        {
-            merger->mergeEventsA = !(merger->mergeEventsA);
-            CoreServices::updateSignalChain(this);
-            return;
-        } else if (result == continuousMergeIndexA)
+        if (result == continuousMergeIndexA)
         {
             merger->mergeContinuousA = !merger->mergeContinuousA;
-            CoreServices::updateSignalChain(this);
-            return;
-        } else if (result == eventMergeIndexB)
-        {
-            merger->mergeEventsB = !merger->mergeEventsB;
             CoreServices::updateSignalChain(this);
             return;
         } else if (result == continuousMergeIndexB)

--- a/Source/Processors/Merger/MergerEditor.cpp
+++ b/Source/Processors/Merger/MergerEditor.cpp
@@ -140,22 +140,40 @@ void MergerEditor::mouseDown(const MouseEvent& e)
         
         Array<GenericProcessor*> selectableProcessors;
 
-        for (auto& processor : availableProcessors)
+        for (auto& processorToCheck : availableProcessors)
         {
-            if (!processor->isMerger() &&
-                !processor->isSplitter() &&
-                processor->getDestNode() == 0)
+            if (!processorToCheck->isMerger() &&
+                !processorToCheck->isSplitter() &&
+                processorToCheck->getDestNode() == 0)
             {
-
-                String name = String(processor->getNodeId());
-                name += " - ";
-                name += processor->getName();
-
-                menu.addItem(++menuItemIndex, // index
-                             name, // message
-                             true); // isSelectable
                 
-                selectableProcessors.add(processor);
+                bool isDownstream = false;
+                GenericProcessor* sourceNode = processorToCheck->getSourceNode();
+                    
+                while (sourceNode != 0)
+                {
+                    if (sourceNode == getProcessor())
+                    {
+                        isDownstream = true;
+                        break;
+                    }
+                    
+                    sourceNode = sourceNode->getSourceNode();
+                }
+                       
+                if (!isDownstream)
+                {
+                    String name = String(processorToCheck->getNodeId());
+                    name += " - ";
+                    name += processorToCheck->getName();
+
+                    menu.addItem(++menuItemIndex, // index
+                                 name, // message
+                                 true); // isSelectable
+                    
+                    selectableProcessors.add(processorToCheck);
+                }
+                
             }
         }
 

--- a/Source/Processors/Merger/MergerEditor.h
+++ b/Source/Processors/Merger/MergerEditor.h
@@ -70,6 +70,9 @@ public:
 
 private:
     
+    String getNameString(GenericProcessor*);
+    Array<GenericProcessor*> getSelectableProcessors();
+    
     ImageButton* pipelineSelectorA;
     ImageButton* pipelineSelectorB;
 

--- a/Source/Processors/Merger/MergerEditor.h
+++ b/Source/Processors/Merger/MergerEditor.h
@@ -40,24 +40,36 @@ class MergerEditor : public GenericEditor
 
 {
 public:
+    
+    /** Constructor*/
     MergerEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors);
+    
+    /** Destructor*/
     virtual ~MergerEditor();
 
+    /** Called whenever the pathway selector button is pressed.*/
     virtual void buttonEvent(Button* button);
 
+    /** Changes the active pathway to 0 or 1 */
     void switchSource(int);
+    
+    /** Swaps the active pathway*/
     void switchSource();
 
+    /** Changes the active pathway to 0 or 1, and selects the editor */
     void switchIO(int);
-
+    
+    /** Called for mouse events in the editor's title bar */
     void mouseDown(const MouseEvent& event);
 
+    /** Returns the pathway (0 or 1) for a particular editor*/
     int getPathForEditor(GenericEditor* editor);
 
+    /** Returns an array of the editors that feed into the merger*/
     Array<GenericEditor*> getConnectedEditors();
 
 private:
-
+    
     ImageButton* pipelineSelectorA;
     ImageButton* pipelineSelectorB;
 

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -845,7 +845,9 @@ void EditorViewport::mouseDrag(const MouseEvent& e)
     if (editorArray.contains((GenericEditor*) e.originalComponent)
         && e.y < 15
         && canEdit
-        && editorArray.size() > 1)
+        && editorArray.size() > 1
+        && e.getDistanceFromDragStart() > 10
+        )
     {
 
         componentWantsToMove = true;

--- a/Source/UI/GraphViewer.cpp
+++ b/Source/UI/GraphViewer.cpp
@@ -158,7 +158,38 @@ void GraphViewer::updateNodeLocations()
         }
     }
     
+    // remove extra horizontal shift
+    //for (auto& node : availableNodes)
+    //{
+    //    if (node->getHorzShift() > 0)
+    //    {
+    //        for (int i = 0; i < 3; i++)
+     //       {
+     //           if (isEmptySpace(node->getLevel(), node->getHorzShift()-1))
+     //           {
+     //               node->setHorzShift(node->getHorzShift()-1);
+     //           }
+     //       }
+     //   }
+    //}
+    
     repaint();
+}
+
+bool GraphViewer::isEmptySpace(int level, int horzShift)
+{
+    if (horzShift < 0)
+        return false;
+    
+    for (auto& node : availableNodes)
+    {
+        if (node->getHorzShift() == horzShift && node->getLevel() == level)
+        {
+            return false;
+        }
+    }
+    
+    return true;
 }
 
 

--- a/Source/UI/GraphViewer.cpp
+++ b/Source/UI/GraphViewer.cpp
@@ -78,9 +78,9 @@ int GraphViewer::getLevel(GraphNode* node) {
 
 void GraphViewer::adjustBranchLayout(GraphNode* rootNode, int startLevel)
 {
-    if (rootNode->getLevel() != -1)
+    if (rootNode->getLevel() != -1 && rootNode->isSplitter())
     {
-        return; // we've already adjusted this node
+        return; // we've already adjusted this splitter node
     }
     
     int level = startLevel + 1;
@@ -95,11 +95,13 @@ void GraphViewer::adjustBranchLayout(GraphNode* rootNode, int startLevel)
         if (upstreamEditors[0] != nullptr)
         {
             level1 = getNodeForEditor(upstreamEditors[0])->getLevel() + 1;
+            std::cout << "Merger input 1 at " << level1 << std::endl;
         }
         
         if (upstreamEditors[1] != nullptr)
         {
             level2 = getNodeForEditor(upstreamEditors[1])->getLevel() + 1;
+            std::cout << "Merger input 2 at " << level1 << std::endl;
         }
         
         level = (level1 > level2) ? level1 : level2;

--- a/Source/UI/GraphViewer.h
+++ b/Source/UI/GraphViewer.h
@@ -29,84 +29,133 @@
 
 #include "../../JuceLibraryCode/JuceHeader.h"
 
-/**
- 
- Displays the full processor graph for a given session.
- 
- Inhabits a tab in the DataViewport.
- 
- @see UIComponent, DataViewport, ProcessorGraph, EditorViewport
- 
- */
 
+/**
+ Represents an individual processor/plugin in the GraphViewer.
+ 
+ @see GraphViewer
+*/
 
 class GraphNode : public Component
 {
 public:
+    
+    /** Constructor */
     GraphNode (GenericEditor* editor, GraphViewer* g);
+    
+    /** Destructor */
     ~GraphNode();
     
+    /** Paint component */
     void paint (Graphics& g)    override;
     
+    /** Behavior on start of mouse hover */
     void mouseEnter (const MouseEvent& event) override;
+    
+    /** Behavior on end of mouse hover */
     void mouseExit  (const MouseEvent& event) override;
+    
+    /** Behavior on mouse click */
     void mouseDown  (const MouseEvent& event) override;
     
+    /** Indicates whether node has an editor component */
     bool hasEditor (GenericEditor* editor) const;
     
+    /** Returns location of component center point */
     juce::Point<float> getCenterPoint() const;
+    
+    /** Returns editor of downstream node */
     GenericEditor* getDest()    const;
+    
+    /** Returns editor of upstream node */
     GenericEditor* getSource()  const;
+    
+    /** Returns array of editors for all connected nodes (splitter and merger only) */
     Array<GenericEditor*> getConnectedEditors() const;
     
+    /** Returns true if node is a splitter */
     bool isSplitter() const;
+    
+    /** Returns true if node is a merger */
     bool isMerger()   const;
     
+    /** Returns name of the underlying processor */
     const String getName() const;
     
+    /** Returns level (y-position) of node in graph display */
     int getLevel()     const;
+    
+    /** Returns horizontal shift (x-position of node in graph display) */
     int getHorzShift() const;
     
+    /** Sets the level (y-position) of node in graph display) */
     void setLevel (int newLevel);
+    
+    /** Sets the horizontal shift (x-position of node in graph display) */
     void setHorzShift (int newHorizontalShift);
     
-    void updateBoundaries();
-    void switchIO (int path);
-    
-    int horzShift;
-    int vertShift;
+    /** Not currently used (consider deleting) */
+    //void switchIO (int path);
     
 private:
     GenericEditor* editor;
     GraphViewer* gv;
     
+    void updateBoundaries();
+    
     bool isMouseOver;
+    int horzShift;
+    int vertShift;
 };
 
+/**
 
+ Displays the full processor graph for a given session.
+
+ Inhabits a tab in the DataViewport, and allows the user to select processor editors by clicking on their icons inside the graph.
+
+@see UIComponent, DataViewport, ProcessorGraph, EditorViewport
+
+*/
 class GraphViewer : public Component
 {
 public:
+    
+    /** Constructor */
     GraphViewer();
+    
+    /** Destructor */
     ~GraphViewer();
     
     /** Draws the GraphViewer.*/
     void paint (Graphics& g)    override;
     
+    /** Adds a graph node for a particular processor */
     void addNode    (GenericEditor* editor);
+    
+    /** Removevs a graph node for a particular processor */
     void removeNode (GenericEditor* editor);
+    
+    /** Clears the graph */
     void removeAllNodes();
+    
+    /** Repositions all nodes in the graph */
     void updateNodeLocations();
     
-    int nodesAtLevel (int lvl) const;
-    int getHorizontalShift (GraphNode*) const;
-    GraphNode* getNodeForEditor (GenericEditor* editor) const;
+    /** Returns the number of nodes at a particular level (y-position) */
+    //int nodesAtLevel (int lvl) const;
     
+    /** Returns the horizontal shift (x-position) of a particular node  */
+    int getHorizontalShift (GraphNode*) const;
+    
+    /** Returns the graph node for a particular processor editor */
+    GraphNode* getNodeForEditor (GenericEditor* editor) const;
     
 private:
     void connectNodes (int, int, Graphics&);
-    void checkLayout (GraphNode*);
-    
+    void adjustBranchLayout(GraphNode*, int);
+
+    int getLevel(GraphNode*);
     int getIndexOfEditor (GenericEditor* editor) const;
     
     int rootNum;

--- a/Source/UI/GraphViewer.h
+++ b/Source/UI/GraphViewer.h
@@ -154,6 +154,7 @@ public:
 private:
     void connectNodes (int, int, Graphics&);
     void adjustBranchLayout(GraphNode*, int);
+    bool isEmptySpace(int level, int horzShift);
 
     int getLevel(GraphNode*);
     int getIndexOfEditor (GenericEditor* editor) const;

--- a/Source/UI/SignalChainManager.cpp
+++ b/Source/UI/SignalChainManager.cpp
@@ -168,13 +168,13 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     // Step 1: update the editor array
     if (action == ADD)
     {
-        //std::cout << "    Adding editor." << std::endl;
+        std::cout << "    Adding editor." << std::endl;
         editorArray.insert(insertionPoint, activeEditor);
 
     }
     else if (action == MOVE)
     {
-        // std::cout << "    Moving editors." << std::endl;
+        std::cout << "    Moving editors." << std::endl;
         if (insertionPoint < index)
             editorArray.move(index, insertionPoint);
         else if (insertionPoint > index)
@@ -184,11 +184,10 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     else if (action == REMOVE)
     {
 
-        // std::cout << "    Removing editor." << std::endl;
+        std::cout << "    Removing editor." << std::endl;
 
         GenericProcessor* p = (GenericProcessor*) editorArray[index]->getProcessor();
 
-        // GenericProcessor* source = p->getSourceNode();
         if (p->getSourceNode() != nullptr)
             if (p->getSourceNode()->isSplitter())
                 p->getSourceNode()->setSplitterDestNode(nullptr);
@@ -298,23 +297,40 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     if (action != ACTIVATE && action != UPDATE && editorArray.size() > 0)
     {
 
-        // std::cout << "Updating connections." << std::endl;
+        //std::cout << "Updating connections." << std::endl;
 
         GenericProcessor* source = 0;
         GenericProcessor* dest = (GenericProcessor*) editorArray[0]->getProcessor();
 
-        dest->setSourceNode(source);
-
+        if (!dest->isMerger())
+        {
+            dest->setSourceNode(source);
+        } else {
+            dest->setMergerSourceNode(source);
+        }
+        
         for (int n = 1; n < editorArray.size(); n++)
         {
 
             dest = (GenericProcessor*) editorArray[n]->getProcessor();
             source = (GenericProcessor*) editorArray[n-1]->getProcessor();
 
-            dest->setSourceNode(source);
+            if (!dest->isMerger())
+            {
+                dest->setSourceNode(source);
+            } else {
+                dest->setMergerSourceNode(source);
+            }
+            
         }
 
-        dest->setDestNode(0);
+        if (!dest->isSplitter())
+        {
+            dest->setDestNode(0);
+        } else {
+            dest->setSplitterDestNode(0);
+        }
+        
 
     }
 
@@ -322,7 +338,7 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     if (action != ACTIVATE && action != UPDATE)
     {
 
-        //  std::cout << "Checking for new tabs." << std::endl;
+        //std::cout << "Checking for new tabs." << std::endl;
 
         for (int n = 0; n < editorArray.size(); n++)
         {
@@ -367,7 +383,7 @@ void SignalChainManager::updateVisibleEditors(GenericEditor* activeEditor,
     }
 
     editorArray.clear();
-    // std::cout << "Cleared editor array." << std::endl;
+    //std::cout << "Cleared editor array." << std::endl;
 
     GenericEditor* editorToAdd = activeEditor;
 


### PR DESCRIPTION
These updates make it so that sinks can be placed in the middle of a signal chain, similar to how filters currently behave. 

Other changes include:
- Simplified logic for drawing GraphView
- New aesthetics for GraphView (see below)
- Fixed bugs when moving around Splitters or Mergers
- Add a distance threshold for dragging editors, to avoid accidentally triggering a "MOVE" event

<img width="154" alt="Screen Shot 2020-09-02 at 2 35 44 PM" src="https://user-images.githubusercontent.com/200366/92039240-a079cb80-ed29-11ea-9905-db3533ecd06b.png">
