### PR TITLE
Use gateway site to speed up Plugin Installer

### DIFF
--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -114,12 +114,22 @@ MainWindow::~MainWindow()
 		audioComponent->endCallbacks();
 		processorGraph->disableProcessors();
 	}
+    
+    
+        
 
 	saveWindowBounds();
 
 	audioComponent->disconnectProcessorGraph();
 	UIComponent* ui = (UIComponent*) getContentComponent();
 	ui->disableDataViewport();
+    
+    if (ui->getPluginInstaller() != nullptr)
+    {
+        PluginInstaller* pi =ui->getPluginInstaller();
+        pi->setVisible(false);
+        delete pi;
+    }
 
 	File lastConfig = CoreServices::getSavedStateDirectory().getChildFile("lastConfig.xml");
 	File recoveryConfig = CoreServices::getSavedStateDirectory().getChildFile("recoveryConfig.xml");

--- a/Source/UI/PluginInstaller.h
+++ b/Source/UI/PluginInstaller.h
@@ -135,7 +135,8 @@ private:
 */
 class PluginListBoxComponent : public Component,
                                public ListBoxModel,
-                               public ThreadWithProgressWindow
+                               public Thread
+                             //  public ThreadWithProgressWindow
 {
 public:
 
@@ -164,6 +165,8 @@ private:
     Font listFont;
     int numRows;
     int maxTextWidth = 0;
+    
+    var pluginData;
 
     String lastPluginSelected; 
     Array<String> pluginVersion;

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -183,6 +183,11 @@ PluginManager* UIComponent::getPluginManager()
 	return pluginManager;
 }
 
+PluginInstaller* UIComponent::getPluginInstaller()
+{
+    return pluginInstaller;
+}
+
 void UIComponent::buttonClicked(Button* button)
 {
     if (button == &messageCenterButton)

--- a/Source/UI/UIComponent.h
+++ b/Source/UI/UIComponent.h
@@ -100,6 +100,8 @@ public:
 
 	PluginManager* getPluginManager();
     
+    PluginInstaller* getPluginInstaller();
+    
     /** Called by the MessageCenterButton */
     void buttonClicked(Button* button);
 


### PR DESCRIPTION
* Instead of making multiple HTTP requests to the bintray API, use open-ephys-bintray-gateway.herokuapp.com to gather all plugin information in one go
* Gracefully shut down the application if the Plugin Installer is open when quitting