### PR TITLE
Prevent crashes when re-loading signal chain with disconnected acq board

### DIFF
--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -50,7 +50,9 @@ LfpDisplayCanvas::LfpDisplayCanvas(LfpDisplayNode* processor_) :
     nChans = processor->getNumSubprocessorChannels();
 
     displayBuffer = processor->getDisplayBufferAddress();
-    displayBufferSize = displayBuffer->getNumSamples();
+
+    if (displayBuffer != nullptr)
+        displayBufferSize = displayBuffer->getNumSamples();
 
     screenBuffer = new AudioSampleBuffer(MAX_N_CHAN, MAX_N_SAMP);
     screenBuffer->clear();
@@ -194,7 +196,7 @@ void LfpDisplayCanvas::resizeToChannels(bool respectViewportPosition)
 void LfpDisplayCanvas::beginAnimation()
 {
 
-    if (true)
+    if (displayBuffer != nullptr)
     {
 
         displayBufferSize = displayBuffer->getNumSamples();
@@ -220,7 +222,8 @@ void LfpDisplayCanvas::endAnimation()
 void LfpDisplayCanvas::update()
 {
 
-    displayBufferSize = displayBuffer->getNumSamples();
+    if (displayBuffer != nullptr)
+        displayBufferSize = displayBuffer->getNumSamples();
 
     nChans = jmax(processor->getNumSubprocessorChannels(), 0);
 

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -143,6 +143,22 @@ void LfpDisplayNode::updateSettings()
     resizeBuffer();
 }
 
+std::shared_ptr<AudioSampleBuffer> LfpDisplayNode::getDisplayBufferAddress() const
+{ 
+    if (displayBuffers.size() > 0)
+        return displayBuffers[allSubprocessors.indexOf(subprocessorToDraw)];
+    else
+        return nullptr;
+}
+
+int LfpDisplayNode::getDisplayBufferIndex(int chan) const
+{ 
+    if (displayBufferIndices.size() > 0)
+        return displayBufferIndices[allSubprocessors.indexOf(subprocessorToDraw)][chan];
+    else
+        return -1;
+}
+
 uint32 LfpDisplayNode::getEventSourceId(const EventChannel* event)
 {
     return getProcessorFullId(event->getTimestampOriginProcessor(), event->getTimestampOriginSubProcessor());

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.h
@@ -62,9 +62,9 @@ public:
 
     void handleEvent (const EventChannel* eventInfo, const MidiMessage& event, int samplePosition = 0) override;
 
-    std::shared_ptr<AudioSampleBuffer> getDisplayBufferAddress() const { return displayBuffers[allSubprocessors.indexOf(subprocessorToDraw)]; }
+    std::shared_ptr<AudioSampleBuffer> getDisplayBufferAddress() const;
 
-    int getDisplayBufferIndex (int chan) const { return displayBufferIndices[allSubprocessors.indexOf(subprocessorToDraw)][chan]; }
+    int getDisplayBufferIndex(int chan) const;
 
     CriticalSection* getMutex() { return &displayMutex; }
 

--- a/Plugins/RhythmNode/RHD2000Editor.cpp
+++ b/Plugins/RhythmNode/RHD2000Editor.cpp
@@ -119,6 +119,10 @@ void FPGAchannelList::buttonClicked(Button* btn)
 
 void FPGAchannelList::update()
 {
+
+    if (!proc->isEnabled)
+        return;
+
    // const int columnWidth = 330;
     const int columnWidth = 250;
     // Query processor for number of channels, types, gains, etc... and update the UI
@@ -204,25 +208,33 @@ void FPGAchannelList::update()
             {
                 int channelGainIndex = 1;
                 int realChan = thread->getChannelFromHeadstage(k, ch);
-                float ch_gain = proc->getDataChannel(realChan)->getBitVolts() / proc->getBitVolts(proc->getDataChannel(realChan));
-                for (int j = 0; j < gains.size(); j++)
-                {
-                    if (fabs(gains[j] - ch_gain) < 1e-3)
-                    {
-                        channelGainIndex = j;
-                        break;
-                    }
-                }
-                if (k < MAX_NUM_HEADSTAGES)
-                    type = ch < numChannelsPerHeadstage[k] ? DataChannel::HEADSTAGE_CHANNEL : DataChannel::AUX_CHANNEL;
-                else
-                    type = DataChannel::ADC_CHANNEL;
 
-                FPGAchannelComponent* comp = new FPGAchannelComponent(this, realChan, channelGainIndex + 1, thread->getChannelName(realChan), gains, type);
-                comp->setBounds(10 + hsColumn[k], 70 + ch * 22, columnWidth, 22);
-                comp->setUserDefinedData(k);
-                addAndMakeVisible(comp);
-                channelComponents.add(comp);
+                RHD2000Thread* p = (RHD2000Thread*) proc->getThread();
+
+                if (realChan < p->getNumChannels())
+                {
+                    float ch_gain = proc->getDataChannel(realChan)->getBitVolts() / proc->getBitVolts(proc->getDataChannel(realChan));
+
+                    for (int j = 0; j < gains.size(); j++)
+                    {
+                        if (fabs(gains[j] - ch_gain) < 1e-3)
+                        {
+                            channelGainIndex = j;
+                            break;
+                        }
+                    }
+                    if (k < MAX_NUM_HEADSTAGES)
+                        type = ch < numChannelsPerHeadstage[k] ? DataChannel::HEADSTAGE_CHANNEL : DataChannel::AUX_CHANNEL;
+                    else
+                        type = DataChannel::ADC_CHANNEL;
+
+                    FPGAchannelComponent* comp = new FPGAchannelComponent(this, realChan, channelGainIndex + 1, thread->getChannelName(realChan), gains, type);
+                    comp->setBounds(10 + hsColumn[k], 70 + ch * 22, columnWidth, 22);
+                    comp->setUserDefinedData(k);
+                    addAndMakeVisible(comp);
+                    channelComponents.add(comp);
+                }
+                
             }
         }
     }

--- a/Plugins/RhythmNode/RHD2000Thread.cpp
+++ b/Plugins/RhythmNode/RHD2000Thread.cpp
@@ -130,6 +130,7 @@ RHD2000Thread::RHD2000Thread(SourceNode* sn) : DataThread(sn),
     dacChannels = nullptr;
     dacThresholds = nullptr;
     dacChannelsToUpdate = nullptr;
+
     if (openBoard(libraryFilePath))
     {
         dataBlock = new Rhd2000DataBlock(1,evalBoard->isUSB3());
@@ -201,7 +202,10 @@ bool RHD2000Thread::usesCustomNames() const
 
 unsigned int RHD2000Thread::getNumSubProcessors() const
 {
-    return 1;
+    if (deviceFound)
+        return 1;
+    else
+        return 0;
 }
 
 void RHD2000Thread::setDACthreshold(int dacOutput, float threshold)
@@ -1176,12 +1180,14 @@ void RHD2000Thread::enableAuxs(bool t)
     acquireAuxChannels = t;
     sourceBuffers[0]->resize(getNumChannels(), 10000);
     updateRegisters();
+    sn->update();
 }
 
 void RHD2000Thread::enableAdcs(bool t)
 {
     acquireAdcChannels = t;
     sourceBuffers[0]->resize(getNumChannels(), 10000);
+    sn->update();
 }
 
 bool RHD2000Thread::isAuxEnabled()

--- a/Source/Processors/DataThreads/DataThread.cpp
+++ b/Source/Processors/DataThreads/DataThread.cpp
@@ -82,12 +82,14 @@ void DataThread::updateChannels()
 	ttlEventWords.clear();
 	timestamps.clear();
 	int nSub = getNumSubProcessors();
+
 	for (int i = 0; i < nSub; i++)
 	{
 		ttlEventWords.add(0);
 		timestamps.add(0);
 	}
-    if (usesCustomNames())
+
+    if (foundInputSource() && usesCustomNames())
     {
         channelInfo.resize (sn->getTotalDataChannels());
         setDefaultChannelNames();

--- a/Source/Processors/Editors/GenericEditor.cpp
+++ b/Source/Processors/Editors/GenericEditor.cpp
@@ -37,11 +37,11 @@
 #ifndef M_PI
 #define M_PI 3.14159265359
 #endif
-GenericEditor::GenericEditor(GenericProcessor* owner, bool useDefaultParameterEditors=true)
+GenericEditor::GenericEditor(GenericProcessor* owner, bool useDefaultParameterEditors = true)
     : AudioProcessorEditor(owner),
-      desiredWidth(150), isFading(false), accumulator(0.0), acquisitionIsActive(false),
-      drawerButton(0), drawerWidth(170),
-      drawerOpen(false), channelSelector(0), isSelected(false), isEnabled(true), isCollapsed(false), tNum(-1)
+    desiredWidth(150), isFading(false), accumulator(0.0), acquisitionIsActive(false),
+    drawerButton(0), drawerWidth(170),
+    drawerOpen(false), channelSelector(0), isSelected(false), isEnabled(false), isCollapsed(false), tNum(-1)
 {
     constructorInitialize(owner, useDefaultParameterEditors);
 }

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -337,6 +337,7 @@ void RecordNode::updateSubprocessorMap()
     std::map<int, std::vector<int>> inputs;
 
     int updatedNumSubprocessors = 0;
+	int originalChannelCount = numChannels;
     int ch = 0;
 
     while (ch < dataChannelArray.size())
@@ -379,7 +380,7 @@ void RecordNode::updateSubprocessorMap()
         }
         
     }
-    
+
     //Remove any stale processors
     std::vector<int> sources;
     for(auto const& sourceID : inputs)

--- a/Source/Processors/SourceNode/SourceNode.cpp
+++ b/Source/Processors/SourceNode/SourceNode.cpp
@@ -234,10 +234,22 @@ void SourceNode::setEnabledState (bool newState)
     if (newState && ! dataThread->foundInputSource())
     {
         isEnabled = false;
+
+        if (editor != nullptr)
+            editor->disable();
     }
     else
     {
         isEnabled = newState;
+
+        if (editor != nullptr)
+        {
+            if (newState)
+                editor->enable();
+            else
+                editor->disable();
+        }
+        
     }
 }
 


### PR DESCRIPTION
Cases tested:
- 2 headstages + ADCs in saved state, 1 headstage on re-load
- 1 headstage + ADCs in saved state, no headstages on re-load
- ADCs in saved state, no acquisition board connected on re-load

Also made some changes to prevent LFP Viewer from crashing with 0 input channels. 