### PR TITLE
Allow RecordNode to load saved data path on startup

### DIFF
--- a/Source/Processors/RecordNode/RecordNodeEditor.cpp
+++ b/Source/Processors/RecordNode/RecordNodeEditor.cpp
@@ -66,6 +66,7 @@ RecordNodeEditor::RecordNodeEditor(RecordNode* parentNode, bool useDefaultParame
 	dataPathLabel->setColour(Label::backgroundColourId, Colours::grey);
 	dataPathLabel->setColour(Label::backgroundWhenEditingColourId, Colours::white);
 	dataPathLabel->setJustificationType(Justification::centredLeft);
+	dataPathLabel->addListener(this);
 	addAndMakeVisible(dataPathLabel);
 
 	dataPathButton = new UtilityButton("...", Font(12));
@@ -353,6 +354,11 @@ void RecordNodeEditor::buttonEvent(Button *button)
 
 	}
 
+}
+
+void RecordNodeEditor::labelTextChanged(Label* label)
+{
+	recordNode->setDataDirectory(label->getText());
 }
 
 void RecordNodeEditor::collapsedStateChanged()

--- a/Source/Processors/RecordNode/RecordNodeEditor.h
+++ b/Source/Processors/RecordNode/RecordNodeEditor.h
@@ -101,7 +101,7 @@ private:
 	void paintButton(Graphics& g, bool isMouseOver, bool isButtonDown) override;
 };
 \
-class RecordNodeEditor : public GenericEditor, ComboBoxListener
+class RecordNodeEditor : public GenericEditor, ComboBoxListener, LabelListener
 {
 public:
 
@@ -119,6 +119,7 @@ public:
 
 	void timerCallback() override;
 	void comboBoxChanged(ComboBox*); 
+	void labelTextChanged(Label*);
 
 	void saveCustomParameters(XmlElement* xml);
 	void loadCustomParameters(XmlElement* xml);


### PR DESCRIPTION
Custom Record Node saving paths were not actually getting re-loaded from config files. This is fixed now.