### PR TITLE
 Change plugin and shared directory location depending on GUI build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Open Ephys GUI main build file
 cmake_minimum_required(VERSION 3.5.0)
 
-set(GUI_VERSION 0.5.0)
+set(GUI_VERSION 0.5.1)
 
 string(REGEX MATCHALL "[0-9]+" VERSION_LIST ${GUI_VERSION})
 set(GUI_VERSION_HEX "0x")

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Our primary user base is scientists performing electrophysiology experiments wit
 
 The easiest way to get started is to download the installer for your platform of choice:
 
-- [Windows](https://dl.bintray.com/open-ephys-gui/Release-Installer/Install-Open-Ephys-GUI-v0.5.0.exe) (Neuropixels plugins available via File > Plugin Installer)
-- [Ubuntu/Debian](https://dl.bintray.com/open-ephys-gui/Release-Installer/open-ephys-gui-v0.5.0.deb)
-- [macOS](https://dl.bintray.com/open-ephys-gui/Release-Installer/Open_Ephys_GUI_v0.5.0.dmg)
+- [Windows](https://dl.bintray.com/open-ephys-gui/Release-Installer/Install-Open-Ephys-GUI-v0.5.1.exe) (Neuropixels plugins available via File -> Plugin Installer)
+- [Ubuntu/Debian](https://dl.bintray.com/open-ephys-gui/Release-Installer/open-ephys-gui-v0.5.1.deb)
+- [macOS](https://dl.bintray.com/open-ephys-gui/Release-Installer/Open_Ephys_GUI_v0.5.1.dmg)
 
-It’s also possible to obtain the binaries as a .zip file for [Windows](https://dl.bintray.com/open-ephys-gui/Release/open-ephys-v0.5.0-windows.zip), [Linux](https://dl.bintray.com/open-ephys-gui/Release/open-ephys-v0.5.0-linux.zip), or [Mac](https://dl.bintray.com/open-ephys-gui/Release/open-ephys-v0.5.0-mac.zip).
+It’s also possible to obtain the binaries as a .zip file for [Windows](https://dl.bintray.com/open-ephys-gui/Release/open-ephys-v0.5.1-windows.zip), [Linux](https://dl.bintray.com/open-ephys-gui/Release/open-ephys-v0.5.1-linux.zip), or [Mac](https://dl.bintray.com/open-ephys-gui/Release/open-ephys-v0.5.1-mac.zip).
 
 Detailed installation instructions can be found [here](https://open-ephys.github.io/gui-docs/User-Manual/Installing-the-GUI.html).
 

--- a/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/control
+++ b/Resources/Installers/Linux/Open-Ephys_Installer/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: open-ephys
-Version: 0.5.0
+Version: 0.5.1
 Architecture: amd64
 Installed-Size: 18644
 Section: science

--- a/Resources/Installers/Windows/windows_installer_script.iss
+++ b/Resources/Installers/Windows/windows_installer_script.iss
@@ -1,7 +1,7 @@
 [Setup]
 AppName=Open Ephys
-AppVersion=0.5.0
-AppVerName=Open Ephys 0.5.0
+AppVersion=0.5.1
+AppVerName=Open Ephys 0.5.1
 AppPublisher=open-ephys.org
 AppPublisherURL=https://open-ephys.org/gui
 DefaultDirName={autopf}\Open Ephys
@@ -23,6 +23,7 @@ Name: install_usb; Description: "Install Opal Kelly Front Panel USB driver for O
 
 [Files]
 Source: "..\..\..\Build\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs; BeforeInstall: UpdateProgress(0);
+Source: "..\..\..\Build\Release\shared\*"; DestDir: "{commonappdata}\Open Ephys\shared"; Flags: ignoreversion recursesubdirs; BeforeInstall: UpdateProgress(55);
 Source: "..\..\DataFiles\*"; DestDir: "{userdocs}\Open Ephys\DataFiles"; Flags: ignoreversion recursesubdirs; BeforeInstall: UpdateProgress(60);
 Source: "vcredist_x64.exe"; DestDir: {tmp}; Flags: deleteafterinstall; BeforeInstall: UpdateProgress(70);
 Source: "..\..\DLLs\FrontPanelUSB-DriverOnly-4.5.5.exe"; DestDir: {tmp}; Flags: deleteafterinstall; BeforeInstall: UpdateProgress(90);

--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -245,9 +245,19 @@ namespace CoreServices
 #if defined(__APPLE__)
     	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
 #elif _WIN32
-    	File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
+    	String appDir = File::getSpecialLocation(File::currentApplicationFile).getFullPathName();
+		File dir;
+		if(appDir.contains("plugin-GUI\\Build\\"))
+			dir = File::getSpecialLocation(File::currentApplicationFile).getParentDirectory();
+		else
+			dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
 #else
-		File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");;
+		String appDir = File::getSpecialLocation(File::currentApplicationFile).getFullPathName();
+		File dir;
+		if(appDir.contains("plugin-GUI/Build/"))
+			dir = File::getSpecialLocation(File::currentApplicationFile).getParentDirectory();
+		else
+			dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");;
 #endif
 		if (!dir.isDirectory()) {
 			dir.createDirectory();

--- a/Source/UI/PluginInstaller.cpp
+++ b/Source/UI/PluginInstaller.cpp
@@ -37,17 +37,6 @@
 
 //-----------------------------------------------------------------------
 
-static inline File getPluginsLocationDirectory() {
-#if defined(__APPLE__)
-    File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile("Application Support/open-ephys");
-#elif _WIN32
-    File dir = File::getSpecialLocation(File::commonApplicationDataDirectory).getChildFile("Open Ephys");
-#else
-	File dir = File::getSpecialLocation(File::userApplicationDataDirectory).getChildFile(".open-ephys");
-#endif
-    return std::move(dir);
-}
-
 static String osType;
 
 PluginInstaller::PluginInstaller(MainWindow* mainWindow)
@@ -108,12 +97,12 @@ void PluginInstaller::closeButtonPressed()
 
 void PluginInstaller::createXmlFile()
 {
-	File pluginsDir = getPluginsLocationDirectory().getChildFile("plugins");
+	File pluginsDir = CoreServices::getSavedStateDirectory().getChildFile("plugins");
     if (!pluginsDir.isDirectory())
         pluginsDir.createDirectory();
     
     String xmlFile = "plugins" + File::separatorString + "installedPlugins.xml";
-	File file = getPluginsLocationDirectory().getChildFile(xmlFile);
+	File file = CoreServices::getSavedStateDirectory().getChildFile(xmlFile);
 
 	XmlDocument doc(file);
 	std::unique_ptr<XmlElement> xml (doc.getDocumentElement());
@@ -139,7 +128,7 @@ void PluginInstaller::createXmlFile()
 
 		forEachXmlChildElement(*child, e)
 		{
-			File pluginPath = getPluginsLocationDirectory().getChildFile(baseStr + e->getAttributeValue(1));
+			File pluginPath = CoreServices::getSavedStateDirectory().getChildFile(baseStr + e->getAttributeValue(1));
 			if (!pluginPath.exists())
 				elementsToRemove.add(e);	
 		}
@@ -341,7 +330,7 @@ void PluginInstallerComponent::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
 void PluginInstallerComponent::run()
 {
 	String fileStr = "plugins" + File::separatorString + "installedPlugins.xml";
-	File xmlFile = getPluginsLocationDirectory().getChildFile(fileStr);
+	File xmlFile = CoreServices::getSavedStateDirectory().getChildFile(fileStr);
 
 	XmlDocument doc(xmlFile);
 	std::unique_ptr<XmlElement> xml (doc.getDocumentElement());
@@ -665,7 +654,7 @@ bool PluginListBoxComponent::loadPluginInfo(const String& pluginName)
 
 	// If the plugin is already installed, get installed version number
 	String fileStr = "plugins" + File::separatorString + "installedPlugins.xml";
-	File xmlFile = getPluginsLocationDirectory().getChildFile(fileStr);
+	File xmlFile = CoreServices::getSavedStateDirectory().getChildFile(fileStr);
 
 	XmlDocument doc(xmlFile);
 	std::unique_ptr<XmlElement> xml (doc.getDocumentElement());
@@ -1111,7 +1100,7 @@ int PluginInfoComponent::downloadPlugin(const String& plugin, const String& vers
 			return 0;
 
 		//Get path to plugins directory
-		File pluginsPath = getPluginsLocationDirectory();
+		File pluginsPath = CoreServices::getSavedStateDirectory();
 
 		//Construct path for downloaded zip file
 		String pluginFilePath = pluginsPath.getFullPathName();


### PR DESCRIPTION
 - If GUI is built from source:
   - Plugin Installer plugins and shared dependencies will be installed at executable-level plugins and shared directory respectively
   - Config and windowState XML files will be saved at the same level as executable
- If GUI is installed using installers/zip:
  - Same as in [v0.5.0](https://github.com/open-ephys/plugin-GUI/releases/tag/v0.5.0)
- Fixes open-ephys-plugins/nidaq-plugin#5
- Bumps the GUI version to v0.5.1