### PR TITLE
Implement copy/paste and undo/redo

### DIFF
--- a/Source/Processors/Merger/Merger.h
+++ b/Source/Processors/Merger/Merger.h
@@ -82,6 +82,10 @@ public:
 
     GenericProcessor* sourceNodeA;
     GenericProcessor* sourceNodeB;
+    
+    int getPath() {
+        return activePath;
+    }
 
 private:
 

--- a/Source/Processors/Merger/MergerEditor.cpp
+++ b/Source/Processors/Merger/MergerEditor.cpp
@@ -104,22 +104,12 @@ void MergerEditor::buttonEvent(Button* button)
     
     if (button == pipelineSelectorA)
     {
-        pipelineSelectorA->setToggleState(true, dontSendNotification);
-        pipelineSelectorB->setToggleState(false, dontSendNotification);
-        Merger* processor = (Merger*) getProcessor();
-        processor->switchIO(0);
-
+        AccessClass::getEditorViewport()->switchIO(getProcessor(), 0);
     }
     else if (button == pipelineSelectorB)
     {
-        pipelineSelectorB->setToggleState(true, dontSendNotification);
-        pipelineSelectorA->setToggleState(false, dontSendNotification);
-        Merger* processor = (Merger*) getProcessor();
-        processor->switchIO(1);
-
+        AccessClass::getEditorViewport()->switchIO(getProcessor(), 1);
     }
-
-    AccessClass::getProcessorGraph()->updateViews(getProcessor());
 }
 
 Array<GenericProcessor*> MergerEditor::getSelectableProcessors()

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -568,6 +568,8 @@ void ProcessorGraph::clearSignalChain()
     updateViews(nullptr);
 }
 
+
+
 void ProcessorGraph::changeListenerCallback(ChangeBroadcaster* source)
 {
     refreshColors();

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -90,7 +90,7 @@ void ProcessorGraph::updatePointers()
 }
 
 void ProcessorGraph::moveProcessor(GenericProcessor* processor,
-                                    GenericProcessor* newSource,
+                                   GenericProcessor* newSource,
                                    GenericProcessor* newDest,
                                    bool moveDownstream)
 {
@@ -146,7 +146,7 @@ void ProcessorGraph::moveProcessor(GenericProcessor* processor,
         }
     }
     
-    checkForNewRootNodes(processor, false);
+    checkForNewRootNodes(processor, false, true);
     
     if (moveDownstream) // processor is further down the signal chain, its original dest may have changed
         updateSettings(originalDest);
@@ -267,6 +267,8 @@ GenericProcessor* ProcessorGraph::createProcessor(ProcessorDescription& descript
 	else
 	{
 		CoreServices::sendStatusMessage("Not a valid processor.");
+        
+        return nullptr;
 	}
     
     if (!signalChainIsLoading)
@@ -704,6 +706,20 @@ Array<GenericProcessor*> ProcessorGraph::getListOfProcessors()
 
 }
 
+GenericProcessor* ProcessorGraph::getProcessorWithNodeId(int nodeId)
+{
+
+    for (auto processor : getListOfProcessors())
+    {
+        if (processor->getNodeId() == nodeId)
+        {
+            return processor;
+        }
+    }
+    
+    return nullptr;
+}
+
 void ProcessorGraph::clearConnections()
 {
 
@@ -1029,7 +1045,7 @@ GenericProcessor* ProcessorGraph::createProcessorFromDescription(ProcessorDescri
 	{
 
         LOGD("Creating from description...");
-        LOGD(description.libName, "::", description.processorName, \
+        LOGD(description.libName, "::", description.processorName, " (", \
             description.processorType, "-", description.processorIndex,")");
 
 		processor = ProcessorManager::createProcessor((ProcessorClasses) description.processorType,

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.h
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.h
@@ -144,6 +144,8 @@ private:
     int currentNodeId;
     
     bool isLoadingSignalChain;
+    
+
 
     enum nodeIds
     {

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.h
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.h
@@ -85,6 +85,7 @@ public:
     void removeProcessor(GenericProcessor* processor);
     Array<GenericProcessor*> getListOfProcessors();
     
+    GenericProcessor* getProcessorWithNodeId(int nodeId);
     
     Array<GenericProcessor*> getRootNodes() {return rootNodes;}
     

--- a/Source/Processors/Splitter/SplitterEditor.cpp
+++ b/Source/Processors/Splitter/SplitterEditor.cpp
@@ -100,22 +100,12 @@ void SplitterEditor::buttonEvent(Button* button)
 {
     if (button == pipelineSelectorA)
     {
-        pipelineSelectorA->setToggleState(true, dontSendNotification);
-        pipelineSelectorB->setToggleState(false, dontSendNotification);
-        Splitter* processor = (Splitter*) getProcessor();
-        processor->switchIO(0);
-
+        AccessClass::getEditorViewport()->switchIO(getProcessor(), 0);
     }
     else if (button == pipelineSelectorB)
     {
-        pipelineSelectorB->setToggleState(true, dontSendNotification);
-        pipelineSelectorA->setToggleState(false, dontSendNotification);
-        Splitter* processor = (Splitter*) getProcessor();
-        processor->switchIO(1);
-
+        AccessClass::getEditorViewport()->switchIO(getProcessor(), 1);
     }
-    
-    AccessClass::getProcessorGraph()->updateViews(getProcessor());
 }
 
 void SplitterEditor::switchDest(int dest)

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -530,6 +530,16 @@ bool EditorViewport::keyPressed(const KeyPress& key)
 
 }
 
+void EditorViewport::switchIO(GenericProcessor* processor, int path)
+{
+    
+    undoManager.beginNewTransaction();
+    
+    SwitchIO* switchIO = new SwitchIO(processor, path);
+    
+    undoManager.perform(switchIO);
+}
+
 
 void EditorViewport::copySelectedEditors()
 {

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -169,6 +169,20 @@ public:
     int getDesiredWidth();
     
     GenericProcessor* addProcessor(ProcessorDescription desc, int insertionPt);
+    
+    GenericProcessor* createProcessorAtInsertionPoint(XmlElement* processor, int insertionPt, bool rhythmNodePatch, bool ignoreNodeId);
+
+    void copySelectedEditors();
+    
+    void addToUndoBuffer(XmlElement*);
+    
+    void copy(Array<XmlElement*>);
+    
+    void paste();
+    
+    void undo();
+    
+    void redo();
 
 private:
 
@@ -198,6 +212,12 @@ private:
     void resized();
     
     bool shiftDown;
+    
+    OwnedArray<XmlElement> copyBuffer;
+    
+    OwnedArray<XmlElement> undoBuffer;
+    
+    OwnedArray<XmlElement> redoBuffer;
     
     Label editorNamingLabel;
 

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -190,6 +190,8 @@ public:
     GenericProcessor* createProcessorAtInsertionPoint(XmlElement* processor, int insertionPt, bool rhythmNodePatch, bool ignoreNodeId);
     
     ProcessorDescription getDescriptionFromXml(XmlElement* settings, bool ignoreNodeId, bool rhythmNodePatch);
+    
+    void switchIO(GenericProcessor* processor, int path);
 
     void copySelectedEditors();
     

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -43,6 +43,9 @@ class SignalChainScrollButton;
 class ControlPanel;
 class UIComponent;
 
+enum Action {ADD, MOVE, REMOVE, ACTIVATE, UPDATE};
+
+
 /**
 
   Allows the user to view and edit the signal chain.
@@ -170,11 +173,11 @@ public:
     
     GenericProcessor* addProcessor(ProcessorDescription desc, int insertionPt);
     
+    void deleteProcessors(Array<GenericProcessor*>);
+    
     GenericProcessor* createProcessorAtInsertionPoint(XmlElement* processor, int insertionPt, bool rhythmNodePatch, bool ignoreNodeId);
 
     void copySelectedEditors();
-    
-    void addToUndoBuffer(XmlElement*);
     
     void copy(Array<XmlElement*>);
     
@@ -183,6 +186,12 @@ public:
     void undo();
     
     void redo();
+    
+    bool editorIsSelected();
+    
+    bool canPaste();
+    
+    UndoManager undoManager;
 
 private:
 
@@ -205,7 +214,6 @@ private:
     bool componentWantsToMove;
     int indexOfMovingComponent;
 
-    enum actions {ADD, MOVE, REMOVE, ACTIVATE, UPDATE};
 
     SignalChainTabComponent* signalChainTabComponent;
 
@@ -215,13 +223,44 @@ private:
     
     OwnedArray<XmlElement> copyBuffer;
     
-    OwnedArray<XmlElement> undoBuffer;
-    
-    OwnedArray<XmlElement> redoBuffer;
-    
     Label editorNamingLabel;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EditorViewport);
+
+};
+
+/**
+
+  Specifies an action (ADD, DELETE, MOVE) that can be undone
+
+  @see EditorViewport, UndoManager
+
+*/
+class AddProcessorAction : public UndoableAction
+{
+    
+public:
+    AddProcessor(Action, Array<GenericProcessor*>, EditorViewport*);
+ 
+    ~AddProcessor();
+    
+    bool perform();
+    bool undo();
+    
+private:
+    Action action;
+    
+    struct ProcessorInfo
+    {
+        int nodeId;
+        int sourceNodeId;
+        int destNodeId;
+        XmlElement* settings;
+    };
+    
+    Array<ProcessorInfo> processorInfo;
+    
+    EditorViewport* editorViewport;
 
 };
 

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -2,7 +2,7 @@
     ------------------------------------------------------------------
 
     This file is part of the Open Ephys GUI
-    Copyright (C) 2014 Open Ephys
+    Copyright (C) 2021 Open Ephys
 
     ------------------------------------------------------------------
 
@@ -135,9 +135,21 @@ public:
 
 	/** Save the current configuration as an XML file. Reference wrapper*/
 	const String saveState(File filename, String& xmlText);
+    
+    /** Save the current configuration as an XML file. Reference wrapper*/
+    XmlElement* createSettingsXml();
 
     /** Load a saved configuration from an XML file. */
     const String loadState(File filename);
+    
+    /** Load a saved configuration from an XML object*/
+    const String loadStateFromXml(XmlElement* xml);
+    
+    /** Load a saved plugin configuration from an XML file. */
+    const String loadPluginState(File filename, GenericEditor* selectedEditor = nullptr);
+    
+    /** Load a saved plugin configuration from an XML file. */
+    const String savePluginState(File filename, GenericEditor* selectedEditor = nullptr);
 
     /** Converts information about a given editor to XML. */
     XmlElement* createNodeXml(GenericProcessor*, bool isStartOfSignalChain);
@@ -173,9 +185,11 @@ public:
     
     GenericProcessor* addProcessor(ProcessorDescription desc, int insertionPt);
     
-    void deleteProcessors(Array<GenericProcessor*>);
+    void deleteSelectedProcessors();
     
     GenericProcessor* createProcessorAtInsertionPoint(XmlElement* processor, int insertionPt, bool rhythmNodePatch, bool ignoreNodeId);
+    
+    ProcessorDescription getDescriptionFromXml(XmlElement* settings, bool ignoreNodeId, bool rhythmNodePatch);
 
     void copySelectedEditors();
     
@@ -192,6 +206,8 @@ public:
     bool canPaste();
     
     UndoManager undoManager;
+    
+    Array<GenericEditor*> editorArray;
 
 private:
 
@@ -205,15 +221,12 @@ private:
 
     int selectionIndex;
 
-    Array<GenericEditor*> editorArray;
-
     Font font;
     Image sourceDropImage;
     
     int insertionPoint;
     bool componentWantsToMove;
     int indexOfMovingComponent;
-
 
     SignalChainTabComponent* signalChainTabComponent;
 
@@ -229,40 +242,7 @@ private:
 
 };
 
-/**
 
-  Specifies an action (ADD, DELETE, MOVE) that can be undone
-
-  @see EditorViewport, UndoManager
-
-*/
-class AddProcessorAction : public UndoableAction
-{
-    
-public:
-    AddProcessor(Action, Array<GenericProcessor*>, EditorViewport*);
- 
-    ~AddProcessor();
-    
-    bool perform();
-    bool undo();
-    
-private:
-    Action action;
-    
-    struct ProcessorInfo
-    {
-        int nodeId;
-        int sourceNodeId;
-        int destNodeId;
-        XmlElement* settings;
-    };
-    
-    Array<ProcessorInfo> processorInfo;
-    
-    EditorViewport* editorViewport;
-
-};
 
 /**
 

--- a/Source/UI/EditorViewportActions.cpp
+++ b/Source/UI/EditorViewportActions.cpp
@@ -1,0 +1,392 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2021 Open Ephys
+
+    ------------------------------------------------------------------
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include <stdio.h>
+
+#include "EditorViewportActions.h"
+
+
+AddProcessor::AddProcessor(ProcessorDescription description_,
+                           GenericProcessor* sourceProcessor,
+                           GenericProcessor* destProcessor,
+                           EditorViewport* editorViewport_)
+{
+    description = description_;
+    
+    editorViewport = editorViewport_;
+    
+    if (sourceProcessor != nullptr)
+        sourceNodeId = sourceProcessor->getNodeId();
+    else
+        sourceNodeId = -1;
+    
+    if (destProcessor != nullptr)
+        destNodeId = destProcessor->getNodeId();
+    else
+        destNodeId = -1;
+}
+
+AddProcessor::~AddProcessor()
+{
+    
+}
+   
+bool AddProcessor::perform()
+{
+    LOGD("Performing add processor.");
+    GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(sourceNodeId);
+    
+    GenericProcessor* destProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(destNodeId);
+    
+    processor = AccessClass::getProcessorGraph()->createProcessor(description,
+                                                      sourceProcessor,
+                                                      destProcessor,
+                                                      false);
+    
+    if (processor != nullptr)
+        return true;
+    else
+        return false;
+}
+
+bool AddProcessor::undo()
+{
+    LOGD("Undoing add processor.");
+    Array<GenericProcessor*> processorToDelete;
+    processorToDelete.add(processor);
+    
+    AccessClass::getProcessorGraph()->deleteNodes(processorToDelete);
+    
+    return true;
+}
+   
+DeleteProcessor::DeleteProcessor(GenericProcessor* processor_, EditorViewport* editorViewport_)
+{
+    
+    processor = processor_;
+    editorViewport = editorViewport_;
+    
+    settings = editorViewport->createNodeXml(processor, false);
+    
+    if (processor->getSourceNode() != nullptr)
+        sourceNodeId = processor->getSourceNode()->getNodeId();
+    else
+        sourceNodeId = -1;
+    
+    if (processor->getDestNode() != nullptr)
+        destNodeId = processor->getDestNode()->getNodeId();
+    else
+        destNodeId = -1;
+}
+
+DeleteProcessor::~DeleteProcessor()
+{
+    delete settings;
+}
+   
+bool DeleteProcessor::perform()
+{
+    LOGD("Peforming delete processor.");
+    Array<GenericProcessor*> processorToDelete;
+    processorToDelete.add(processor);
+    
+    AccessClass::getProcessorGraph()->deleteNodes(processorToDelete);
+    
+    return true;
+}
+
+bool DeleteProcessor::undo()
+{
+    LOGD("Undoing delete processor.");
+    ProcessorDescription description = editorViewport->getDescriptionFromXml(settings, false, false);
+
+    GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(sourceNodeId);
+    
+    GenericProcessor* destProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(destNodeId);
+    
+    processor = AccessClass::getProcessorGraph()->createProcessor(description,
+                                                      sourceProcessor,
+                                                      destProcessor,
+                                                      false);
+    processor->parametersAsXml = settings;
+    processor->loadFromXml();
+    
+    AccessClass::getProcessorGraph()->updateSettings(processor);
+    
+    if (processor != nullptr)
+        return true;
+    else
+        return false;
+}
+   
+
+MoveProcessor::MoveProcessor(GenericProcessor* processor_,
+                             GenericProcessor* sourceNode,
+                             GenericProcessor* destNode,
+                             bool moveDownstream_)
+{
+    
+    processor = processor_;
+    moveDownstream = moveDownstream_;
+
+    if (processor->getSourceNode() != nullptr)
+        originalSourceNodeId = processor->getSourceNode()->getNodeId();
+    else
+        originalSourceNodeId = -1;
+    
+    if (processor->getDestNode() != nullptr)
+        originalDestNodeId = processor->getDestNode()->getNodeId();
+    else
+        originalDestNodeId = -1;
+    
+    if (sourceNode != nullptr)
+        newSourceNodeId = sourceNode->getNodeId();
+    else
+        newSourceNodeId = -1;
+    
+    if (destNode != nullptr)
+        newDestNodeId = destNode->getNodeId();
+    else
+        newDestNodeId = -1;
+}
+
+MoveProcessor::~MoveProcessor()
+{
+
+}
+   
+bool MoveProcessor::perform()
+{
+    LOGD("Peforming move processor.");
+    
+    GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(newSourceNodeId);
+    
+    GenericProcessor* destProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(newDestNodeId);
+    
+    AccessClass::getProcessorGraph()->moveProcessor(processor,
+                                                    sourceProcessor,
+                                                    destProcessor,
+                                                    moveDownstream);
+    
+    return true;
+}
+
+bool MoveProcessor::undo()
+{
+    LOGD("Undoing move processor.");
+    GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(originalSourceNodeId);
+    
+    GenericProcessor* destProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(originalDestNodeId);
+    
+    AccessClass::getProcessorGraph()->moveProcessor(processor,
+                                                    sourceProcessor,
+                                                    destProcessor,
+                                                    moveDownstream);
+    
+    return true;
+}
+   
+
+ClearSignalChain::ClearSignalChain(EditorViewport* editorViewport_)
+{
+    editorViewport = editorViewport_;
+    
+    settings = editorViewport->createSettingsXml();
+}
+    
+ 
+ClearSignalChain::~ClearSignalChain()
+{
+    delete settings;
+}
+    
+bool ClearSignalChain::perform()
+{
+    LOGD("Performing clear signal chain.");
+    AccessClass::getProcessorGraph()->clearSignalChain();
+    
+    return true;
+}
+
+bool ClearSignalChain::undo()
+{
+    LOGD("Undoing clear signal chain.");
+    editorViewport->loadStateFromXml(settings);
+    
+    return true;
+}
+
+
+
+LoadSignalChain::LoadSignalChain(EditorViewport* editorViewport_, XmlElement* newSettings_)
+{
+    editorViewport = editorViewport_;
+    newSettings = newSettings_;
+    
+    oldSettings = editorViewport->createSettingsXml();
+}
+    
+ 
+LoadSignalChain::~LoadSignalChain()
+{
+    delete oldSettings;
+    delete newSettings;
+}
+    
+bool LoadSignalChain::perform()
+{
+    LOGD("Performing load signal chain.");
+    error = editorViewport->loadStateFromXml(newSettings);
+    
+    return true;
+}
+
+bool LoadSignalChain::undo()
+{
+    LOGD("Undoing load signal chain.");
+    error = editorViewport->loadStateFromXml(oldSettings);
+    
+    return true;
+}
+
+const String LoadSignalChain::getError()
+{
+    return String(error);
+}
+
+LoadPluginSettings::LoadPluginSettings(EditorViewport* editorViewport_,
+                                       GenericProcessor* processor,
+                                       XmlElement* newSettings_)
+{
+    editorViewport = editorViewport_;
+    newSettings = newSettings_;
+    
+    oldSettings = editorViewport->createNodeXml(processor, false);
+    
+    processorId = processor->getNodeId();
+    
+}
+    
+ 
+LoadPluginSettings::~LoadPluginSettings()
+{
+    delete oldSettings;
+    delete newSettings;
+}
+    
+bool LoadPluginSettings::perform()
+{
+    
+    String oldPluginType = oldSettings->getStringAttribute("name");
+    String newPluginType = newSettings->getStringAttribute("name");
+    
+    if (oldPluginType.equalsIgnoreCase(newPluginType))
+    {
+        LOGD("Performing load plugin settings.");
+        LOGD("Getting processor");
+        GenericProcessor* processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(processorId);
+        
+        
+        LOGD("Updating NodeId");
+        newSettings->setAttribute("NodeId", processorId);
+        LOGD("Setting parameters");
+        processor->parametersAsXml = newSettings;
+        LOGD("Loading parameters");
+        processor->loadCustomParametersFromXml();
+
+        // load editor parameters
+        forEachXmlChildElement(*newSettings, xmlNode)
+        {
+            if (xmlNode->hasTagName("EDITOR"))
+            {
+                processor->getEditor()->loadEditorParameters(xmlNode);
+            }
+        }
+
+        forEachXmlChildElement(*newSettings, xmlNode)
+        {
+            if (xmlNode->hasTagName("CHANNEL"))
+            {
+                processor->loadChannelParametersFromXml(xmlNode, InfoObjectCommon::DATA_CHANNEL);
+            }
+            else if (xmlNode->hasTagName("EVENTCHANNEL"))
+            {
+                processor->loadChannelParametersFromXml(xmlNode, InfoObjectCommon::EVENT_CHANNEL);
+            }
+            else if (xmlNode->hasTagName("SPIKECHANNEL"))
+            {
+                processor->loadChannelParametersFromXml(xmlNode, InfoObjectCommon::SPIKE_CHANNEL);
+            }
+        }
+        
+        AccessClass::getProcessorGraph()->updateViews(processor);
+        
+        return true;
+    } else {
+        
+        CoreServices::sendStatusMessage("Plugin types do not match.");
+        
+        return false;
+    }
+    
+}
+
+bool LoadPluginSettings::undo()
+{
+    LOGD("Undoing load plugin settings.");
+    GenericProcessor* processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(processorId);
+    
+    processor->parametersAsXml = oldSettings;
+    processor->loadCustomParametersFromXml();
+
+    // load editor parameters
+    forEachXmlChildElement(*oldSettings, xmlNode)
+    {
+        if (xmlNode->hasTagName("EDITOR"))
+        {
+            processor->getEditor()->loadEditorParameters(xmlNode);
+        }
+    }
+
+    forEachXmlChildElement(*oldSettings, xmlNode)
+    {
+        if (xmlNode->hasTagName("CHANNEL"))
+        {
+            processor->loadChannelParametersFromXml(xmlNode, InfoObjectCommon::DATA_CHANNEL);
+        }
+        else if (xmlNode->hasTagName("EVENTCHANNEL"))
+        {
+            processor->loadChannelParametersFromXml(xmlNode, InfoObjectCommon::EVENT_CHANNEL);
+        }
+        else if (xmlNode->hasTagName("SPIKECHANNEL"))
+        {
+            processor->loadChannelParametersFromXml(xmlNode, InfoObjectCommon::SPIKE_CHANNEL);
+        }
+    }
+    
+    AccessClass::getProcessorGraph()->updateViews(processor);
+    
+    return true;
+}
+
+

--- a/Source/UI/EditorViewportActions.h
+++ b/Source/UI/EditorViewportActions.h
@@ -43,10 +43,14 @@ public:
     
     GenericProcessor* processor;
     
+    XmlElement* settings;
+    
 private:
 
     int sourceNodeId;
     int destNodeId;
+    
+    int nodeId;
     
     ProcessorDescription description;
 
@@ -71,6 +75,7 @@ private:
     
     int sourceNodeId;
     int destNodeId;
+    int nodeId;
     
     XmlElement* settings;
     
@@ -96,12 +101,14 @@ public:
     
 private:
 
-    GenericProcessor* processor;
+    int nodeId;
     
     int originalSourceNodeId;
     int originalDestNodeId;
     int newSourceNodeId;
     int newDestNodeId;
+    
+    int originalDestNodeDestNodeId;
     
     bool moveDownstream;
     
@@ -175,5 +182,24 @@ private:
 
 };
 
+class SwitchIO : public UndoableAction
+{
+    
+public:
+    SwitchIO(GenericProcessor* processor, int path);
+ 
+    ~SwitchIO();
+    
+    bool perform();
+    bool undo();
+
+private:
+
+    EditorViewport* editorViewport;
+    int processorId;
+    
+    int originalPath;
+
+};
 
 #endif /* EditorViewportActions_h */

--- a/Source/UI/EditorViewportActions.h
+++ b/Source/UI/EditorViewportActions.h
@@ -1,0 +1,179 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2021 Open Ephys
+
+    ------------------------------------------------------------------
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef EditorViewportActions_h
+#define EditorViewportActions_h
+
+#include "EditorViewport.h"
+
+
+class AddProcessor : public UndoableAction
+{
+    
+public:
+    AddProcessor(ProcessorDescription description,
+                 GenericProcessor* source,
+                 GenericProcessor* dest,
+                 EditorViewport*);
+ 
+    ~AddProcessor();
+    
+    bool perform();
+    bool undo();
+    
+    GenericProcessor* processor;
+    
+private:
+
+    int sourceNodeId;
+    int destNodeId;
+    
+    ProcessorDescription description;
+
+    EditorViewport* editorViewport;
+
+};
+
+class DeleteProcessor : public UndoableAction
+{
+    
+public:
+    DeleteProcessor(GenericProcessor* p, EditorViewport*);
+ 
+    ~DeleteProcessor();
+    
+    bool perform();
+    bool undo();
+    
+private:
+
+    GenericProcessor* processor;
+    
+    int sourceNodeId;
+    int destNodeId;
+    
+    XmlElement* settings;
+    
+    EditorViewport* editorViewport;
+
+};
+
+
+
+class MoveProcessor : public UndoableAction
+{
+    
+public:
+    MoveProcessor(GenericProcessor* p,
+                  GenericProcessor* source,
+                  GenericProcessor* dest,
+                  bool moveDownstream);
+ 
+    ~MoveProcessor();
+    
+    bool perform();
+    bool undo();
+    
+private:
+
+    GenericProcessor* processor;
+    
+    int originalSourceNodeId;
+    int originalDestNodeId;
+    int newSourceNodeId;
+    int newDestNodeId;
+    
+    bool moveDownstream;
+    
+};
+
+class ClearSignalChain : public UndoableAction
+{
+    
+public:
+    ClearSignalChain(EditorViewport*);
+ 
+    ~ClearSignalChain();
+    
+    bool perform();
+    bool undo();
+    
+private:
+    
+    XmlElement* settings;
+
+    EditorViewport* editorViewport;
+
+};
+
+class LoadSignalChain : public UndoableAction
+{
+    
+public:
+    LoadSignalChain(EditorViewport*, XmlElement* newSettings);
+ 
+    ~LoadSignalChain();
+    
+    bool perform();
+    bool undo();
+    
+    const String getError();
+    
+private:
+    
+    XmlElement* oldSettings;
+    XmlElement* newSettings;
+    
+    String error;
+
+    EditorViewport* editorViewport;
+
+};
+
+class LoadPluginSettings : public UndoableAction
+{
+    
+public:
+    LoadPluginSettings(EditorViewport*, GenericProcessor* processor, XmlElement* newSettings);
+ 
+    ~LoadPluginSettings();
+    
+    bool perform();
+    bool undo();
+    
+    const String getError();
+    
+private:
+    
+    XmlElement* oldSettings;
+    XmlElement* newSettings;
+    
+    String error;
+
+    EditorViewport* editorViewport;
+    int processorId;
+
+};
+
+
+#endif /* EditorViewportActions_h */

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -511,25 +511,25 @@ void UIComponent::getCommandInfo(CommandID commandID, ApplicationCommandInfo& re
 		case undo:
 			result.setInfo("Undo", "Undo the last action.", "General", 0);
 			result.addDefaultKeypress('Z', ModifierKeys::commandModifier);
-			result.setActive(false);
+			result.setActive(!acquisitionStarted && getEditorViewport()->undoManager.canUndo());
 			break;
 
 		case redo:
 			result.setInfo("Redo", "Undo the last action.", "General", 0);
-			result.addDefaultKeypress('Y', ModifierKeys::commandModifier);
-			result.setActive(false);
+			result.addDefaultKeypress('Z', ModifierKeys::commandModifier | ModifierKeys::shiftModifier);
+			result.setActive(!acquisitionStarted && getEditorViewport()->undoManager.canRedo());
 			break;
 
 		case copySignalChain:
 			result.setInfo("Copy", "Copy selected processors.", "General", 0);
 			result.addDefaultKeypress('C', ModifierKeys::commandModifier);
-			result.setActive(!acquisitionStarted);
+			result.setActive(!acquisitionStarted && getEditorViewport()->editorIsSelected());
 			break;
 
 		case pasteSignalChain:
 			result.setInfo("Paste", "Paste processors.", "General", 0);
 			result.addDefaultKeypress('V', ModifierKeys::commandModifier);
-			result.setActive(!acquisitionStarted);
+			result.setActive(!acquisitionStarted && getEditorViewport()->canPaste());
 			break;
 
 		case clearSignalChain:
@@ -662,6 +662,18 @@ bool UIComponent::perform(const InvocationInfo& info)
 			}
 			break;
 
+        case undo:
+            {
+                getEditorViewport()->undo();
+                break;
+            }
+            
+        case redo:
+            {
+                getEditorViewport()->redo();
+                break;
+            }
+            
         case copySignalChain:
             {
                 getEditorViewport()->copySelectedEditors();

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -521,15 +521,15 @@ void UIComponent::getCommandInfo(CommandID commandID, ApplicationCommandInfo& re
 			break;
 
 		case copySignalChain:
-			result.setInfo("Copy", "Copy a portion of the signal chain.", "General", 0);
+			result.setInfo("Copy", "Copy selected processors.", "General", 0);
 			result.addDefaultKeypress('C', ModifierKeys::commandModifier);
-			result.setActive(false);
+			result.setActive(!acquisitionStarted);
 			break;
 
 		case pasteSignalChain:
-			result.setInfo("Paste", "Paste a portion of the signal chain.", "General", 0);
+			result.setInfo("Paste", "Paste processors.", "General", 0);
 			result.addDefaultKeypress('V', ModifierKeys::commandModifier);
-			result.setActive(false);
+			result.setActive(!acquisitionStarted);
 			break;
 
 		case clearSignalChain:
@@ -662,6 +662,18 @@ bool UIComponent::perform(const InvocationInfo& info)
 			}
 			break;
 
+        case copySignalChain:
+            {
+                getEditorViewport()->copySelectedEditors();
+                break;
+            }
+            
+        case pasteSignalChain:
+            {
+                getEditorViewport()->paste();
+                break;
+            }
+                
 		case clearSignalChain:
 			{
 				getEditorViewport()->clearSignalChain();

--- a/Source/UI/UIComponent.h
+++ b/Source/UI/UIComponent.h
@@ -185,8 +185,8 @@ private:
     /** Contains codes for common user commands to which the application must react.*/
     enum CommandIDs
     {
-        openConfiguration 		= 0x2001,
-        saveConfiguration		= 0x2002,
+        openSignalChain 		= 0x2001,
+        saveSignalChain 		= 0x2002,
         undo					= 0x2003,
         redo 					= 0x2004,
         copySignalChain			= 0x2005,
@@ -198,9 +198,11 @@ private:
         showHelp				= 0x2011,
         resizeWindow            = 0x2012,
         reloadOnStartup         = 0x2013,
-        saveConfigurationAs     = 0x2014,
+        saveSignalChainAs       = 0x2014,
 		openTimestampSelectionWindow = 0x2015,
-        openPluginInstaller     = 0x2016
+        openPluginInstaller     = 0x2016,
+        loadPluginSettings      = 0x3001,
+        savePluginSettings      = 0x3002
     };
 
     File currentConfigFile;


### PR DESCRIPTION
* Selected plugins can be copied and pasted, maintaining their original settings
* Settings for plugins can be saved/loaded individually, independently of the rest of the signal chain
* The following actions can be undone/redone:
   * Adding a plugin
   * Deleting a plugin
   * Moving a plugin
   * Clearing the signal chain
   * Loading a new signal chain
   * Switching the i/o path of a Merger or Splitter

**CAUTION:** There are currently no restrictions on copying plugins that requires a unique hardware input, such as Rhythm FPGA or Neuropixels-PXI. Protections against this should be added in the future.