### PR TITLE
Change location of user generated files, add recovery config feature & add scripts of Windows and Linux Installers

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,6 +38,16 @@ jobs:
         user_info="$bintrayUser:$bintrayApiKey"
         curl -T $zipfile --user $user_info https://api.bintray.com/content/open-ephys-gui/Test/Test-linux/$gui_ver/$zipfile
         curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Test/Test-linux/$gui_ver/publish
+        cd ../Resources/Installers/Linux/Open-Ephys_Installer
+        mkdir -p usr/local/bin/open-ephys-gui
+        cp -r ../../../../Build/Release usr/local/bin/open-ephys-gui
+        cp ../../../Scripts/40-open-ephys.rules usr/local/bin/open-ephys-gui
+        cd ..
+        dpkg-deb --build Open-Ephys_Installer
+        installer=Open-Ephys_Installer_${gui_ver}-beta.deb
+        mv -v Open-Ephys_Installer.deb $installer
+        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/$installer
+        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/publish
       shell: bash
     - name: deploy_release
       if: github.ref == 'refs/heads/master'
@@ -55,4 +65,14 @@ jobs:
         user_info="$bintrayUser:$bintrayApiKey"
         curl -T $zipfile --user $user_info https://api.bintray.com/content/open-ephys-gui/Release/Release-linux/$gui_ver/$zipfile
         curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Release/Release-linux/$gui_ver/publish
+        cd ../Resources/Installers/Linux/Open-Ephys_Installer
+        mkdir -p usr/local/bin/open-ephys-gui
+        cp -r ../../../../Build/Release usr/local/bin/open-ephys-gui
+        cp ../../../Scripts/40-open-ephys.rules usr/local/bin/open-ephys-gui
+        cd ..
+        dpkg-deb --build Open-Ephys_Installer
+        installer=Open-Ephys_Installer_${gui_ver}-beta.deb
+        mv Open-Ephys_Installer.deb $installer
+        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/$installer
+        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/publish
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,6 +42,12 @@ jobs:
         user_info="$bintrayUser:$bintrayApiKey"
         curl -T $zipfile --user $user_info https://api.bintray.com/content/open-ephys-gui/Test/Test-windows/$gui_ver/$zipfile
         curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Test/Test-windows/$gui_ver/publish
+        cd ../Resources/Installers/Windows
+        iscc "windows_installer_script.iss"
+        installer=Open-Ephys_Installer_${gui_ver}-beta.exe
+        mv Open-Ephys_Installer.exe $installer
+        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/$installer
+        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/publish
       shell: bash
     - name: deploy_release
       if: github.ref == 'refs/heads/master'
@@ -60,4 +66,10 @@ jobs:
         user_info="$bintrayUser:$bintrayApiKey"
         curl -T $zipfile --user $user_info https://api.bintray.com/content/open-ephys-gui/Release/Release-windows/$gui_ver/$zipfile
         curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Release/Release-windows/$gui_ver/publish
+        cd ../Resources/Installers/Windows
+        iscc "windows_installer_script.iss"
+        installer=Open-Ephys_Installer_${gui_ver}.exe
+        mv Open-Ephys_Installer.exe $installer
+        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/$installer
+        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/publish
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,8 +46,8 @@ jobs:
         iscc "windows_installer_script.iss"
         installer=Open-Ephys_Installer_${gui_ver}-beta.exe
         mv Open-Ephys_Installer.exe $installer
-        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/$installer
-        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/publish
+        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/$installer
+        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/publish
       shell: bash
     - name: deploy_release
       if: github.ref == 'refs/heads/master'
@@ -70,6 +70,6 @@ jobs:
         iscc "windows_installer_script.iss"
         installer=Open-Ephys_Installer_${gui_ver}.exe
         mv Open-Ephys_Installer.exe $installer
-        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/$installer
-        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Test-Installer/Test-Installer-windows/$gui_ver/publish
+        curl -T $installer --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/$installer
+        curl -X POST --user $user_info https://api.bintray.com/content/open-ephys-gui/Release-Installer/Release-Installer-windows/$gui_ver/publish
       shell: bash

--- a/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/control
+++ b/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/control
@@ -1,0 +1,9 @@
+Package: open-ephys
+Version: 0.5.0
+Architecture: amd64
+Installed-Size: 18644
+Section: science
+Priority: optional
+Maintainer: Open Ephys <info@open-ephys.com>
+Homepage: https://open-ephys.org/gui
+Description: Software for processing, recording, and visualizing multichannel electrophysiology data.

--- a/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/copyright
+++ b/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/copyright
@@ -1,0 +1,3 @@
+Files: *
+Copyright: 2020 Open Ephys <info@open-ephys.com>
+License: GPL-3+

--- a/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/postinst
+++ b/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/postinst
@@ -1,0 +1,17 @@
+#!/bin/sh
+# postinst script for Open Ephys
+
+if [ "$1" = configure ]; then
+
+    echo "Copying open-ephys udev rules and restaring udev service..."
+    cd /usr/local/bin
+    mv open-ephys-gui/40-open-ephys.rules /etc/udev/rules.d
+    service udev restart
+
+    echo "Creating open-ephys symlink to /usr/local/bin..."
+    ln -sf open-ephys-gui/open-ephys open-ephys
+
+    echo "Installation finished!"
+
+fi
+

--- a/Resources/Installers/Windows/windows_installer_script.iss
+++ b/Resources/Installers/Windows/windows_installer_script.iss
@@ -1,0 +1,77 @@
+[Setup]
+AppName=Open Ephys
+AppVersion=0.5.0
+AppVerName=Open Ephys 0.5.0
+AppPublisher=open-ephys.org
+AppPublisherURL=https://open-ephys.org/gui
+DefaultDirName={autopf}\Open Ephys
+DefaultGroupName=Open Ephys
+OutputBaseFilename=Open-Ephys_Installer
+OutputDir=.
+LicenseFile=..\..\..\Licenses\LICENSE
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+ChangesAssociations=yes
+SetupIconFile="..\..\Build-files\icon.ico"
+UninstallDisplayIcon={app}\open-ephys.exe
+AllowNoIcons=yes
+WizardStyle=modern
+
+[Tasks]
+Name: desktopicon; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+Name: install_usb; Description: "Install Opal Kelly Front Panel USB driver for Open Ephys Acquisition Board"; GroupDescription: "External drivers:";
+
+[Files]
+Source: "..\..\..\Build\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; BeforeInstall: UpdateProgress(0);
+Source: "..\..\DataFiles\*"; DestDir: "{userdocs}\Open Ephys\DataFiles"; Flags: ignoreversion recursesubdirs; BeforeInstall: UpdateProgress(60);
+Source: "vcredist_x64.exe"; DestDir: {tmp}; Flags: deleteafterinstall; BeforeInstall: UpdateProgress(70);
+Source: "..\..\DLLs\FrontPanelUSB-DriverOnly-4.5.5.exe"; DestDir: {tmp}; Flags: deleteafterinstall; BeforeInstall: UpdateProgress(90);
+
+[Icons]
+Name: "{group}\Open Ephys"; Filename: "{app}\open-ephys.exe"
+Name: "{autodesktop}\Open Ephys"; Filename: "{app}\open-ephys.exe"; Tasks: desktopicon
+Name: "{autoprograms}\Open Ephys"; Filename: "{app}\open-ephys.exe"
+
+[Run]
+Filename: "{tmp}\vcredist_x64.exe"; Parameters: "/q /norestart /q:a /c:""VCREDI~3.EXE /q:a /c:""""msiexec /i vcredist.msi /qn"""" """; Check: VCRedistNeedsInstall; WorkingDir: {app}; StatusMsg: "Installing VC++ 2019 Redistributables...";
+Filename: "{tmp}\FrontPanelUSB-DriverOnly-4.5.5.exe"; StatusMsg: "Installing Front Panel USB driver..."; Tasks: install_usb; Flags: skipifsilent
+
+[Code]
+procedure UpdateProgress(Position: Integer);
+begin
+  WizardForm.ProgressGauge.Position := Position * WizardForm.ProgressGauge.Max div 100;
+end;
+
+#IFDEF UNICODE
+  #DEFINE AW "W"
+#ELSE
+  #DEFINE AW "A"
+#ENDIF
+type
+  INSTALLSTATE = Longint;
+const
+  INSTALLSTATE_INVALIDARG = -2;  // An invalid parameter was passed to the function.
+  INSTALLSTATE_UNKNOWN = -1;     // The product is neither advertised or installed.
+  INSTALLSTATE_ADVERTISED = 1;   // The product is advertised but not installed.
+  INSTALLSTATE_ABSENT = 2;       // The product is installed for a different user.
+  INSTALLSTATE_DEFAULT = 5;      // The product is installed for the current user.
+
+  // Visual C++ 2019 Redistributable 14.25.28508
+  VC_2019_REDIST_X86_MIN = '{2BC3BD4D-FABA-4394-93C7-9AC82A263FE2}';
+  VC_2019_REDIST_X64_MIN = '{EEA66967-97E2-4561-A999-5C22E3CDE428}';
+
+  VC_2019_REDIST_X86_ADD = '{0FA68574-690B-4B00-89AA-B28946231449}';
+  VC_2019_REDIST_X64_ADD = '{7D0B74C2-C3F8-4AF1-940F-CD79AB4B2DCE}';
+
+function MsiQueryProductState(szProduct: string): INSTALLSTATE; 
+  external 'MsiQueryProductState{#AW}@msi.dll stdcall';
+
+function VCVersionInstalled(const ProductID: string): Boolean;
+begin
+  Result := MsiQueryProductState(ProductID) = INSTALLSTATE_DEFAULT;
+end;
+
+function VCRedistNeedsInstall: Boolean;
+begin
+  Result := not (VCVersionInstalled(VC_2019_REDIST_X64_MIN));
+end;

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -241,6 +241,20 @@ namespace CoreServices
 		return std::move(dir);
 	}
 
+	File getSavedStateDirectory() {
+#if defined(__APPLE__)
+    	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
+#elif _WIN32
+    	File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
+#else
+		File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");;
+#endif
+		if (!dir.isDirectory()) {
+			dir.createDirectory();
+		}
+    	return std::move(dir);
+	}
+
 	String getGUIVersion()
 	{
 #define XSTR_DEF(s) #s

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -229,14 +229,16 @@ namespace CoreServices
 	File getDefaultUserSaveDirectory()
 	{
 #if defined(__APPLE__)
-		File dir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("open-ephys");
+    	const File dir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("Open Ephys");
+#elif _WIN32
+    	const File dir = File::getSpecialLocation(File::userDocumentsDirectory).getChildFile("Open Ephys");
+#else
+    	const File dir = File::getSpecialLocation(File::userHomeDirectory).getChildFile("open-ephys");
+#endif
 		if (!dir.isDirectory()) {
 			dir.createDirectory();
 		}
 		return std::move(dir);
-#else
-		return File::getCurrentWorkingDirectory();
-#endif
 	}
 
 	String getGUIVersion()

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -129,6 +129,9 @@ PLUGIN_API const char* getApplicationResource(const char* name, int& size);
 /** Gets the default directory for user-initiated file saving/loading */
 PLUGIN_API File getDefaultUserSaveDirectory();
 
+/** Gets the save directory for GUI-related file saving/loading */
+PLUGIN_API File getSavedStateDirectory();
+
 /** Gets the GUI version */
 PLUGIN_API String getGUIVersion();
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -65,21 +65,20 @@ public:
 
 #ifdef WIN32
         //glWinInit();
-
-        int consoleArg = parameters.indexOf("--console", true);
-        if (consoleArg != -1)
+        if (AllocConsole())
         {
-            parameters.remove(consoleArg);
-            if (AllocConsole())
-            {
-                freopen("CONOUT$","w",stdout);
-				freopen("CONOUT$","w",stderr);
-                console_out = std::ofstream("CONOUT$");
-                std::cout.rdbuf(console_out.rdbuf());
-				std::cerr.rdbuf(console_out.rdbuf());
-                SetConsoleTitle("Debug Console");
-				std::cout << "Debug console..." << std::endl;
-            }
+            freopen("CONOUT$","w",stdout);
+            freopen("CONOUT$","w",stderr);
+            console_out = std::ofstream("CONOUT$");
+            std::cout.rdbuf(console_out.rdbuf());
+            std::cerr.rdbuf(console_out.rdbuf());
+            SMALL_RECT windowSize = {0, 0, 85 - 1, 35 - 1};
+            COORD bufferSize = { 85 , 9999 };
+            HANDLE wHnd = GetStdHandle(STD_OUTPUT_HANDLE);
+            SetConsoleTitle("[Open Ephys] Debug Console");
+            SetConsoleWindowInfo(wHnd, true, &windowSize); 
+            SetConsoleScreenBufferSize(wHnd, bufferSize);
+            std::cout << "Debug console..." << std::endl;
         }
 
 #endif

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -37,7 +37,7 @@
 	setResizable(true,      // isResizable
 			false);   // useBottomCornerRisizer -- doesn't work very well
 
-	shouldReloadOnStartup = false;
+	shouldReloadOnStartup = true;
 
 	// Create ProcessorGraph and AudioComponent, and connect them.
 	// Callbacks will be set by the play button in the control panel
@@ -85,7 +85,6 @@
 		{
 			if(compareConfigFiles(lastConfig, recoveryConfig))
 			{
-				std::cout << "Loading last config.\n" << std::endl;
 				ui->getEditorViewport()->loadState(lastConfig);
 			}
 			else

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -30,13 +30,13 @@
 static inline File getSavedStateDirectory() {
 #if defined(__APPLE__)
     File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
-    if (!dir.isDirectory()) {
+#else
+    File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
+#endif
+	if (!dir.isDirectory()) {
         dir.createDirectory();
     }
     return std::move(dir);
-#else
-    return File::getSpecialLocation(File::currentExecutableFile).getParentDirectory();
-#endif
 }
 
 	MainWindow::MainWindow(const File& fileToLoad)

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -30,8 +30,10 @@
 static inline File getSavedStateDirectory() {
 #if defined(__APPLE__)
     File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
-#else
+#elif _WIN32
     File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
+#else
+	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");;
 #endif
 	if (!dir.isDirectory()) {
         dir.createDirectory();

--- a/Source/MainWindow.h
+++ b/Source/MainWindow.h
@@ -74,6 +74,10 @@ private:
         from which the GUI is run. */
     void loadWindowBounds();
 
+    /** Checks whether the signal chains of both the config files (lastConfig.xml & recoveryConfig.xml) 
+     *  match or not. */
+    bool compareConfigFiles(File file1, File file2);
+
     /** A pointer to the application's AudioComponent (owned by the MainWindow). */
     ScopedPointer<AudioComponent> audioComponent;
 

--- a/Source/Processors/AudioNode/AudioEditor.cpp
+++ b/Source/Processors/AudioNode/AudioEditor.cpp
@@ -24,6 +24,7 @@
 #include "AudioEditor.h"
 #include "../../Audio/AudioComponent.h"
 #include "../../AccessClass.h"
+#include "../../UI/EditorViewport.h"
 #include "../../UI/LookAndFeel/MaterialSliderLookAndFeel.h"
 
 
@@ -325,6 +326,9 @@ AudioConfigurationWindow::~AudioConfigurationWindow()
 
 void AudioConfigurationWindow::closeButtonPressed()
 {
+    File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
+    AccessClass::getEditorViewport()->saveState(recoveryFile);
+
     controlButton->setToggleState (false, dontSendNotification);
     setVisible (false);
 }

--- a/Source/Processors/Editors/GenericEditor.cpp
+++ b/Source/Processors/Editors/GenericEditor.cpp
@@ -552,10 +552,11 @@ void GenericEditor::update()
             drawerButton->setVisible(true);
     }
 
-
-
     updateVisualizer(); // does nothing unless this method
     // has been implemented
+
+    File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
+    AccessClass::getEditorViewport()->saveState(recoveryFile);
 
 }
 

--- a/Source/Processors/PluginManager/PluginManager.cpp
+++ b/Source/Processors/PluginManager/PluginManager.cpp
@@ -85,6 +85,11 @@ PluginManager::PluginManager()
 
 	AddDllDirectory(installSharedPath.getFullPathName().toWideCharPointer());
 	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+#elif __linux__
+	File installSharedPath = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys/shared");
+	if (!installSharedPath.isDirectory()) {
+        installSharedPath.createDirectory();
+    }
 #endif
 }
 
@@ -100,9 +105,12 @@ void PluginManager::loadAllPlugins()
 #ifdef __APPLE__
     paths.add(File::getSpecialLocation(File::currentApplicationFile).getChildFile("Contents/PlugIns"));
     paths.add(File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys/plugins"));
+#elif _WIN32
+	paths.add(File::getSpecialLocation(File::currentApplicationFile).getParentDirectory().getChildFile("plugins"));
+	paths.add(File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys/plugins"));
 #else
 	paths.add(File::getSpecialLocation(File::currentApplicationFile).getParentDirectory().getChildFile("plugins"));
-	paths.add(File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys/plugins"));	
+	paths.add(File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys/plugins"));	
 #endif
 
     for (auto &pluginPath : paths) {

--- a/Source/UI/ControlPanel.cpp
+++ b/Source/UI/ControlPanel.cpp
@@ -426,11 +426,7 @@ ControlPanel::ControlPanel(ProcessorGraph* graph_, AudioComponent* audio_)
     addChildComponent(newDirectoryButton);
 
 
-#if defined(__APPLE__)
     const File dataDirectory = CoreServices::getDefaultUserSaveDirectory();
-#else
-    const File dataDirectory = File::getSpecialLocation(File::currentExecutableFile).getParentDirectory();
-#endif
 
     filenameComponent = new FilenameComponent("folder selector",
                                               dataDirectory.getFullPathName(),

--- a/Source/UI/PluginInstaller.cpp
+++ b/Source/UI/PluginInstaller.cpp
@@ -40,13 +40,10 @@
 static inline File getPluginsLocationDirectory() {
 #if defined(__APPLE__)
     File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
-    if (!dir.isDirectory()) {
-        dir.createDirectory();
-    }
-    return std::move(dir);
 #else
-    return File::getSpecialLocation(File::currentExecutableFile).getParentDirectory();
+    File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
 #endif
+    return std::move(dir);
 }
 
 static String osType;

--- a/Source/UI/PluginInstaller.cpp
+++ b/Source/UI/PluginInstaller.cpp
@@ -40,8 +40,10 @@
 static inline File getPluginsLocationDirectory() {
 #if defined(__APPLE__)
     File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
-#else
+#elif _WIN32
     File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
+#else
+	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");;
 #endif
     return std::move(dir);
 }

--- a/Source/UI/PluginInstaller.cpp
+++ b/Source/UI/PluginInstaller.cpp
@@ -679,7 +679,7 @@ void PluginListBoxComponent::returnKeyPressed (int lastRowSelected)
 
 /* ================================== Plugin Information Component ================================== */
 
-PluginInfoComponent::PluginInfoComponent()
+PluginInfoComponent::PluginInfoComponent() : ThreadWithProgressWindow("Plugin Installer", false, false)
 {
 	infoFont = Font("FiraSans", 20, Font::plain);
 	infoFontBold = Font("FiraSans Bold", 20, Font::plain);
@@ -792,118 +792,127 @@ void PluginInfoComponent::buttonClicked(Button* button)
 {
 	if (button == &downloadButton)
 	{
-		std::cout << "\nDownloading Plugin: " << pInfo.pluginName << "...  " << std::endl;
-		
-		// If a plugin has depencies outside its zip, download them
-		for (int i = 0; i < pInfo.dependencies.size(); i++)
-		{
-			String depUrl = "https://api.bintray.com/packages/open-ephys-gui-plugins/";
-			depUrl += pInfo.dependencies[i] + "/" + pInfo.dependencies[i] + "-" ;
-			depUrl += osType + "/versions/_latest";
-
-			String depResponse = URL(depUrl).readEntireTextStream();
-			var depReply = JSON::parse(depResponse);
-			String ver = depReply.getProperty("name", "NULL");
-
-			int retCode = downloadPlugin(pInfo.dependencies[i], ver, true);
-
-			if (retCode == 2)
-			{
-				AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-												"[Plugin Installer] " + pInfo.dependencies[i], 
-												"Could not install dependency: " + pInfo.dependencies[i] 
-												+ ". Please contact the developers.");
-				
-				std::cout << "Download Failed!!" << std::endl;
-				return;
-			}
-		}
-		
-		// download the plugin
-		int dlReturnCode = downloadPlugin(pInfo.pluginName, pInfo.selectedVersion, false);
-
-		if (dlReturnCode == SUCCESS)
-		{	
-			AlertWindow::showMessageBoxAsync(AlertWindow::InfoIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											pInfo.displayName + " Installed Successfully");
-
-			std::cout << "Download Successfull!!" << std::endl;
-
-			pInfo.installedVersion = pInfo.selectedVersion;
-			downloadButton.setEnabled(false);
-			downloadButton.setButtonText("Installed");
-		}
-		else if (dlReturnCode == ZIP_NOTFOUND)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											"Could not find the ZIP file for " + pInfo.displayName 
-											+ ". Please contact the developers.");
-
-			std::cout << "Download Failed!!" << std::endl;
-		}
-		else if (dlReturnCode == UNCMP_ERR)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											"Could not uncompress the ZIP file. Please try again.");
-
-			std::cout << "Download Failed!!" << std::endl;
-		}
-		else if (dlReturnCode == XML_MISSING)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											"Unable to locate installedPlugins.xml \n Please restart Plugin Installer and try again.");
-
-			std::cout << "XML File Missing!!" << std::endl;
-		}
-		else if (dlReturnCode == VER_EXISTS_ERR)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											pInfo.displayName + " v" + pInfo.selectedVersion 
-											+ " already exists. Please download another version.");
-
-			std::cout << "Download Failed!!" << std::endl;
-		}
-		else if (dlReturnCode == XML_WRITE_ERR)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											"Unable to write to installedPlugins.xml \n Please try again.");
-			
-			std::cout << "Writing to XML Failed!!" << std::endl;
-		}
-		else if (dlReturnCode == LOAD_ERR)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											"Unable to load " + pInfo.displayName 
-											+ " in the Processor List.\nLook at console output for more details.");
-
-			std::cout << "Loading Plugin Failed!!" << std::endl;
-
-			pInfo.installedVersion = pInfo.selectedVersion;
-			downloadButton.setEnabled(false);
-			downloadButton.setButtonText("Installed");
-		}
-		else if (dlReturnCode == PROC_IN_USE)
-		{
-			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
-											"[Plugin Installer] " + pInfo.displayName, 
-											"Plugin already in use. Please remove it from the signal chain and try again.");
-
-			std::cout << "Error.. Plugin already in use. Please remove it from the signal chain and try again." << std::endl;
-		}
-
+		this->runThread();
 	}
 	else if (button == &documentationButton)
 	{
 		URL url = URL(pInfo.docURL);
 		url.launchInDefaultBrowser();
 	}
+}
+
+void PluginInfoComponent::run()
+{
+	std::cout << "\nDownloading Plugin: " << pInfo.pluginName << "...  " << std::endl;
+		
+	// If a plugin has depencies outside its zip, download them
+	for (int i = 0; i < pInfo.dependencies.size(); i++)
+	{
+		String depUrl = "https://api.bintray.com/packages/open-ephys-gui-plugins/";
+		depUrl += pInfo.dependencies[i] + "/" + pInfo.dependencies[i] + "-" ;
+		depUrl += osType + "/versions/_latest";
+
+		setStatusMessage("Downloading dependency: " + pInfo.dependencies[i]);
+
+		String depResponse = URL(depUrl).readEntireTextStream();
+		var depReply = JSON::parse(depResponse);
+		String ver = depReply.getProperty("name", "NULL");
+
+		int retCode = downloadPlugin(pInfo.dependencies[i], ver, true);
+
+		if (retCode == 2)
+		{
+			AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+											"[Plugin Installer] " + pInfo.dependencies[i], 
+											"Could not install dependency: " + pInfo.dependencies[i] 
+											+ ". Please contact the developers.");
+			
+			std::cout << "Download Failed!!" << std::endl;
+			return;
+		}
+	}
+	
+	setStatusMessage("Downloading " + pInfo.displayName + " ...");
+
+	// download the plugin
+	int dlReturnCode = downloadPlugin(pInfo.pluginName, pInfo.selectedVersion, false);
+
+	if (dlReturnCode == SUCCESS)
+	{	
+		AlertWindow::showMessageBoxAsync(AlertWindow::InfoIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										pInfo.displayName + " Installed Successfully");
+
+		std::cout << "Download Successfull!!" << std::endl;
+
+		pInfo.installedVersion = pInfo.selectedVersion;
+		downloadButton.setEnabled(false);
+		downloadButton.setButtonText("Installed");
+	}
+	else if (dlReturnCode == ZIP_NOTFOUND)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										"Could not find the ZIP file for " + pInfo.displayName 
+										+ ". Please contact the developers.");
+
+		std::cout << "Download Failed!!" << std::endl;
+	}
+	else if (dlReturnCode == UNCMP_ERR)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										"Could not uncompress the ZIP file. Please try again.");
+
+		std::cout << "Download Failed!!" << std::endl;
+	}
+	else if (dlReturnCode == XML_MISSING)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										"Unable to locate installedPlugins.xml \n Please restart Plugin Installer and try again.");
+
+		std::cout << "XML File Missing!!" << std::endl;
+	}
+	else if (dlReturnCode == VER_EXISTS_ERR)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										pInfo.displayName + " v" + pInfo.selectedVersion 
+										+ " already exists. Please download another version.");
+
+		std::cout << "Download Failed!!" << std::endl;
+	}
+	else if (dlReturnCode == XML_WRITE_ERR)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										"Unable to write to installedPlugins.xml \n Please try again.");
+		
+		std::cout << "Writing to XML Failed!!" << std::endl;
+	}
+	else if (dlReturnCode == LOAD_ERR)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										"Unable to load " + pInfo.displayName 
+										+ " in the Processor List.\nLook at console output for more details.");
+
+		std::cout << "Loading Plugin Failed!!" << std::endl;
+
+		pInfo.installedVersion = pInfo.selectedVersion;
+		downloadButton.setEnabled(false);
+		downloadButton.setButtonText("Installed");
+	}
+	else if (dlReturnCode == PROC_IN_USE)
+	{
+		AlertWindow::showMessageBoxAsync(AlertWindow::WarningIcon, 
+										"[Plugin Installer] " + pInfo.displayName, 
+										"Plugin already in use. Please remove it from the signal chain and try again.");
+
+		std::cout << "Error.. Plugin already in use. Please remove it from the signal chain and try again." << std::endl;
+	}
+
 }
 
 int PluginInfoComponent::versionCompare(const String& v1, const String& v2)

--- a/Source/UI/PluginInstaller.cpp
+++ b/Source/UI/PluginInstaller.cpp
@@ -43,7 +43,7 @@ static inline File getPluginsLocationDirectory() {
 #elif _WIN32
     File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
 #else
-	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");;
+	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");
 #endif
     return std::move(dir);
 }

--- a/Source/UI/PluginInstaller.h
+++ b/Source/UI/PluginInstaller.h
@@ -68,7 +68,8 @@ struct SelectedPluginInfo
 */
 class PluginInfoComponent : public Component,
                             public Button::Listener,
-                            public ComboBox::Listener
+                            public ComboBox::Listener,
+                            public ThreadWithProgressWindow
 {
 public:
     PluginInfoComponent();
@@ -122,6 +123,8 @@ private:
     SelectedPluginInfo pInfo;
 
     enum RetunCode {ZIP_NOTFOUND, SUCCESS, UNCMP_ERR, XML_MISSING, VER_EXISTS_ERR, XML_WRITE_ERR, LOAD_ERR, PROC_IN_USE};
+
+    void run() override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (PluginInfoComponent);
 

--- a/Source/UI/SignalChainManager.cpp
+++ b/Source/UI/SignalChainManager.cpp
@@ -25,6 +25,8 @@
 
 #include "EditorViewport.h"
 
+#include "../AccessClass.h"
+
 #include <iostream>
 
 SignalChainManager::SignalChainManager
@@ -557,4 +559,7 @@ void SignalChainManager::updateProcessorSettings()
 			}
 		}
 	}
+
+    File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
+    AccessClass::getEditorViewport()->saveState(recoveryFile);
 }


### PR DESCRIPTION
This PR makes following updates:

* Display a "downloading" window while installing a plugin via Plugin Installer (see below)
* Change locations of plugins installed via Plugin Installer, as well as, lastConfig.xml and windowState.xml files
   * Windows: `C:\ProgramData\Open Ephys`
   * Linux: `/home/<Username>/.open-ephys`
   * Mac: `/Users/<Username>/Library/Application Support/open-ephys/plugins` (unchanged)
* Change default data directory for Recordings and SampleData
   * Windows: `C:\Users\<Username>\Documents\Open Ephys`
   * Linux: `/home/<Username>/open-ephys`
   * Mac: `/Users/<Username>/Documents/Open Ephys`
* Add support for generating installers for Windows and Linux (.deb) via GitHub Actions
* Add a recoverConfig.xml as a backup that saves configured settings every time Signal Chain or audio configuration is updated, to use when a GUI crash occurs. 
* Launch debug console on Windows by default (no need to run the GUI via command line with `--console` option)
* Set Reload on Startup to true by default.

![plugin-installer-downloading-plugin](https://user-images.githubusercontent.com/11559287/92189478-9502cf00-ee13-11ea-9666-6fb112fb5582.png)



