### PR TITLE
Fix splitter attaching first processor to second branch causing errors

### DIFF
--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -83,6 +83,7 @@
 
 		if(lastConfig.existsAsFile())
 		{
+			std::cout << "Comparing configs" << std::endl;
 			if(compareConfigFiles(lastConfig, recoveryConfig))
 			{
 				ui->getEditorViewport()->loadState(lastConfig);
@@ -282,6 +283,7 @@ bool MainWindow::compareConfigFiles(File file1, File file2)
 	if(rcXml == 0 || ! rcXml->hasTagName("SETTINGS"))
 	{
 		std::cout << "Recovery config is inavlid. Loading lastConfig.xml" << std::endl;
+		return true;
 	}
 
 	auto lcSig = lcXml->getChildByName("SIGNALCHAIN");

--- a/Source/Processors/Editors/GenericEditor.cpp
+++ b/Source/Processors/Editors/GenericEditor.cpp
@@ -554,9 +554,13 @@ void GenericEditor::update()
 
     updateVisualizer(); // does nothing unless this method
     // has been implemented
-
-    File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
-    AccessClass::getEditorViewport()->saveState(recoveryFile);
+    
+    EditorViewport* ev = AccessClass::getEditorViewport();
+    if(!ev->loadingConfig)
+    {
+        File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
+        ev->saveState(recoveryFile);
+    }
 
 }
 

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1222,6 +1222,7 @@ const String EditorViewport::saveState(File fileToUse, String* xmlText)
 
     Array<GenericProcessor*> splitPoints;
     Array<GenericProcessor*> allSplitters;
+    Array<int> splitterStates;
     /** Used to reset saveOrder at end, to allow saving the same processor multiple times*/
     Array<GenericProcessor*> allProcessors;
 
@@ -1262,7 +1263,12 @@ const String EditorViewport::saveState(File fileToUse, String* xmlText)
                 {
                     // add to list of splitters to come back to
                     splitPoints.add(processor);
-                    allSplitters.add(processor);
+
+                    //keep track of all splitters and their inital states
+                    allSplitters.add(processor); 
+                    Splitter* sp = (Splitter*)processor;
+                    splitterStates.add(sp->getPath());
+                    
                     processor->switchIO(0);
                 }
 
@@ -1296,12 +1302,13 @@ const String EditorViewport::saveState(File fileToUse, String* xmlText)
                 }
             }
         }
-        
-        for (GenericProcessor* sp : allSplitters) {
-            sp->switchIO(0);
-        }
 
         xml->addChildElement(signalChain);
+    }
+
+    // Loop through all splitters and reset their states to original values
+    for (int i = 0; i < allSplitters.size(); i++) {
+        allSplitters[i]->switchIO(splitterStates[i]);
     }
 
     XmlElement* audioSettings = new XmlElement("AUDIO");

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -157,7 +157,7 @@ public:
     const String loadState(File filename);
 
     /** Converts information about a given editor to XML. */
-    XmlElement* createNodeXml(GenericProcessor*);
+    XmlElement* createNodeXml(GenericProcessor*, bool isStartOfSignalChain);
 
     /** Converts information about a splitter or merge to XML. */
     XmlElement* switchNodeXml(GenericProcessor*);

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -28,6 +28,7 @@
 #include "../Processors/ProcessorGraph/ProcessorGraph.h"
 #include "../Processors/Editors/GenericEditor.h"
 #include "../Processors/Splitter/SplitterEditor.h"
+#include "../Processors/Splitter/Splitter.h"
 #include "../Processors/Merger/MergerEditor.h"
 
 #include "ControlPanel.h"

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -174,6 +174,9 @@ public:
     int leftmostEditor;
 
     File currentFile;
+    
+    // Flag to check whether config is being loaded currently
+    bool loadingConfig;
 
 private:
 

--- a/Source/UI/SignalChainManager.cpp
+++ b/Source/UI/SignalChainManager.cpp
@@ -575,7 +575,11 @@ void SignalChainManager::updateProcessorSettings()
 			}
 		}
 	}
-
-    File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
-    AccessClass::getEditorViewport()->saveState(recoveryFile);
+    
+    EditorViewport* ev = AccessClass::getEditorViewport();
+    if(!ev->loadingConfig)
+    {
+        File recoveryFile = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");
+        ev->saveState(recoveryFile);
+    }
 }


### PR DESCRIPTION
* Reset the state of Splitters to the last activePath value when adding it to signal chain while saving to recoveryConfig.
* Stop saving state to recoveryConfig while loading config on startup.
* Fix a crash with Reload on startup enabled when recoveryConfig file does not exists and lastConfig does.
* Resolves #377 
