### PR TITLE
Fix bug when renaming TTL channels

### DIFF
--- a/Plugins/RhythmNode/RHD2000Editor.h
+++ b/Plugins/RhythmNode/RHD2000Editor.h
@@ -57,7 +57,7 @@ namespace RhythmNode
 
 		FPGAchannelList(GenericProcessor* proc, Viewport* p, FPGAcanvas* c);
 		~FPGAchannelList();
-		void setNewName(int channelIndex, String newName);
+		void setNewName(int channelIndex, String newName, DataChannel::DataChannelTypes type);
 		void setNewGain(int channel, float gain);
 		void disableAll();
 		void enableAll();

--- a/Plugins/RhythmNode/RHD2000Thread.cpp
+++ b/Plugins/RhythmNode/RHD2000Thread.cpp
@@ -161,6 +161,11 @@ RHD2000Thread::RHD2000Thread(SourceNode* sn) : DataThread(sn),
 
         // setDefaultNamingScheme(numberingScheme);
         //setDefaultChannelNamesAndType();
+
+        for (int k = 0; k < 8; ++k)
+        {
+            eventChannelNames.add("TTL" + String(k + 1));
+        }
     }
 }
 
@@ -762,12 +767,13 @@ int RHD2000Thread::getHeadstageChannels (int hsNum) const
 }
 
 
-void RHD2000Thread::getEventChannelNames (StringArray& Names) const
+void RHD2000Thread::getEventChannelNames (StringArray& names) const
 {
-    Names.clear();
-    for (int k = 0; k < 8; ++k)
+    names.clear();
+
+    for (auto name : eventChannelNames)
     {
-        Names.add ("TTL" + String (k + 1));
+        names.add(name);
     }
 }
 
@@ -780,6 +786,14 @@ int RHD2000Thread::modifyChannelName(int channel, String newName)
     i.name = newName;
     i.modified = true;
     channelInfo.set(channel, i);
+    return 0;
+}
+
+int RHD2000Thread::modifyEventChannelName(int channel, String newName)
+{
+
+    eventChannelNames.set(channel, newName);
+
     return 0;
 }
 

--- a/Plugins/RhythmNode/RHD2000Thread.h
+++ b/Plugins/RhythmNode/RHD2000Thread.h
@@ -118,6 +118,8 @@ namespace RhythmNode
 		int modifyChannelGain(int channel, float gain)      override;
 		int modifyChannelName(int channel, String newName)  override;
 
+		int modifyEventChannelName(int channel, String newName);
+
 		void getEventChannelNames(StringArray& Names) const override;
 		Array<int> getDACchannels() const;
 
@@ -229,6 +231,8 @@ namespace RhythmNode
 
 		// Sync ouput divide factor
 		uint16 clockDivideFactor;
+
+		StringArray eventChannelNames;
 
 		//ADC ranges
 		std::array<atomic_short, 8> adcRangeSettings;


### PR DESCRIPTION
Previously, renaming a TTL channel in the Rhythm FPGA module would actually update the name of a continuous channel. Now, the names update correctly, and are loaded/saved properly.

Note that these channel names are only used locally, and are not currently applied in downstream processors.