### PR TITLE
Clean up new LFP Viewer

### DIFF
--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -46,6 +46,8 @@ namespace LfpViewer {
         }
 
         ttlState = 0;
+
+        std::cout << "Display buffer sample rate: " << sampleRate << std::endl;
     }
 
     DisplayBuffer::~DisplayBuffer()

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -33,7 +33,7 @@ namespace LfpViewer {
 #define BUFFER_LENGTH 3000
 
     DisplayBuffer::DisplayBuffer(int id_, String name_, float sampleRate_) : 
-        id(id_), name(name_), sampleRate(sampleRate_)
+        id(id_), name(name_), sampleRate(sampleRate_), isNeeded(true)
     {
         previousSize = 0;
         numChannels = 0;
@@ -61,6 +61,8 @@ namespace LfpViewer {
         channelMetadata.clear();
         channelMap.clear();
         numChannels = 0;
+
+        isNeeded = false;
     }
 
     void DisplayBuffer::addChannel(String name, int channelNum, int group, float ypos, String structure)
@@ -71,11 +73,14 @@ namespace LfpViewer {
         channelMap[channelNum] = numChannels;
         numChannels++;
 
+        isNeeded = true;
+
        // std::cout << "Adding channel " << name << " with index " << numChannels << "; ";
     }
 
     void DisplayBuffer::update()
     {
+            
         if (numChannels != previousSize)
             setSize(numChannels + 1, BUFFER_LENGTH);
 

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -30,7 +30,7 @@ namespace LfpViewer {
 
 
     */
-#define BUFFER_LENGTH 3000
+#define BUFFER_LENGTH 30000
 
     DisplayBuffer::DisplayBuffer(int id_, String name_, float sampleRate_) : 
         id(id_), name(name_), sampleRate(sampleRate_), isNeeded(true)
@@ -198,6 +198,8 @@ namespace LfpViewer {
         const int samplesLeft = BUFFER_LENGTH - displayBufferIndices[channelMap[chan]];
 
         int newIndex;
+
+        
         
         if (nSamples < samplesLeft)
         {
@@ -234,13 +236,11 @@ namespace LfpViewer {
             newIndex = extraSamples;
         }
 
-        {
-            ScopedLock displayLock(displayMutex);
-
-            displayBufferIndices.set(channelMap[chan], newIndex);
-        }
-
-        //int newIndex = displayBufferIndices[channelMap[chan]];
+        displayBufferIndices.set(channelMap[chan], newIndex);
+        
+        ScopedLock displayLock(displayMutex);
+        
+        newIndex = displayBufferIndices[channelMap[chan]];
 
     }
 

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -185,12 +185,14 @@ namespace LfpViewer {
 
     void DisplayBuffer::addData(AudioSampleBuffer& buffer, int chan, int nSamples)
     {
-        ScopedLock displayLock(displayMutex);
+        
 
         int previousIndex = displayBufferIndices[channelMap[chan]];
         int channelIndex = channelMap[chan];
 
         const int samplesLeft = BUFFER_LENGTH - displayBufferIndices[channelMap[chan]];
+
+        int newIndex;
         
         if (nSamples < samplesLeft)
         {
@@ -202,7 +204,9 @@ namespace LfpViewer {
                 nSamples);                 // numSamples
 
             int lastIndex = displayBufferIndices[channelMap[chan]];
-            displayBufferIndices.set(channelMap[chan],  lastIndex + nSamples);
+
+            newIndex = lastIndex + nSamples;
+            
         }
         else
         {
@@ -222,10 +226,16 @@ namespace LfpViewer {
                 samplesLeft,               // source start sample
                 extraSamples);             // numSamples
 
-            displayBufferIndices.set(channelMap[chan], extraSamples);
+            newIndex = extraSamples;
         }
 
-        int newIndex = displayBufferIndices[channelMap[chan]];
+        {
+            ScopedLock displayLock(displayMutex);
+
+            displayBufferIndices.set(channelMap[chan], newIndex);
+        }
+
+        //int newIndex = displayBufferIndices[channelMap[chan]];
 
     }
 

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -47,7 +47,7 @@ namespace LfpViewer {
 
         ttlState = 0;
 
-        std::cout << "Display buffer sample rate: " << sampleRate << std::endl;
+        //std::cout << "Display buffer sample rate: " << sampleRate << std::endl;
     }
 
     DisplayBuffer::~DisplayBuffer()

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -67,7 +67,11 @@ namespace LfpViewer {
 
     void DisplayBuffer::addChannel(String name, int channelNum, int group, float ypos, String structure)
     {
-        ChannelMetadata metadata = ChannelMetadata({ name, group, ypos, structure });
+        ChannelMetadata metadata = ChannelMetadata();
+        metadata.name = name;
+        metadata.group = group;
+        metadata.ypos = ypos;
+        metadata.structure = structure;
 
         channelMetadata.add(metadata);
         channelMap[channelNum] = numChannels;

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -30,7 +30,7 @@ namespace LfpViewer {
 
 
     */
-#define BUFFER_LENGTH 30000
+#define BUFFER_LENGTH 20000
 
     DisplayBuffer::DisplayBuffer(int id_, String name_, float sampleRate_) : 
         id(id_), name(name_), sampleRate(sampleRate_), isNeeded(true)
@@ -202,8 +202,6 @@ namespace LfpViewer {
         const int samplesLeft = BUFFER_LENGTH - displayBufferIndices[channelMap[chan]];
 
         int newIndex;
-
-        
         
         if (nSamples < samplesLeft)
         {
@@ -240,11 +238,9 @@ namespace LfpViewer {
             newIndex = extraSamples;
         }
 
-        displayBufferIndices.set(channelMap[chan], newIndex);
-        
         ScopedLock displayLock(displayMutex);
-        
-        newIndex = displayBufferIndices[channelMap[chan]];
+
+        displayBufferIndices.set(channelMap[chan], newIndex);
 
     }
 

--- a/Plugins/LfpDisplayNode/DisplayBuffer.h
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.h
@@ -92,6 +92,8 @@ namespace LfpViewer {
 
         CriticalSection displayMutex;
 
+        bool isNeeded;
+
     };
 };
 

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -153,7 +153,7 @@ void LfpChannelDisplay::pxPaint()
     if (ifrom < 0)
         ifrom = 0;
     
-    int ito = canvasSplit->screenBufferIndex[chan] +0;
+    int ito = canvasSplit->screenBufferIndex[chan] + 0;
     
     if (fullredraw)
     {
@@ -199,21 +199,25 @@ void LfpChannelDisplay::pxPaint()
             // draw event markers
             int rawEventState = canvasSplit->getYCoord(canvasSplit->getNumChannels(), i);// get last channel+1 in buffer (represents events)
             
-            for (int ev_ch = 0; ev_ch < 8 ; ev_ch++) // for all event channels
+            if (i > ifrom + 39)
             {
-                if (display->getEventDisplayState(ev_ch))  // check if plotting for this channel is enabled
+                for (int ev_ch = 0; ev_ch < 8; ev_ch++) // for all event channels
                 {
-                    if (rawEventState & (1 << ev_ch))    // events are  representet by a bit code, so we have to extract the individual bits with a mask
+                    if (display->getEventDisplayState(ev_ch))  // check if plotting for this channel is enabled
                     {
-//                        std::cout << "Drawing event." << std::endl;
-                        Colour currentcolor=display->channelColours[ev_ch*2];
-                        
-                        for (int k=jfrom_wholechannel; k<=jto_wholechannel; k++) // draw line
-                            bdLfpChannelBitmap.setPixelColour(i,k,bdLfpChannelBitmap.getPixelColour(i,k).interpolatedWith(currentcolor,0.3f));
-                        
+                        if (rawEventState & (1 << ev_ch))    // events are  representet by a bit code, so we have to extract the individual bits with a mask
+                        {
+                            //                        std::cout << "Drawing event." << std::endl;
+                            Colour currentcolor = display->channelColours[ev_ch * 2];
+
+                            for (int k = jfrom_wholechannel; k <= jto_wholechannel; k++) // draw line
+                                bdLfpChannelBitmap.setPixelColour(i, k, bdLfpChannelBitmap.getPixelColour(i, k).interpolatedWith(currentcolor, 0.3f));
+
+                        }
                     }
                 }
             }
+           
             
             //std::cout << "e " << canvas->getYCoord(canvas->getNumChannels()-1, i) << std::endl;
             

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -134,9 +134,9 @@ void LfpChannelDisplay::pxPaint()
     if (jto_wholechannel >= display->lfpChannelBitmap.getHeight()) {jto_wholechannel=display->lfpChannelBitmap.getHeight()-1;};
     
     // draw most recent drawn sample position
-    if (canvasSplit->screenBufferIndex[chan]+1 <= display->lfpChannelBitmap.getWidth())
+    if (canvasSplit->screenBufferIndex[0] < display->lfpChannelBitmap.getWidth())
         for (int k=jfrom_wholechannel; k<=jto_wholechannel; k+=2) // draw line
-            bdLfpChannelBitmap.setPixelColour(canvasSplit->screenBufferIndex[chan]+1,k, Colours::yellow);
+            bdLfpChannelBitmap.setPixelColour(canvasSplit->screenBufferIndex[0],k, Colours::yellow);
     
     bool clipWarningHi =false; // keep track if something clipped in the display, so we can draw warnings after the data pixels are done
     bool clipWarningLo =false;
@@ -153,17 +153,20 @@ void LfpChannelDisplay::pxPaint()
     int from = 0; // for vertical line drawing in the LFP data
     int to = 0;
     
-    int ifrom = canvasSplit->lastScreenBufferIndex[chan] - 40; // need to start drawing a bit before the actual redraw window for the interpolated line to join correctly
+    int ifrom = canvasSplit->lastScreenBufferIndex[0]; // base everything on the first channel
     
-    if (ifrom < 0)
-        ifrom = 0;
+    //if (ifrom < 0)
+    //    ifrom = display->lfpChannelBitmap.getWidth() + ifrom;
     
-    int ito = canvasSplit->screenBufferIndex[chan] + 0;
+    int ito = canvasSplit->screenBufferIndex[0];
+
+    if (ito < ifrom)
+        ito = getWidth() + ito;
     
     if (fullredraw)
     {
         ifrom = 0; //canvas->leftmargin;
-        ito = getWidth()-stepSize;
+        ito = getWidth();
         fullredraw = false;
     }
     
@@ -171,217 +174,223 @@ void LfpChannelDisplay::pxPaint()
     
     LfpBitmapPlotterInfo plotterInfo; // hold and pass plotting info for each plotting method class
     
-    for (int i = ifrom; i < ito ; i += stepSize) // redraw only changed portion
+    //if (getChannelNumber() == 0)
+    //    std::cout << "ifrom: " << ifrom << ", ito: " << ito << std::endl;
+
+    for (int index = ifrom; index < ito; index++)
     {
-        if (i < display->lfpChannelBitmap.getWidth())
+
+        int i = index;
+
+        i %= getWidth();
+
+        //draw zero line
+        int m = getY() + center;
+            
+        if (m > 0 && m < display->lfpChannelBitmap.getHeight())
         {
-            //draw zero line
-            int m = getY()+center;
-            
-            if(m > 0 && m < display->lfpChannelBitmap.getHeight())
-            {
-                if ( bdLfpChannelBitmap.getPixelColour(i,m) == display->getColourSchemePtr()->getBackgroundColour() ) { // make sure we're not drawing over an existing plot from another channel
-                    bdLfpChannelBitmap.setPixelColour(i,m,Colour(50,50,50));
-                }
+            if ( bdLfpChannelBitmap.getPixelColour(i,m) == display->getColourSchemePtr()->getBackgroundColour() ) { // make sure we're not drawing over an existing plot from another channel
+                bdLfpChannelBitmap.setPixelColour(i,m,Colour(50,50,50));
             }
+        }
             
-            //draw range markers
-            if (isSelected)
-            {
-                int start = getY()+center -channelHeight/2;
-                int jump = channelHeight/4;
+        //draw range markers
+        if (isSelected)
+        {
+            int start = getY()+center -channelHeight/2;
+            int jump = channelHeight/4;
                 
-                for (m = start; m <= start + jump*4; m += jump)
+            for (m = start; m <= start + jump*4; m += jump)
+            {
+                if (m > 0 && m < display->lfpChannelBitmap.getHeight())
                 {
-                    if (m > 0 && m < display->lfpChannelBitmap.getHeight())
-                    {
-                        if ( bdLfpChannelBitmap.getPixelColour(i,m) == display->getColourSchemePtr()->getBackgroundColour()) // make sure we're not drawing over an existing plot from another channel
-                            bdLfpChannelBitmap.setPixelColour(i, m, Colour(80,80,80));
-                    }
+                    if ( bdLfpChannelBitmap.getPixelColour(i,m) == display->getColourSchemePtr()->getBackgroundColour()) // make sure we're not drawing over an existing plot from another channel
+                        bdLfpChannelBitmap.setPixelColour(i, m, Colour(80,80,80));
                 }
             }
+        }
             
-            // draw event markers
-            int rawEventState = canvasSplit->getYCoord(canvasSplit->getNumChannels(), i);// get last channel+1 in buffer (represents events)
+        // draw event markers
+        int rawEventState = canvasSplit->getYCoord(canvasSplit->getNumChannels(), i);// get last channel+1 in buffer (represents events)
             
-            if (i > ifrom + 39)
+        for (int ev_ch = 0; ev_ch < 8; ev_ch++) // for all event channels
+        {
+            if (display->getEventDisplayState(ev_ch))  // check if plotting for this channel is enabled
             {
-                for (int ev_ch = 0; ev_ch < 8; ev_ch++) // for all event channels
+                if (rawEventState & (1 << ev_ch))    // events are  representet by a bit code, so we have to extract the individual bits with a mask
                 {
-                    if (display->getEventDisplayState(ev_ch))  // check if plotting for this channel is enabled
-                    {
-                        if (rawEventState & (1 << ev_ch))    // events are  representet by a bit code, so we have to extract the individual bits with a mask
-                        {
-                            //                        std::cout << "Drawing event." << std::endl;
-                            Colour currentcolor = display->channelColours[ev_ch * 2];
+                    //                        std::cout << "Drawing event." << std::endl;
+                    Colour currentcolor = display->channelColours[ev_ch * 2];
 
-                            for (int k = jfrom_wholechannel; k <= jto_wholechannel; k++) // draw line
-                                bdLfpChannelBitmap.setPixelColour(i, k, bdLfpChannelBitmap.getPixelColour(i, k).interpolatedWith(currentcolor, 0.3f));
+                    for (int k = jfrom_wholechannel; k <= jto_wholechannel; k++) // draw line
+                        bdLfpChannelBitmap.setPixelColour(i, k, bdLfpChannelBitmap.getPixelColour(i, k).interpolatedWith(currentcolor, 0.3f));
 
-                        }
-                    }
                 }
             }
-           
+        }
+ 
+        //std::cout << "e " << canvas->getYCoord(canvas->getNumChannels()-1, i) << std::endl;
             
-            //std::cout << "e " << canvas->getYCoord(canvas->getNumChannels()-1, i) << std::endl;
+        // set max-min range for plotting, used in all methods
+        double a = (canvasSplit->getYCoordMax(chan, i)/range*channelHeightFloat);
+        double b = (canvasSplit->getYCoordMin(chan, i)/range*channelHeightFloat);
             
-            // set max-min range for plotting, used in all methods
-            double a = (canvasSplit->getYCoordMax(chan, i)/range*channelHeightFloat);
-            double b = (canvasSplit->getYCoordMin(chan, i)/range*channelHeightFloat);
+        double mean = (canvasSplit->getMean(chan)/range*channelHeightFloat);
             
-            double mean = (canvasSplit->getMean(chan)/range*channelHeightFloat);
+        if (drawWithOffsetCorrection)
+        {
+            a -= mean;
+            b -= mean;
+        }
             
-            if (drawWithOffsetCorrection)
-            {
-                a -= mean;
-                b -= mean;
-            }
+        double a_raw = canvasSplit->getYCoordMax(chan, i);
+        double b_raw = canvasSplit->getYCoordMin(chan, i);
+        double from_raw=0; double to_raw=0;
             
-            double a_raw = canvasSplit->getYCoordMax(chan, i);
-            double b_raw = canvasSplit->getYCoordMin(chan, i);
-            double from_raw=0; double to_raw=0;
-            
-            //double m = (canvas->getYCoordMean(chan, i)/range*channelHeightFloat)+getHeight()/2;
-            if (a<b)
-            {
-                from = (a); to = (b);
-                from_raw = (a_raw); to_raw = (b_raw);
+        //double m = (canvas->getYCoordMean(chan, i)/range*channelHeightFloat)+getHeight()/2;
+        if (a<b)
+        {
+            from = (a); to = (b);
+            from_raw = (a_raw); to_raw = (b_raw);
                 
-            }
-            else
-            {
-                from = (b); to = (a);
-                from_raw = (b_raw); to_raw = (a_raw);
-            }
+        }
+        else
+        {
+            from = (b); to = (a);
+            from_raw = (b_raw); to_raw = (a_raw);
+        }
             
-            // start by clipping so that we're not populating pixels that we dont want to plot
-            int lm= channelHeightFloat*canvasSplit->channelOverlapFactor;
-            if (lm>0)
-                lm=-lm;
+        // start by clipping so that we're not populating pixels that we dont want to plot
+        int lm= channelHeightFloat*canvasSplit->channelOverlapFactor;
+        if (lm>0)
+            lm=-lm;
             
-            if (from > -lm) {from = -lm; clipWarningHi=true;};
-            if (to > -lm) {to = -lm; clipWarningHi=true;};
-            if (from < lm) {from = lm; clipWarningLo=true;};
-            if (to < lm) {to = lm; clipWarningLo=true;};
+        if (from > -lm) {from = -lm; clipWarningHi=true;};
+        if (to > -lm) {to = -lm; clipWarningHi=true;};
+        if (from < lm) {from = lm; clipWarningLo=true;};
+        if (to < lm) {to = lm; clipWarningLo=true;};
             
-            // test if raw data is clipped for displaying saturation warning
-            if (from_raw > options->selectedSaturationValueFloat) { saturateWarningHi=true;};
-            if (to_raw > options->selectedSaturationValueFloat) { saturateWarningHi=true;};
-            if (from_raw < -options->selectedSaturationValueFloat) { saturateWarningLo=true;};
-            if (to_raw < -options->selectedSaturationValueFloat) { saturateWarningLo=true;};
+        // test if raw data is clipped for displaying saturation warning
+        if (from_raw > options->selectedSaturationValueFloat) { saturateWarningHi=true;};
+        if (to_raw > options->selectedSaturationValueFloat) { saturateWarningHi=true;};
+        if (from_raw < -options->selectedSaturationValueFloat) { saturateWarningLo=true;};
+        if (to_raw < -options->selectedSaturationValueFloat) { saturateWarningLo=true;};
             
-            bool spikeFlag = display->getSpikeRasterPlotting()
-                && (from_raw - canvasSplit->getYCoordMean(chan, i) < display->getSpikeRasterThreshold()
-                        || to_raw - canvasSplit->getYCoordMean(chan, i) < display->getSpikeRasterThreshold());
+        bool spikeFlag = display->getSpikeRasterPlotting()
+            && (from_raw - canvasSplit->getYCoordMean(chan, i) < display->getSpikeRasterThreshold()
+                    || to_raw - canvasSplit->getYCoordMean(chan, i) < display->getSpikeRasterThreshold());
 
-           // && !(saturateWarningHi || saturateWarningLo)
+        // && !(saturateWarningHi || saturateWarningLo)
             
-            from = from + getHeight()/2;       // so the plot is centered in the channeldisplay
-            to = to + getHeight()/2;
+        from = from + getHeight()/2;       // so the plot is centered in the channeldisplay
+        to = to + getHeight()/2;
             
-            int samplerange = to - from;
+        int samplerange = to - from;
             
-            if (drawMethod) // switched between 'supersampled' drawing and simple pixel wise drawing
-            { // histogram based supersampling method
-                plotterInfo.channelID = chan;
-                plotterInfo.samp = i;
-                plotterInfo.y = getY();
-                plotterInfo.from = from;
-                plotterInfo.height = getHeight();
-                plotterInfo.lineColourBright = lineColourBright;
-                plotterInfo.lineColourDark = lineColourDark;
-                plotterInfo.range = range;
-                plotterInfo.channelHeightFloat = channelHeightFloat;
-               // plotterInfo.sampleCountPerPixel = canvasSplit->getSampleCountPerPixel(i);
-                //plotterInfo.samplesPerPixel = canvasSplit->getSamplesPerPixel(chan, i);
-                plotterInfo.histogramParameterA = canvasSplit->histogramParameterA;
-                plotterInfo.samplerange = samplerange;
+        if (drawMethod) // switched between 'supersampled' drawing and simple pixel wise drawing
+        { // histogram based supersampling method
+            plotterInfo.channelID = chan;
+            plotterInfo.samp = i;
+            plotterInfo.y = getY();
+            plotterInfo.from = from;
+            plotterInfo.height = getHeight();
+            plotterInfo.lineColourBright = lineColourBright;
+            plotterInfo.lineColourDark = lineColourDark;
+            plotterInfo.range = range;
+            plotterInfo.channelHeightFloat = channelHeightFloat;
+            // plotterInfo.sampleCountPerPixel = canvasSplit->getSampleCountPerPixel(i);
+            //plotterInfo.samplesPerPixel = canvasSplit->getSamplesPerPixel(chan, i);
+            plotterInfo.histogramParameterA = canvasSplit->histogramParameterA;
+            plotterInfo.samplerange = samplerange;
                 
-                // TODO: (kelly) complete transition toward plotter class encapsulation
+            // TODO: (kelly) complete transition toward plotter class encapsulation
 //                display->getPlotterPtr()->plot(bdLfpChannelBitmap, plotterInfo);
                 
-            }
-            else //drawmethod
-            { // simple per-pixel min-max drawing, has no anti-aliasing, but runs faster
+        }
+        else //drawmethod
+        { // simple per-pixel min-max drawing, has no anti-aliasing, but runs faster
                 
-                plotterInfo.channelID = chan;
-                plotterInfo.y = getY();
-                plotterInfo.from = from;
-                plotterInfo.to = to;
-                plotterInfo.samp = i;
-                plotterInfo.lineColour = lineColour;
+            plotterInfo.channelID = chan;
+            plotterInfo.y = getY();
+            plotterInfo.from = from;
+            plotterInfo.to = to;
+            plotterInfo.samp = i;
+            plotterInfo.lineColour = lineColour;
                 
-                // TODO: (kelly) complete transition toward plotter class encapsulation
+            // TODO: (kelly) complete transition toward plotter class encapsulation
 //                display->getPlotterPtr()->plot(bdLfpChannelBitmap, plotterInfo); // plotterInfo is prepared above
                 
-            }
+        }
             
-            // Do the actual plotting for the selected plotting method
-            if (!display->getSpikeRasterPlotting())
-                display->getPlotterPtr()->plot(bdLfpChannelBitmap, plotterInfo);
+        // Do the actual plotting for the selected plotting method
+        if (!display->getSpikeRasterPlotting())
+            display->getPlotterPtr()->plot(bdLfpChannelBitmap, plotterInfo);
             
-            // now draw warnings, if needed
-            if (canvasSplit->drawClipWarning) // draw simple warning if display cuts off data
-            {
+        // now draw warnings, if needed
+        if (canvasSplit->drawClipWarning) // draw simple warning if display cuts off data
+        {
                 
-                if(clipWarningHi) {
-                    for (int j=0; j<=3; j++)
-                    {
-                        int clipmarker = jto_wholechannel_clip;
+            if(clipWarningHi) {
+                for (int j=0; j<=3; j++)
+                {
+                    int clipmarker = jto_wholechannel_clip;
                         
-                        if(clipmarker>0 && clipmarker<display->lfpChannelBitmap.getHeight()){
-                            bdLfpChannelBitmap.setPixelColour(i,clipmarker-j,Colour(255,255,255));
-                        }
+                    if(clipmarker>0 && clipmarker<display->lfpChannelBitmap.getHeight()){
+                        bdLfpChannelBitmap.setPixelColour(i,clipmarker-j,Colour(255,255,255));
                     }
                 }
+            }
                 
-                if(clipWarningLo) {
-                    for (int j=0; j<=3; j++)
-                    {
-                        int clipmarker = jfrom_wholechannel_clip;
+            if(clipWarningLo) {
+                for (int j=0; j<=3; j++)
+                {
+                    int clipmarker = jfrom_wholechannel_clip;
                         
-                        if(clipmarker>0 && clipmarker<display->lfpChannelBitmap.getHeight()){
-                            bdLfpChannelBitmap.setPixelColour(i,clipmarker+j,Colour(255,255,255));
-                        }
+                    if(clipmarker>0 && clipmarker<display->lfpChannelBitmap.getHeight()){
+                        bdLfpChannelBitmap.setPixelColour(i,clipmarker+j,Colour(255,255,255));
                     }
                 }
-                
-                clipWarningHi=false;
-                clipWarningLo=false;
             }
+                
+            clipWarningHi=false;
+            clipWarningLo=false;
+        }
             
-            if (spikeFlag) // draw spikes
-            {
+        if (spikeFlag) // draw spikes
+        {
+            for (int k=jfrom_wholechannel; k<=jto_wholechannel; k++){ // draw line
+                if(k>0 && k<display->lfpChannelBitmap.getHeight()){
+                    bdLfpChannelBitmap.setPixelColour(i,k,lineColour);
+                }
+            };
+        }
+            
+        if (canvasSplit->drawSaturationWarning) // draw bigger warning if actual data gets cuts off
+        {
+                
+            if(saturateWarningHi || saturateWarningLo) {
+                    
                 for (int k=jfrom_wholechannel; k<=jto_wholechannel; k++){ // draw line
+                    Colour thiscolour=Colour(255,0,0);
+                    if (fmod((i+k),50)>25){
+                        thiscolour=Colour(255,255,255);
+                    }
                     if(k>0 && k<display->lfpChannelBitmap.getHeight()){
-                        bdLfpChannelBitmap.setPixelColour(i,k,lineColour);
+                        bdLfpChannelBitmap.setPixelColour(i,k,thiscolour);
                     }
                 };
             }
-            
-            if (canvasSplit->drawSaturationWarning) // draw bigger warning if actual data gets cuts off
-            {
                 
-                if(saturateWarningHi || saturateWarningLo) {
-                    
-                    for (int k=jfrom_wholechannel; k<=jto_wholechannel; k++){ // draw line
-                        Colour thiscolour=Colour(255,0,0);
-                        if (fmod((i+k),50)>25){
-                            thiscolour=Colour(255,255,255);
-                        }
-                        if(k>0 && k<display->lfpChannelBitmap.getHeight()){
-                            bdLfpChannelBitmap.setPixelColour(i,k,thiscolour);
-                        }
-                    };
-                }
-                
-                saturateWarningHi=false; // we likely just need one of this because for this warning we dont care if its saturating on the positive or negative side
-                saturateWarningLo=false;
-            }
+            saturateWarningHi=false; // we likely just need one of this because for this warning we dont care if its saturating on the positive or negative side
+            saturateWarningLo=false;
+
         } // if i < getWidth()
+
+        //i++;
+
+        //i %= getWidth() - canvasSplit->leftmargin;
         
-    } // for i (x pixels)
+    } // while i
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -105,8 +105,11 @@ void LfpChannelDisplay::setHidden(bool isHidden_)
 
 void LfpChannelDisplay::pxPaint()
 {
-    if (!isEnabled || isHidden) return; // return early if THIS display is not enabled
-    
+    if (!isEnabled || isHidden)
+    {
+        return; // return early if THIS display is not enabled
+    }
+
     Image::BitmapData bdLfpChannelBitmap(display->lfpChannelBitmap, 0,0, display->lfpChannelBitmap.getWidth(), display->lfpChannelBitmap.getHeight());
     
     int center = getHeight()/2;

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -148,7 +148,7 @@ void LfpChannelDisplay::pxPaint()
     int from = 0; // for vertical line drawing in the LFP data
     int to = 0;
     
-    int ifrom = canvasSplit->lastScreenBufferIndex[chan] - 1; // need to start drawing a bit before the actual redraw window for the interpolated line to join correctly
+    int ifrom = canvasSplit->lastScreenBufferIndex[chan] - 40; // need to start drawing a bit before the actual redraw window for the interpolated line to join correctly
     
     if (ifrom < 0)
         ifrom = 0;

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -95,25 +95,17 @@ void LfpChannelDisplay::updateType()
 
 void LfpChannelDisplay::setEnabledState(bool state)
 {
-
-    //if (state)
-    //std::cout << "Setting channel " << name << " to true." << std::endl;
-    //else
-    //std::cout << "Setting channel " << name << " to false." << std::endl;
-
     isEnabled = state;
-
 }
 
 void LfpChannelDisplay::setHidden(bool isHidden_)
 {
     isHidden = isHidden_;
-    isEnabled = !isHidden;
 }
 
 void LfpChannelDisplay::pxPaint()
 {
-    if (!isEnabled) return; // return early if THIS display is not enabled
+    if (!isEnabled || isHidden) return; // return early if THIS display is not enabled
     
     Image::BitmapData bdLfpChannelBitmap(display->lfpChannelBitmap, 0,0, display->lfpChannelBitmap.getWidth(), display->lfpChannelBitmap.getHeight());
     

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -156,11 +156,14 @@ void LfpChannelDisplay::pxPaint()
     int ifrom = canvasSplit->lastScreenBufferIndex[0]; // base everything on the first channel
     
     //if (ifrom < 0)
-    //    ifrom = display->lfpChannelBitmap.getWidth() + ifrom;
+   //     ifrom = 0;
     
     int ito = canvasSplit->screenBufferIndex[0];
 
-    if (ito < ifrom)
+    //if (ito < 0)
+    //    ito = getWidth();
+
+     if (ito < ifrom)
         ito = getWidth() + ito;
     
     if (fullredraw)

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -288,8 +288,8 @@ void LfpChannelDisplay::pxPaint()
                 plotterInfo.lineColourDark = lineColourDark;
                 plotterInfo.range = range;
                 plotterInfo.channelHeightFloat = channelHeightFloat;
-                plotterInfo.sampleCountPerPixel = canvasSplit->getSampleCountPerPixel(i);
-                plotterInfo.samplesPerPixel = canvasSplit->getSamplesPerPixel(chan, i);
+               // plotterInfo.sampleCountPerPixel = canvasSplit->getSampleCountPerPixel(i);
+                //plotterInfo.samplesPerPixel = canvasSplit->getSamplesPerPixel(chan, i);
                 plotterInfo.histogramParameterA = canvasSplit->histogramParameterA;
                 plotterInfo.samplerange = samplerange;
                 

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -95,6 +95,11 @@ void LfpChannelDisplay::updateType()
 
 void LfpChannelDisplay::setEnabledState(bool state)
 {
+    if (state)
+        std::cout << "ENABLING CHANNEL " << chan << std::endl;
+    else
+        std::cout << "DISABLING CHANNEL " << chan << std::endl;
+
     isEnabled = state;
 }
 

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -95,10 +95,10 @@ void LfpChannelDisplay::updateType()
 
 void LfpChannelDisplay::setEnabledState(bool state)
 {
-    if (state)
+    /*if (state)
         std::cout << "ENABLING CHANNEL " << chan << std::endl;
     else
-        std::cout << "DISABLING CHANNEL " << chan << std::endl;
+        std::cout << "DISABLING CHANNEL " << chan << std::endl;*/
 
     isEnabled = state;
 }

--- a/Plugins/LfpDisplayNode/LfpChannelDisplayInfo.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplayInfo.cpp
@@ -79,7 +79,7 @@ void LfpChannelDisplayInfo::buttonClicked(Button* button)
 
     bool state = button->getToggleState();
 
-    display->setEnabledState(state, chan);
+    display->setEnabledState(state, chan, true);
 
     //UtilityButton* b = (UtilityButton*) button;
 
@@ -96,7 +96,7 @@ void LfpChannelDisplayInfo::buttonClicked(Button* button)
 
 void LfpChannelDisplayInfo::setEnabledState(bool state)
 {
-    enableButton->setToggleState(state, sendNotification);
+    enableButton->setToggleState(state, dontSendNotification);
 }
 
 void LfpChannelDisplayInfo::setSingleChannelState(bool state)

--- a/Plugins/LfpDisplayNode/LfpChannelDisplayInfo.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplayInfo.cpp
@@ -273,6 +273,8 @@ void LfpChannelDisplayInfo::updateXY(float x_, float y_)
 void LfpChannelDisplayInfo::resized()
 {
 
+   // std::cout << "Resizing info" << std::endl;
+
     int center = getHeight()/2 - (isSingleChannel?(75):(0));
     setEnabledButtonVisibility(getHeight() >= 16);
     

--- a/Plugins/LfpDisplayNode/LfpChannelDisplayInfo.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplayInfo.cpp
@@ -209,7 +209,6 @@ void LfpChannelDisplayInfo::mouseUp(const MouseEvent &e)
 
 void LfpChannelDisplayInfo::paint(Graphics& g)
 {
-
     int center = getHeight()/2 - (isSingleChannel?(75):(0));
 	const bool showChannelNumbers = options->getChannelNameState();
 
@@ -222,7 +221,7 @@ void LfpChannelDisplayInfo::paint(Graphics& g)
     g.drawText(channelString,
                showChannelNumbers ? 6 : 2,
                center-4,
-               getWidth()/2,
+               getWidth(),
                10,
                isCentered ? Justification::centred : Justification::centredLeft,
                false);
@@ -279,7 +278,7 @@ void LfpChannelDisplayInfo::resized()
     
     if (getEnabledButtonVisibility())
     {
-        enableButton->setBounds(getWidth()/2 - 10, center - 5, 10, 10);
+        enableButton->setBounds(getWidth() - 13, center - 5, 10, 10);
     }
     
     setChannelNumberIsHidden(getHeight() < 16 && (getDrawableChannelNumber() + 1) % 10 != 0);

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -437,13 +437,13 @@ void LfpDisplay::refresh()
                  // we redraw from 0 to +2 (px) relative to the real redraw window, the +1 draws the vertical update line
                  if (fillfrom < fillto)
                  {
-                     channels[i]->repaint(fillfrom, 0, (fillto - fillfrom) + 2, channels[i]->getHeight());
+                     channels[i]->repaint(fillfrom, 0, (fillto - fillfrom) + 1, channels[i]->getHeight());
                  }
                     
                  else
                  {
-                     channels[i]->repaint(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 2, channels[i]->getHeight());
-                     channels[i]->repaint(0, 0, fillto + 2, channels[i]->getHeight());
+                     channels[i]->repaint(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 1, channels[i]->getHeight());
+                     channels[i]->repaint(0, 0, fillto + 1, channels[i]->getHeight());
                  }
                 
             }
@@ -1132,7 +1132,7 @@ void LfpDisplay::mouseDown(const MouseEvent& event)
     int dist = 0;
     int mindist = 10000;
     int closest = 5;
-
+    
     for (int n = 0; n < drawableChannels.size(); n++) // select closest instead of relying on eventComponent
     {
         drawableChannels[n].channel->deselect();
@@ -1149,7 +1149,7 @@ void LfpDisplay::mouseDown(const MouseEvent& event)
         }
     }
 
-   // std::cout << "Closest channel" << closest << std::endl;
+    //std::cout << "Closest channel" << closest << std::endl;
 
     drawableChannels[closest].channel->select();
     options->setSelectedType(drawableChannels[closest].channel->getType());
@@ -1176,7 +1176,7 @@ void LfpDisplay::mouseDown(const MouseEvent& event)
 
     canvasSplit->select();
 
-    canvasSplit->fullredraw = true;//issue full redraw
+    canvasSplit->fullredraw = true; //issue full redraw
 
     refresh();
 

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -166,12 +166,6 @@ void LfpDisplay::setNumChannels(int newChannelCount)
         drawableChannels.removeLast(numChans - newChannelCount);
     }
     
-    //removeAllChildren();
-
-    //channels.clear();
-    //channelInfo.clear();
-    //drawableChannels.clear();
-
     totalHeight = 0;
 
     cachedDisplayChannelHeight = canvasSplit->getChannelHeight();
@@ -225,7 +219,7 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
     setColors();
 
-    //std::cout << "TOTAL HEIGHT = " << totalHeight << std::endl;
+   // std::cout << "TOTAL HEIGHT = " << totalHeight << std::endl;
 
 }
 
@@ -327,9 +321,9 @@ void LfpDisplay::resized()
     else
         lfpChannelBitmap = Image(Image::ARGB, 10, 10, false);
     
-    //inititalize black background
+    //inititalize background
     Graphics gLfpChannelBitmap(lfpChannelBitmap);
-    gLfpChannelBitmap.setColour(Colour(0,0,0)); //background color
+    gLfpChannelBitmap.setColour(getColourSchemePtr()->getBackgroundColour()); //background color
     gLfpChannelBitmap.fillRect(0,0, getWidth(), getHeight());
 
     canvasSplit->fullredraw = true;
@@ -342,13 +336,17 @@ void LfpDisplay::resized()
 
 void LfpDisplay::paint(Graphics& g)
 {
-
+    
     g.drawImageAt(lfpChannelBitmap, canvasSplit->leftmargin, 0);
     
 }
 
 void LfpDisplay::refresh()
 {
+
+    if (numChans == 0)
+        return;
+
     // Ensure the lfpChannelBitmap has been initialized
     if (lfpChannelBitmap.isNull())
     {
@@ -913,6 +911,9 @@ void LfpDisplay::reactivateChannels()
 
 void LfpDisplay::rebuildDrawableChannelsList()
 {
+
+    if (channels.size() == 0)
+        return;
     
     if (displaySkipAmt != 0) removeAllChildren(); // start with clean slate
     

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -163,7 +163,6 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
         channels.removeLast(numChans - newChannelCount);
         channelInfo.removeLast(numChans - newChannelCount);
-        drawableChannels.removeLast(numChans - newChannelCount);
     }
     
     totalHeight = 0;
@@ -183,11 +182,11 @@ void LfpDisplay::setNumChannels(int newChannelCount)
                 //std::cout << "Adding new display for channel " << i << std::endl;
 
                 lfpChan = new LfpChannelDisplay(canvasSplit, this, options, i);
-                addAndMakeVisible(lfpChan);
+                //addAndMakeVisible(lfpChan);
                 channels.add(lfpChan);
 
                 lfpInfo = new LfpChannelDisplayInfo(canvasSplit, this, options, i);
-                addAndMakeVisible(lfpInfo);
+                //addAndMakeVisible(lfpInfo);
                 channelInfo.add(lfpInfo);
 
                 drawableChannels.add(LfpChannelTrack{
@@ -915,7 +914,7 @@ void LfpDisplay::rebuildDrawableChannelsList()
     if (channels.size() == 0)
         return;
     
-    if (displaySkipAmt != 0) removeAllChildren(); // start with clean slate
+    removeAllChildren(); // start with clean slate
     
     Array<LfpChannelTrack> channelsToDraw;
     drawableChannels = Array<LfpDisplay::LfpChannelTrack>();
@@ -923,14 +922,6 @@ void LfpDisplay::rebuildDrawableChannelsList()
     // iterate over all channels and select drawable ones
     for (int i = 0, drawableChannelNum = 0; i < channels.size(); i++)
     {
-//        std::cout << "\tchannel " << i << " has subprocessor index of "  << channelInfo[i]->getSubprocessorIdx() << std::endl;
-        // if channel[i] is not sourced from the correct subprocessor, then hide it and continue
-        //if (channelInfo[i]->getSubprocessorIdx() != getDisplayedSubprocessor())
-        //{
-        //    channels[i]->setHidden(true);
-        //    channelInfo[i]->setHidden(true);
-        //    continue;
-        //}
         
 		//std::cout << "Checking for hidden channels" << std::endl;
         if (displaySkipAmt == 0 || (i % displaySkipAmt == 0)) // no skips, add all channels
@@ -971,8 +962,8 @@ void LfpDisplay::rebuildDrawableChannelsList()
                 channels[i]->setHidden(true);
                 channelInfo[i]->setHidden(true);
                 
-                removeChildComponent(channels[i]);
-                removeChildComponent(channelInfo[i]);
+                //removeChildComponent(channels[i]);
+                //removeChildComponent(channelInfo[i]);
 //            }
         }
     }

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -152,12 +152,12 @@ ChannelColourScheme * LfpDisplay::getColourSchemePtr()
 void LfpDisplay::setNumChannels(int newChannelCount)
 {
 
-    std::cout << "setting num channels to " << newChannelCount << std::endl;
+   // std::cout << "setting num channels to " << newChannelCount << std::endl;
     
     if (numChans > newChannelCount)
     {
 
-        std::cout << "   removing " << numChans - newChannelCount << " extra channels." << std::endl;
+       // std::cout << "   removing " << numChans - newChannelCount << " extra channels." << std::endl;
 
         for (int i = newChannelCount; i < numChans; i++)
         {
@@ -184,7 +184,7 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
             if (i >= numChans)
             {
-                std::cout << "ADDING NEW CHANNEL " << i << std::endl;
+               // std::cout << "ADDING NEW CHANNEL " << i << std::endl;
 
                 lfpChan = new LfpChannelDisplay(canvasSplit, this, options, i);
                 channels.add(lfpChan);
@@ -219,7 +219,7 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
     numChans = newChannelCount;
 
-    std::cout << "Done setting channels." << std::endl;
+   // std::cout << "Done setting channels." << std::endl;
 
 }
 
@@ -883,11 +883,10 @@ void LfpDisplay::reactivateChannels()
 
 void LfpDisplay::rebuildDrawableChannelsList()
 {
-    std::cout << "REBUILDING DRAWABLE CHANNELS LIST" << std::endl;
 
     if (getSingleChannelState())
     {
-        std::cout << "Single channel on (" << singleChan << ")" << std::endl;
+        //std::cout << "Single channel on (" << singleChan << ")" << std::endl;
 
         int newHeight = viewport->getHeight();
 
@@ -905,57 +904,61 @@ void LfpDisplay::rebuildDrawableChannelsList()
         if (channelIndex > -1)
         {
 
-            LfpChannelTrack lfpChannelTrack{ channels[channelIndex], channelInfo[channelIndex] };
-
-            removeAllChildren();
-
-            // disable unused channels
-            for (int i = 0; i < drawableChannels.size(); i++)
+            if (drawableChannels.size() != 1) // if we haven't already gone through this ordeal
             {
-                if (drawableChannels[i].channel != lfpChannelTrack.channel)
-                    drawableChannels[i].channel->setEnabledState(false);
+                LfpChannelTrack lfpChannelTrack{ channels[channelIndex], channelInfo[channelIndex] };
+
+                removeAllChildren();
+
+                // disable unused channels
+                for (int i = 0; i < drawableChannels.size(); i++)
+                {
+                    if (drawableChannels[i].channel != lfpChannelTrack.channel)
+                        drawableChannels[i].channel->setEnabledState(false);
+                }
+
+                // update drawableChannels, give only the single channel to focus on
+                drawableChannels = Array<LfpDisplay::LfpChannelTrack>();
+                drawableChannels.add(lfpChannelTrack);
+
+                lfpChannelTrack.channel->setEnabledState(true);
+                lfpChannelTrack.channelInfo->setEnabledState(true);
+                lfpChannelTrack.channelInfo->setSingleChannelState(true);
+
+                addAndMakeVisible(lfpChannelTrack.channel);
+                addAndMakeVisible(lfpChannelTrack.channelInfo);
+
+                // set channel height and position (so that we allocate the smallest
+                // necessary image size for drawing)
+                setChannelHeight(newHeight, false);
+
+                lfpChannelTrack.channel->setTopLeftPosition(canvasSplit->leftmargin, 0);
+                lfpChannelTrack.channelInfo->setTopLeftPosition(0, 0);
+                setSize(getWidth(), getChannelHeight());
+
+                viewport->setViewPosition(0, 0);
+
+                setColors();
+
+                // this guards against an exception where the editor sets the drawable samplerate
+                // before the lfpDisplay is fully initialized
+                if (getHeight() > 0 && getWidth() > 0)
+                {
+                    canvasSplit->resizeToChannels();
+                }
+
             }
-
-            // update drawableChannels, give only the single channel to focus on
-            drawableChannels = Array<LfpDisplay::LfpChannelTrack>();
-            drawableChannels.add(lfpChannelTrack);
-
-            lfpChannelTrack.channel->setEnabledState(true);
-            lfpChannelTrack.channelInfo->setEnabledState(true);
-            lfpChannelTrack.channelInfo->setSingleChannelState(true);
-
-            addAndMakeVisible(lfpChannelTrack.channel);
-            addAndMakeVisible(lfpChannelTrack.channelInfo);
-
-            // set channel height and position (so that we allocate the smallest
-            // necessary image size for drawing)
-            setChannelHeight(newHeight, false);
-
-            lfpChannelTrack.channel->setTopLeftPosition(canvasSplit->leftmargin, 0);
-            lfpChannelTrack.channelInfo->setTopLeftPosition(0, 0);
-            setSize(getWidth(), getChannelHeight());
-
-            viewport->setViewPosition(0, 0);
-
-            setColors();
-
-            // this guards against an exception where the editor sets the drawable samplerate
-            // before the lfpDisplay is fully initialized
-            if (getHeight() > 0 && getWidth() > 0)
-            {
-                canvasSplit->resizeToChannels();
-            }
-
-            std::cout << "Finished single channel rebuild" << std::endl;
+           
+            //std::cout << "Finished single channel rebuild" << std::endl;
 
             return;
         }
 
-        std::cout << "Single channel not found." << std::endl;
+        //std::cout << "Single channel not found." << std::endl;
 
     }
 
-    std::cout << "Standard channel rebuild" << std::endl;
+   // std::cout << "Standard channel rebuild" << std::endl;
 
     removeAllChildren(); // start with clean slate
     
@@ -1046,7 +1049,7 @@ void LfpDisplay::rebuildDrawableChannelsList()
     
     setColors();
 
-    std::cout << "Finished standard channel rebuild" << std::endl;
+   // std::cout << "Finished standard channel rebuild" << std::endl;
 }
 
 LfpBitmapPlotter * const LfpDisplay::getPlotterPtr() const
@@ -1066,7 +1069,6 @@ int LfpDisplay::getSingleChannelShown()
 
 void LfpDisplay::setSingleChannelView(int chan)
 {
-    std::cout << "SETTING SINGLE CHANNEL VIWWWWWWEEEE  TI " << chan << std::endl;
     singleChan = chan;
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -1107,9 +1107,9 @@ void LfpDisplay::mouseDown(const MouseEvent& event)
 
     canvasSplit->select();
 
-//    canvas->fullredraw = true;//issue full redraw
+    canvasSplit->fullredraw = true;//issue full redraw
 
-//    refresh();
+    refresh();
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -618,7 +618,7 @@ void LfpDisplay::orderChannelsByDepth(bool state)
     std::vector<float> depths(numChannels);
 
     bool allSame = true;
-    float last = drawableChannels[0].channel->getDepth();
+    float last = drawableChannels[0].channelInfo->getDepth();
 
     if (channelsOrderedByDepth)
     {
@@ -630,7 +630,7 @@ void LfpDisplay::orderChannelsByDepth(bool state)
             if (d != last)
                 allSame = false;
 
-           // std::cout << d << std::endl;
+            //std::cout << d << std::endl;
 
             depths[i] = d;
 
@@ -647,7 +647,7 @@ void LfpDisplay::orderChannelsByDepth(bool state)
             int ch = drawableChannels[i].channel->getChannelNumber();
             depths[i] = float(ch);
 
-           // std::cout << ch << std::endl;
+            //std::cout << ch << std::endl;
         }
             
     }

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -164,7 +164,7 @@ void LfpDisplay::setNumChannels(int newChannelCount)
         channels.removeLast(numChans - newChannelCount);
         channelInfo.removeLast(numChans - newChannelCount);
     }
-    
+
     totalHeight = 0;
 
     cachedDisplayChannelHeight = canvasSplit->getChannelHeight();
@@ -213,12 +213,8 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
 		}
 	}
-    
+
     numChans = newChannelCount;
-
-    setColors();
-
-   // std::cout << "TOTAL HEIGHT = " << totalHeight << std::endl;
 
 }
 
@@ -226,9 +222,6 @@ void LfpDisplay::setColors()
 {
     for (int i = 0; i < drawableChannels.size(); i++)
     {
-
-//        channels[i]->setColour(channelColours[(int(i/colorGrouping)+1) % channelColours.size()]);
-//        channelInfo[i]->setColour(channelColours[(int(i/colorGrouping)+1)  % channelColours.size()]);
         drawableChannels[i].channel->setColour(getColourSchemePtr()->getColourForIndex(i));
         drawableChannels[i].channelInfo->setColour(getColourSchemePtr()->getColourForIndex(i));
     }
@@ -528,7 +521,11 @@ void LfpDisplay::setDrawMethod(bool isDrawMethod)
 int LfpDisplay::getChannelHeight()
 {
 //    return cachedDisplayChannelHeight;
-    return drawableChannels[0].channel->getChannelHeight();
+
+    if (drawableChannels.size() > 0)
+        return drawableChannels[0].channel->getChannelHeight();
+    else
+        return 0;
 //    return channels[0]->getChannelHeight();
 }
 
@@ -911,9 +908,6 @@ void LfpDisplay::reactivateChannels()
 void LfpDisplay::rebuildDrawableChannelsList()
 {
 
-    if (channels.size() == 0)
-        return;
-    
     removeAllChildren(); // start with clean slate
     
     Array<LfpChannelTrack> channelsToDraw;
@@ -937,34 +931,13 @@ void LfpDisplay::rebuildDrawableChannelsList()
                 channelInfo[i]
             });
 
-           // std::cout << channels[i]->getDepth() << std::endl;
-            
             addAndMakeVisible(channels[i]);
             addAndMakeVisible(channelInfo[i]);
         }
         else // skip some channels
         {
-//            if (i % (displaySkipAmt) == 0) // add these channels
-//            {
-//                channels[i]->setHidden(false);
-//                channelInfo[i]->setHidden(false);
-//                
-//                channelsToDraw.add(LfpDisplay::LfpChannelTrack{
-//                    channels[i],
-//                    channelInfo[i]
-//                });
-//                
-//                addAndMakeVisible(channels[i]);
-//                addAndMakeVisible(channelInfo[i]);
-//            }
-//            else // but not these
-//            {
-                channels[i]->setHidden(true);
-                channelInfo[i]->setHidden(true);
-                
-                //removeChildComponent(channels[i]);
-                //removeChildComponent(channelInfo[i]);
-//            }
+            channels[i]->setHidden(true);
+            channelInfo[i]->setHidden(true);
         }
     }
     

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -151,9 +151,14 @@ ChannelColourScheme * LfpDisplay::getColourSchemePtr()
 
 void LfpDisplay::setNumChannels(int newChannelCount)
 {
+
+    std::cout << "setting num channels to " << newChannelCount << std::endl;
     
     if (numChans > newChannelCount)
     {
+
+        std::cout << "   removing " << numChans - newChannelCount << " extra channels." << std::endl;
+
         for (int i = newChannelCount; i < numChans; i++)
         {
             removeChildComponent(channels[i]);
@@ -186,11 +191,6 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
                 lfpInfo = new LfpChannelDisplayInfo(canvasSplit, this, options, i);
                 channelInfo.add(lfpInfo);
-
-                drawableChannels.add(LfpChannelTrack{
-                lfpChan,
-                lfpInfo
-                    });
             }
             else {
                 
@@ -201,20 +201,16 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 			lfpChan->setRange(range[options->getChannelType(i)]);
 			lfpChan->setChannelHeight(canvasSplit->getChannelHeight());
 
-            if (!getSingleChannelState())
-
-            {
-                std::cout << "Enabling channel " << i << std::endl;
-                lfpChan->setEnabledState(savedChannelState[i]);
-            }
-                
-
 			lfpInfo->setRange(range[options->getChannelType(i)]);
 			lfpInfo->setChannelHeight(canvasSplit->getChannelHeight());
 			lfpInfo->setSubprocessorIdx(canvasSplit->getChannelSubprocessorIdx(i));
 
             if (!getSingleChannelState())
+            {
+                lfpChan->setEnabledState(savedChannelState[i]);
                 lfpInfo->setEnabledState(savedChannelState[i]);
+            }
+                
 
 			totalHeight += lfpChan->getChannelHeight();
 
@@ -222,6 +218,8 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 	}
 
     numChans = newChannelCount;
+
+    std::cout << "Done setting channels." << std::endl;
 
 }
 
@@ -312,7 +310,7 @@ void LfpDisplay::resized()
     }
     else {
         //std::cout << "Setting view position for single channel " << std::endl;
-        viewport->setViewPosition(juce::Point<int>(0, singleChan * getChannelHeight()));
+        viewport->setViewPosition(0, 0);
     }
        
     if (getWidth() > 0 && getHeight() > 0)
@@ -875,6 +873,7 @@ void LfpDisplay::reactivateChannels()
 
 void LfpDisplay::rebuildDrawableChannelsList()
 {
+    std::cout << "REBUILDING DRAWABLE CHANNELS LIST" << std::endl;
 
     if (getSingleChannelState())
     {
@@ -908,7 +907,7 @@ void LfpDisplay::rebuildDrawableChannelsList()
             }
 
             // update drawableChannels, give only the single channel to focus on
-            drawableChannels.clearQuick();
+            drawableChannels = Array<LfpDisplay::LfpChannelTrack>();
             drawableChannels.add(lfpChannelTrack);
 
             lfpChannelTrack.channel->setEnabledState(true);
@@ -934,6 +933,8 @@ void LfpDisplay::rebuildDrawableChannelsList()
             {
                 canvasSplit->resizeToChannels();
             }
+
+            std::cout << "Finished single channel rebuild" << std::endl;
 
             return;
         }
@@ -1032,6 +1033,8 @@ void LfpDisplay::rebuildDrawableChannelsList()
     }
     
     setColors();
+
+    std::cout << "Finished standard channel rebuild" << std::endl;
 }
 
 LfpBitmapPlotter * const LfpDisplay::getPlotterPtr() const
@@ -1047,6 +1050,11 @@ bool LfpDisplay::getSingleChannelState()
 int LfpDisplay::getSingleChannelShown()
 {
     return singleChan;
+}
+
+void LfpDisplay::setSingleChannelView(int chan)
+{
+    singleChan = chan;
 }
 
 void LfpDisplay::mouseDown(const MouseEvent& event)

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -254,6 +254,9 @@ void LfpDisplay::resized()
 {
     int totalHeight = 0;
 
+    scrollX = viewport->getViewPositionX();
+    scrollY = viewport->getViewPositionY();
+
     //std::cout << "Resizing channels" << std::endl;
     
     for (int i = 0; i < drawableChannels.size(); i++)
@@ -287,8 +290,8 @@ void LfpDisplay::resized()
     
     viewport->setViewPosition(scrollX, scrollY);
 
-    if (singleChan != -1)
-        viewport->setViewPosition(juce::Point<int>(0,singleChan*getChannelHeight()));
+    //if (singleChan != -1)
+    //    viewport->setViewPosition(juce::Point<int>(0,singleChan*getChannelHeight()));
 
     if (getWidth() > 0 && getHeight() > 0)
         lfpChannelBitmap = Image(Image::ARGB, getWidth(), getHeight(), false);

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -392,13 +392,16 @@ void LfpDisplay::refresh()
             gLfpChannelBitmap.fillRect(fillfrom, 0, (fillto - fillfrom) + 1, lfpChannelBitmap.getHeight()); // just clear one section
             //std::cout << "Clearing " << fillfrom << " to " << fillto << std::endl;
         }
-        else {
+        else if (fillfrom > fillto) {
 
             gLfpChannelBitmap.fillRect(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 1, lfpChannelBitmap.getHeight()); // first segment
             gLfpChannelBitmap.fillRect(0, 0, fillto + 1, lfpChannelBitmap.getHeight()); // second segment
 
-           // std::cout << "Clearing " << fillfrom << " to " << lfpChannelBitmap.getWidth() << std::endl;
+            //std::cout << "Clearing " << fillfrom << " to " << lfpChannelBitmap.getWidth() << std::endl;
             //std::cout << "Clearing " << 0 << " to " << fillto << std::endl;
+        }
+        else {
+            ; // no change, do nothing
         }
         
     }

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -833,7 +833,12 @@ void LfpDisplay::mouseWheelMove(const MouseEvent&  e, const MouseWheelDetails&  
         {
             //  passes the event up to the viewport so the screen scrolls
             if (viewport != nullptr && e.eventComponent == this) // passes only if it's not a listening event
+            {
                 viewport->mouseWheelMove(e.getEventRelativeTo(canvasSplit), wheel);
+
+                //canvasSplit->syncDisplayBuffer();
+            }
+                
 
         }
       
@@ -952,6 +957,12 @@ void LfpDisplay::rebuildDrawableChannelsList()
             //std::cout << "Finished single channel rebuild" << std::endl;
 
             return;
+        }
+        else {
+
+            reactivateChannels();
+
+            singleChan = -1; // our channel no longer exists
         }
 
         //std::cout << "Single channel not found." << std::endl;

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -186,7 +186,7 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
             if (i >= numChans)
             {
-                std::cout << "Adding new display for channel " << i << std::endl;
+                //std::cout << "Adding new display for channel " << i << std::endl;
 
                 lfpChan = new LfpChannelDisplay(canvasSplit, this, options, i);
                 addAndMakeVisible(lfpChan);
@@ -225,7 +225,7 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
     setColors();
 
-    std::cout << "TOTAL HEIGHT = " << totalHeight << std::endl;
+    //std::cout << "TOTAL HEIGHT = " << totalHeight << std::endl;
 
 }
 
@@ -281,7 +281,7 @@ void LfpDisplay::resized()
 {
     int totalHeight = 0;
 
-    std::cout << "Resizing channels" << std::endl;
+    //std::cout << "Resizing channels" << std::endl;
     
     for (int i = 0; i < drawableChannels.size(); i++)
     {
@@ -315,10 +315,10 @@ void LfpDisplay::resized()
     if (!getSingleChannelState())
     {
         viewport->setViewPosition(scrollX, scrollY);
-        std::cout << "Setting view position to " << scrollY << std::endl;
+        //std::cout << "Setting view position to " << scrollY << std::endl;
     }
     else {
-        std::cout << "Setting view position for single channel " << std::endl;
+        //std::cout << "Setting view position for single channel " << std::endl;
         viewport->setViewPosition(juce::Point<int>(0, singleChan * getChannelHeight()));
     }
        
@@ -336,7 +336,7 @@ void LfpDisplay::resized()
     
     refresh();
     
-    std::cout << "Total height: " << totalHeight << std::endl;
+    //std::cout << "Total height: " << totalHeight << std::endl;
 
 }
 
@@ -845,7 +845,7 @@ void LfpDisplay::toggleSingleChannel(int chan)
     if (!getSingleChannelState())
     {
         
-        std::cout << "Single channel on (" << chan << ")" << std::endl;
+        //std::cout << "Single channel on (" << chan << ")" << std::endl;
         singleChan = chan;
         
         int newHeight = viewport->getHeight();
@@ -889,7 +889,7 @@ void LfpDisplay::toggleSingleChannel(int chan)
 //    else if (chan == singleChan || chan == -2)
     else
     {
-        std::cout << "Single channel off" << std::endl;
+        //std::cout << "Single channel off" << std::endl;
         
         for (int n = 0; n < numChans; n++)
         {

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -179,14 +179,11 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
             if (i >= numChans)
             {
-                //std::cout << "Adding new display for channel " << i << std::endl;
 
                 lfpChan = new LfpChannelDisplay(canvasSplit, this, options, i);
-                //addAndMakeVisible(lfpChan);
                 channels.add(lfpChan);
 
                 lfpInfo = new LfpChannelDisplayInfo(canvasSplit, this, options, i);
-                //addAndMakeVisible(lfpInfo);
                 channelInfo.add(lfpInfo);
 
                 drawableChannels.add(LfpChannelTrack{
@@ -202,12 +199,16 @@ void LfpDisplay::setNumChannels(int newChannelCount)
             
 			lfpChan->setRange(range[options->getChannelType(i)]);
 			lfpChan->setChannelHeight(canvasSplit->getChannelHeight());
-            lfpChan->setEnabledState(savedChannelState[i]);
+
+            if (!getSingleChannelState())
+                lfpChan->setEnabledState(savedChannelState[i]);
 
 			lfpInfo->setRange(range[options->getChannelType(i)]);
 			lfpInfo->setChannelHeight(canvasSplit->getChannelHeight());
 			lfpInfo->setSubprocessorIdx(canvasSplit->getChannelSubprocessorIdx(i));
-            lfpInfo->setEnabledState(savedChannelState[i]);
+
+            if (!getSingleChannelState())
+                lfpInfo->setEnabledState(savedChannelState[i]);
 
 			totalHeight += lfpChan->getChannelHeight();
 
@@ -289,7 +290,7 @@ void LfpDisplay::resized()
         
         info->setBounds(2,
                         totalHeight-disp->getChannelHeight() + (disp->getChannelOverlap()*canvasSplit->channelOverlapFactor)/4.0,
-                        canvasSplit->leftmargin + 48,
+                        canvasSplit->leftmargin -2,
                         disp->getChannelHeight());
         
         totalHeight += disp->getChannelHeight();
@@ -839,7 +840,8 @@ void LfpDisplay::toggleSingleChannel(int chan)
     if (!getSingleChannelState())
     {
         
-        //std::cout << "Single channel on (" << chan << ")" << std::endl;
+        std::cout << "Single channel on (" << chan << ")" << std::endl;
+
         singleChan = chan;
         
         int newHeight = viewport->getHeight();
@@ -883,12 +885,11 @@ void LfpDisplay::toggleSingleChannel(int chan)
 //    else if (chan == singleChan || chan == -2)
     else
     {
-        //std::cout << "Single channel off" << std::endl;
-        
-        for (int n = 0; n < numChans; n++)
-        {
-            channelInfo[n]->setSingleChannelState(false);
-        }
+        std::cout << "Single channel off" << std::endl;
+
+        channelInfo[singleChan]->setSingleChannelState(false);
+
+        singleChan = -1;
         
         setChannelHeight(cachedDisplayChannelHeight);
 
@@ -1005,9 +1006,12 @@ LfpBitmapPlotter * const LfpDisplay::getPlotterPtr() const
 
 bool LfpDisplay::getSingleChannelState()
 {
-    //if (singleChan < 0) return false;
-    //else return true;
     return singleChan >= 0;
+}
+
+int LfpDisplay::getSingleChannelShown()
+{
+    return singleChan;
 }
 
 void LfpDisplay::mouseDown(const MouseEvent& event)

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -225,11 +225,20 @@ void LfpDisplay::setNumChannels(int newChannelCount)
 
 void LfpDisplay::setColors()
 {
-    for (int i = 0; i < drawableChannels.size(); i++)
+
+    if (!getSingleChannelState())
     {
-        drawableChannels[i].channel->setColour(getColourSchemePtr()->getColourForIndex(i));
-        drawableChannels[i].channelInfo->setColour(getColourSchemePtr()->getColourForIndex(i));
+        for (int i = 0; i < drawableChannels.size(); i++)
+        {
+            drawableChannels[i].channel->setColour(getColourSchemePtr()->getColourForIndex(i));
+            drawableChannels[i].channelInfo->setColour(getColourSchemePtr()->getColourForIndex(i));
+        }
     }
+    else {
+        drawableChannels[0].channel->setColour(getColourSchemePtr()->getColourForIndex(singleChan));
+        drawableChannels[0].channelInfo->setColour(getColourSchemePtr()->getColourForIndex(singleChan));
+    }
+    
 
 }
 
@@ -468,7 +477,7 @@ void LfpDisplay::setChannelHeight(int r, bool resetSingle)
     }
 
 
-    if (resetSingle && singleChan != -1)
+    /*if (resetSingle && singleChan != -1)
     {
         
         setSize(getWidth(), getChannelHeight());
@@ -480,7 +489,8 @@ void LfpDisplay::setChannelHeight(int r, bool resetSingle)
 			channelInfo[n]->setEnabledState(savedChannelState[n]);
         }
     }
-    else if (singleChan == -1) {
+    else*/
+    if (singleChan == -1) {
 
         int overallHeight = drawableChannels.size() * getChannelHeight();
         
@@ -927,6 +937,8 @@ void LfpDisplay::rebuildDrawableChannelsList()
 
             viewport->setViewPosition(0, 0);
 
+            setColors();
+
             // this guards against an exception where the editor sets the drawable samplerate
             // before the lfpDisplay is fully initialized
             if (getHeight() > 0 && getWidth() > 0)
@@ -1054,6 +1066,7 @@ int LfpDisplay::getSingleChannelShown()
 
 void LfpDisplay::setSingleChannelView(int chan)
 {
+    std::cout << "SETTING SINGLE CHANNEL VIWWWWWWEEEE  TI " << chan << std::endl;
     singleChan = chan;
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -390,11 +390,15 @@ void LfpDisplay::refresh()
         if (fillfrom < fillto)
         {
             gLfpChannelBitmap.fillRect(fillfrom, 0, (fillto - fillfrom) + 1, lfpChannelBitmap.getHeight()); // just clear one section
+            //std::cout << "Clearing " << fillfrom << " to " << fillto << std::endl;
         }
         else {
 
-            gLfpChannelBitmap.fillRect(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom, lfpChannelBitmap.getHeight()); // first segment
-            gLfpChannelBitmap.fillRect(0, 0, fillto, lfpChannelBitmap.getHeight()); // second segment
+            gLfpChannelBitmap.fillRect(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 1, lfpChannelBitmap.getHeight()); // first segment
+            gLfpChannelBitmap.fillRect(0, 0, fillto + 1, lfpChannelBitmap.getHeight()); // second segment
+
+           // std::cout << "Clearing " << fillfrom << " to " << lfpChannelBitmap.getWidth() << std::endl;
+            //std::cout << "Clearing " << 0 << " to " << fillto << std::endl;
         }
         
     }
@@ -428,7 +432,16 @@ void LfpDisplay::refresh()
                  // message passing in juce. In any case, this seemingly redundant repaint here seems to fix the issue.
                 
                  // we redraw from 0 to +2 (px) relative to the real redraw window, the +1 draws the vertical update line
-                 channels[i]->repaint(fillfrom, 0, (fillto-fillfrom)+2, channels[i]->getHeight());
+                 if (fillfrom < fillto)
+                 {
+                     channels[i]->repaint(fillfrom, 0, (fillto - fillfrom) + 2, channels[i]->getHeight());
+                 }
+                    
+                 else
+                 {
+                     channels[i]->repaint(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 2, channels[i]->getHeight());
+                     channels[i]->repaint(0, 0, fillto + 2, channels[i]->getHeight());
+                 }
                 
             }
             //std::cout << i << std::endl;

--- a/Plugins/LfpDisplayNode/LfpDisplay.h
+++ b/Plugins/LfpDisplayNode/LfpDisplay.h
@@ -142,6 +142,9 @@ public:
 
     /** Returns true if a single channel is focused in viewport */
     bool getSingleChannelState();
+
+    /** Returns the index of the channel that is focused in viewport */
+    int getSingleChannelShown();
     
     /** Set the viewport's channel focus behavior.
      

--- a/Plugins/LfpDisplayNode/LfpDisplay.h
+++ b/Plugins/LfpDisplayNode/LfpDisplay.h
@@ -64,6 +64,8 @@ public:
 
     void resized();
 
+    void restoreViewPosition();
+
     void reactivateChannels();
 
     void mouseDown(const MouseEvent& event);

--- a/Plugins/LfpDisplayNode/LfpDisplay.h
+++ b/Plugins/LfpDisplayNode/LfpDisplay.h
@@ -146,6 +146,17 @@ public:
     /** Returns the index of the channel that is focused in viewport */
     int getSingleChannelShown();
     
+    /** Convenience struct for holding a channel and its info in drawableChannels */
+    struct LfpChannelTrack
+    {
+        LfpChannelDisplay* channel;
+        LfpChannelDisplayInfo* channelInfo;
+    };
+
+    Array<LfpChannelTrack> drawableChannels;        // holds the channels and info that are
+                                                // drawable to the screen
+
+
     /** Set the viewport's channel focus behavior.
      
         When a single channel is selected, it fills the entire viewport and
@@ -158,7 +169,7 @@ public:
                         Note: this parameter is NOT the index in channel[], but
                         the index of the channel in drawableChannels[].
      */
-    void toggleSingleChannel(int chan = -2);
+    void toggleSingleChannel(LfpChannelTrack drawableChannel);
     
     /** Reconstructs the list of drawableChannels based on ordering and filterning parameters */
     void rebuildDrawableChannelsList();
@@ -173,14 +184,7 @@ public:
     OwnedArray<LfpChannelDisplay> channels;             // all channels
     OwnedArray<LfpChannelDisplayInfo> channelInfo;      // all channelInfos
     
-    /** Convenience struct for holding a channel and its info in drawableChannels */
-    struct LfpChannelTrack
-    {
-        LfpChannelDisplay * channel;
-        LfpChannelDisplayInfo * channelInfo;
-    };
-    Array<LfpChannelTrack> drawableChannels;        // holds the channels and info that are
-                                                    // drawable to the screen
+    
 
     bool eventDisplayEnabled[8];
     bool isPaused; // simple pause function, skips screen buffer updates

--- a/Plugins/LfpDisplayNode/LfpDisplay.h
+++ b/Plugins/LfpDisplayNode/LfpDisplay.h
@@ -145,6 +145,9 @@ public:
 
     /** Returns the index of the channel that is focused in viewport */
     int getSingleChannelShown();
+
+    /** Sets the view to a single channel */
+    void setSingleChannelView(int channel);
     
     /** Convenience struct for holding a channel and its info in drawableChannels */
     struct LfpChannelTrack
@@ -211,10 +214,12 @@ public:
     
     TrackZoomInfo_Struct trackZoomInfo; // and create an instance here
 
+    Array<bool> savedChannelState;
+
 private:
     
     int singleChan;
-	Array<bool> savedChannelState;
+	
 
     int numChans;
     int displaySkipAmt;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -1021,6 +1021,8 @@ void LfpDisplaySplitter::updateSettings()
 
     resized();
 
+    lfpDisplay->restoreViewPosition();
+
    // lfpDisplay->refresh();
 
    // std::cout << " done " << std::endl;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -116,7 +116,11 @@ void LfpDisplayCanvas::resized()
     {
         displaySplits[0]->setVisible(true);
 
-        displaySplits[0]->deselect();
+        
+        displaySplits[0]->deselect(); // to remove boundary
+        displaySplits[0]->options->setVisible(true);
+        displaySplits[1]->options->setVisible(false);
+        displaySplits[2]->options->setVisible(false);
 
         displaySplits[1]->setVisible(false);
         displaySplits[2]->setVisible(false);
@@ -143,6 +147,8 @@ void LfpDisplayCanvas::resized()
 
         if (!displaySplits[1]->getSelectedState())
             displaySplits[0]->select();
+        else
+            displaySplits[1]->select();
         
     }
     else if(selectedLayout == THREE_VERT)

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -806,7 +806,7 @@ void LfpDisplaySplitter::resized()
         //std::cout << "Changing view for display " << splitID << std::endl;
 
         if (lfpDisplay->getSingleChannelState())
-            lfpDisplay->setChannelHeight(viewport->getHeight(),false);
+            lfpDisplay->setChannelHeight(viewport->getHeight(), false);
  
         lfpDisplay->setBounds(0, 0,
             getWidth()-scrollBarThickness, 
@@ -820,15 +820,15 @@ void LfpDisplaySplitter::resized()
     }
 
     subprocessorSelection->setBounds(4, 4, 140, 22);
-
-    
 }
 
 void LfpDisplaySplitter::resizeToChannels(bool respectViewportPosition)
 {
     //std::cout << "Resize to channels " << std::endl;
 
-    lfpDisplay->setBounds(0,0,getWidth()-scrollBarThickness, lfpDisplay->getChannelHeight()*lfpDisplay->drawableChannels.size());
+    lfpDisplay->setBounds(0, 0, 
+        getWidth()-scrollBarThickness, 
+        lfpDisplay->getChannelHeight()*lfpDisplay->drawableChannels.size());
     
     // if param is flagged, move the viewport scroll back to same relative position before
     // resize took place
@@ -949,6 +949,8 @@ void LfpDisplaySplitter::updateSettings()
         }
     }
 
+    std::cout << "DISPLAY SPLIT " << splitID << " UPDATING SETTINGS." << std::endl;
+
     lfpDisplay->setNumChannels(nChans);
 
     for (int i = 0; i < nChans; i++) // update channel metadata
@@ -966,7 +968,7 @@ void LfpDisplaySplitter::updateSettings()
         
     lfpDisplay->rebuildDrawableChannelsList();
 
-    resized();
+    //resized();
 
     isLoading = false;
         
@@ -1087,7 +1089,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                     {
                         
 
-                        const int screenThird = int(maxSamples * ratio / 4);
+                        const int screenThird = int(maxSamples * ratio / 3);
                         const int dispBufLim = displayBufferSize / 2;
 
                         int t0 = triggerTime - std::min(screenThird, dispBufLim);

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -824,7 +824,7 @@ void LfpDisplaySplitter::resized()
 
 void LfpDisplaySplitter::resizeToChannels(bool respectViewportPosition)
 {
-    //std::cout << "Resize to channels " << std::endl;
+    std::cout << "Resize to channels!!!" << std::endl;
 
     lfpDisplay->setBounds(0, 0, 
         getWidth()-scrollBarThickness, 
@@ -968,13 +968,14 @@ void LfpDisplaySplitter::updateSettings()
         
     lfpDisplay->rebuildDrawableChannelsList();
 
-    //resized();
-
     isLoading = false;
         
     syncDisplay();
 
     isUpdating = false;
+
+    std::cout << " done " << std::endl;
+    std::cout << "   " << std::endl;
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -113,6 +113,8 @@ void LfpDisplayCanvas::resized()
     {
         displaySplits[0]->setVisible(true);
 
+        displaySplits[0]->deselect();
+
         displaySplits[1]->setVisible(false);
         displaySplits[2]->setVisible(false);
 
@@ -762,11 +764,11 @@ void LfpDisplaySplitter::resized()
 
     if (canvas->makeRoomForOptions(splitID))
     {
-        viewport->setBounds(0, 30, getWidth(), getHeight() - 90);
+        viewport->setBounds(0, 30, getWidth(), getHeight() - 87);
     }
     else
     {
-        viewport->setBounds(0, 30, getWidth(), getHeight() - 2);
+        viewport->setBounds(0, 30, getWidth(), getHeight() - 32);
     }
        
 
@@ -864,13 +866,13 @@ void LfpDisplaySplitter::updateSettings()
     resizeSamplesPerPixelBuffer(nChans);
     sampleRate = displayBuffer->sampleRate;
 
-    std::cout << "Split canvas sample rate: " << sampleRate << std::endl;
+    //std::cout << "Split canvas sample rate: " << sampleRate << std::endl;
     
     options->setEnabled(nChans != 0);
     // must manually ensure that overlapSelection propagates up to canvas
     channelOverlapFactor = options->selectedOverlapValue.getFloatValue();
 
-    std::cout << "getting sample rate" << std::endl;
+   // std::cout << "getting sample rate" << std::endl;
     int firstChannelInSubprocessor = 0;
 
     if (screenBuffer == nullptr)
@@ -882,7 +884,7 @@ void LfpDisplaySplitter::updateSettings()
 
     }
         
-    std::cout << "updating channels" << std::endl;
+   // std::cout << "updating channels" << std::endl;
 
     if (nChans != lfpDisplay->getNumChannels())
     {
@@ -1387,26 +1389,35 @@ void LfpDisplaySplitter::paint(Graphics& g)
     g.setColour(lfpDisplay->getColourSchemePtr()->getBackgroundColour()); //background color
     g.fillRect(0, 0, getWidth(), getHeight());
 
+    Colour borderColour;
+    ColourGradient timelineColour;
+
     if (isSelected)
     {
-        g.setColour(Colour(252, 210, 0));
-        g.drawRect(0, 0, getWidth(), getHeight(), 2);
+        borderColour = Colour(252, 210, 0);
 
-        g.setGradientFill(ColourGradient(Colour(252, 210, 0), 0, 0,
+        timelineColour = ColourGradient(Colour(252, 210, 0), 0, 0,
             Colour(173, 145, 3), 0, 30,
-            false));
+            false);
     }
     else {
 
-        g.setColour(Colour(50, 50, 50));
-        g.drawRect(0, 0, getWidth(), getHeight(), 2);
+        borderColour = Colour(40, 40, 40);
 
-        g.setGradientFill(ColourGradient(Colour(50, 50, 50), 0, 0,
+        timelineColour = ColourGradient(Colour(50, 50, 50), 0, 0,
             Colour(25, 25, 25), 0, 30,
-            false));
+            false);
     }
+
+    g.setColour(borderColour);
+
+    if (!canvas->makeRoomForOptions(splitID))
+        g.drawRect(0, 0, getWidth(), getHeight(), 2);
+    else
+        g.drawRect(0, 0, getWidth(), getHeight() - 55, 2);
     
-     g.fillRect(2, 2, getWidth()-4, 28);
+    g.setGradientFill(timelineColour);
+    g.fillRect(2, 2, getWidth()-4, 28);
 
   //  g.setColour(Colours::black);
 
@@ -1444,7 +1455,7 @@ void LfpDisplaySplitter::comboBoxChanged(juce::ComboBox *comboBox)
 {
     if (comboBox == subprocessorSelection)
     {
-        std::cout << "Setting subprocessor for Display #"<< splitID << " to " << comboBox->getSelectedId() << std::endl;
+        //std::cout << "Setting subprocessor for Display #"<< splitID << " to " << comboBox->getSelectedId() << std::endl;
         //uint32 subproc = processor->inputSubprocessors[cb->getSelectedId() - 1];
 
         //processor->setSubprocessor(subproc, splitID);

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -880,7 +880,7 @@ void LfpDisplaySplitter::beginAnimation()
 
     }    
 
-    startTimer(33);
+    startTimer(20);
 
     reachedEnd = true;
 }
@@ -1411,16 +1411,29 @@ void LfpDisplaySplitter::updateScreenBuffer()
 
                                 float sample_current = displayBuffer->getSample(channel, dbi);
 
-                                sample_sum = sample_sum + sample_current;
-
-                                if (sample_min >= sample_current)
+                                if (dbi < newDisplayBufferIndex)
                                 {
-                                    sample_min = sample_current;
+                                    
+
+                                    sample_sum = sample_sum + sample_current;
+
+                                    if (sample_min >= sample_current)
+                                    {
+                                        sample_min = sample_current;
+                                    }
+
+                                    if (sample_max <= sample_current)
+                                    {
+                                        sample_max = sample_current;
+                                    }
                                 }
+                                else {
 
-                                if (sample_max <= sample_current)
-                                {
-                                    sample_max = sample_current;
+                                    if (sample_min == 10000000)
+                                        sample_min = sample_current;
+
+                                    if (sample_max == -10000000)
+                                        sample_max = sample_current;
                                 }
 
                                 subSampleOffset -= 1.0f;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -722,7 +722,7 @@ LfpDisplaySplitter::LfpDisplaySplitter(LfpDisplayNode* node,
 
     scrollBarThickness = viewport->getScrollBarThickness();
 
-    isChannelEnabled.insertMultiple(0, true, 10000); // max 10k channels
+    //isChannelEnabled.insertMultiple(0, true, 10000); // max 10k channels
 
     addAndMakeVisible(viewport);
     addAndMakeVisible(timescale);
@@ -850,6 +850,8 @@ void LfpDisplaySplitter::updateSettings()
     nChans = displayBuffer->numChannels;
     resizeSamplesPerPixelBuffer(nChans);
     sampleRate = displayBuffer->sampleRate;
+
+    std::cout << "Split canvas sample rate: " << sampleRate << std::endl;
     
     options->setEnabled(nChans != 0);
     // must manually ensure that overlapSelection propagates up to canvas
@@ -877,27 +879,37 @@ void LfpDisplaySplitter::updateSettings()
         screenBufferMax->setSize(nChans + 1, MAX_N_SAMP);
 
         refreshScreenBuffer();
-
-        if (nChans > 0)
-            lfpDisplay->setNumChannels(nChans);
-
-        for (int i = 0; i < nChans; i++)
-        {
-            lfpDisplay->channelInfo[i]->setName(displayBuffer->channelMetadata[i].name);
-            lfpDisplay->channelInfo[i]->setGroup(displayBuffer->channelMetadata[i].group);
-            lfpDisplay->channelInfo[i]->setDepth(displayBuffer->channelMetadata[i].ypos);
-            lfpDisplay->setEnabledState(isChannelEnabled[i], i);
-        }
-        
-        if (nChans == 0) 
-            lfpDisplay->setBounds(0, 0, getWidth(), getHeight());
-        else {
-            lfpDisplay->rebuildDrawableChannelsList();
-            lfpDisplay->setBounds(0, 0, getWidth()-scrollBarThickness*2, lfpDisplay->getTotalHeight());
-        }
-        
-        resized();
     }
+
+    if (nChans > 0)
+        lfpDisplay->setNumChannels(nChans);
+
+    for (int i = 0; i < nChans; i++)
+    {
+        lfpDisplay->channelInfo[i]->setName(displayBuffer->channelMetadata[i].name);
+        lfpDisplay->channelInfo[i]->setGroup(displayBuffer->channelMetadata[i].group);
+        lfpDisplay->channelInfo[i]->setDepth(displayBuffer->channelMetadata[i].ypos);
+        //lfpDisplay->setEnabledState(isChannelEnabled[i], i);
+
+       // if (isChannelEnabled[i])
+        //{
+       //     std::cout << "CH" << i << " enabled." << std::endl;
+
+       // }
+       // else {
+       //     std::cout << "CH" << i << " DISABLED." << std::endl;
+      //  }
+    }
+        
+    if (nChans == 0) 
+        lfpDisplay->setBounds(0, 0, getWidth(), getHeight());
+    else {
+        lfpDisplay->rebuildDrawableChannelsList();
+        lfpDisplay->setBounds(0, 0, getWidth()-scrollBarThickness*2, lfpDisplay->getTotalHeight());
+    }
+        
+    resized();
+  /*  }
     else
     {
         for (int i = 0; i < nChans; i++)
@@ -914,7 +926,7 @@ void LfpDisplaySplitter::updateSettings()
         {
             lfpDisplay->rebuildDrawableChannelsList();
         }
-    }
+    }*/
 
     syncDisplay();
 }

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -945,6 +945,7 @@ void LfpDisplaySplitter::updateSettings()
     }
         
     lfpDisplay->rebuildDrawableChannelsList();
+
     lfpDisplay->setBounds(0, 0, getWidth()-scrollBarThickness*2, lfpDisplay->getTotalHeight());
 
     isLoading = false;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -583,7 +583,14 @@ void LfpDisplayCanvas::mouseUp(const MouseEvent& e)
 void LfpDisplayCanvas::toggleOptionsDrawer(bool isOpen)
 {
     optionsDrawerIsOpen = isOpen;
-    resized();
+    
+    for (int i = 0; i < 3; i++)
+    {
+        if (optionsDrawerIsOpen)
+            displaySplits[i]->options->setBounds(0, getHeight() - 200, getWidth(), 200);
+        else
+            displaySplits[i]->options->setBounds(0, getHeight() - 55, getWidth(), 55);
+    }
 }
 
 int LfpDisplayCanvas::getTotalSplits()
@@ -944,10 +951,7 @@ void LfpDisplaySplitter::updateSettings()
         
     resized();
 
-    for (int i = 0; i <= nChans; i++)
-    {
-        displayBufferIndex.set(i, displayBuffer->displayBufferIndices[i]);
-    }
+    
 
     syncDisplay();
 
@@ -970,7 +974,7 @@ void LfpDisplaySplitter::setAveraging(bool avg)
 {
     if (trialAveraging == false)
     {
-        numTrials = 0;
+        numTrials = -1;
     }
 
     trialAveraging = avg;
@@ -1025,7 +1029,12 @@ void LfpDisplaySplitter::syncDisplay()
     for (int channel = 0; channel <= nChans; channel++)
     {
         screenBufferIndex.set(channel, 0);
+
+        if (displayBuffer != nullptr)
+            displayBufferIndex.set(channel, displayBuffer->displayBufferIndices[channel]);
     }
+
+
 }
 
 void LfpDisplaySplitter::updateScreenBuffer()
@@ -1277,6 +1286,18 @@ void LfpDisplaySplitter::updateScreenBuffer()
         }
     }
 
+}
+
+void LfpDisplaySplitter::setTimebase(float t)
+{
+    timebase = t;
+
+    if (trialAveraging)
+    {
+        numTrials = -1;
+    }
+
+    syncDisplay();
 }
 
 const float LfpDisplaySplitter::getXCoord(int chan, int samp)

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -626,6 +626,19 @@ void LfpDisplayCanvas::refresh()
     }
 }
 
+void LfpDisplayCanvas::redrawAll()
+{
+    for (auto split : displaySplits)
+    {
+        if (split->isVisible())
+        {
+           // split->fullredraw = true;
+           // split->syncDisplayBuffer();
+        }
+            
+    }
+}
+
 void LfpDisplayCanvas::comboBoxChanged(ComboBox* cb)
 {
     if(cb == displaySelection)
@@ -1050,11 +1063,23 @@ void LfpDisplaySplitter::syncDisplay()
     {
         screenBufferIndex.set(channel, 0);
 
-        if (displayBuffer != nullptr)
-            displayBufferIndex.set(channel, displayBuffer->displayBufferIndices[channel]);
     }
 
+    syncDisplayBuffer();
 
+}
+
+void LfpDisplaySplitter::syncDisplayBuffer()
+{
+    // std::cout << "Synchronizing display " << splitID << std::endl;
+
+    if (displayBuffer == nullptr)
+        return;
+
+    for (int channel = 0; channel <= nChans; channel++)
+    {
+        displayBufferIndex.set(channel, displayBuffer->displayBufferIndices[channel]);
+    }
 }
 
 void LfpDisplaySplitter::updateScreenBuffer()
@@ -1131,6 +1156,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                 ScopedLock displayLock(*displayBuffer->getMutex());
                 index = displayBuffer->displayBufferIndices[channel]; // get the latest value from the display buffer
             }
+            
 
             int nSamples = index - dbi; // N new samples (not pixels) to be added to displayBufferIndex
 
@@ -1151,7 +1177,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
             }
             float subSampleOffset = 0.0;
 
-           /* if (channel == 0 || channel == 1 || channel == 2)
+            /*if (channel == 15 && splitID == 2)
                 std::cout << "Channel "
                 << channel << " : "
                 << sbi << " : "
@@ -1304,7 +1330,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
 
                 // update values after we're done
                 screenBufferIndex.set(channel, sbi);
-                displayBufferIndex.set(channel, dbi); // need to store this locally
+                displayBufferIndex.set(channel, index); // need to store this locally
 
                
             }
@@ -1508,6 +1534,16 @@ void LfpDisplaySplitter::paint(Graphics& g)
     g.drawLine(0,getHeight()-60,getWidth(),getHeight()-60,3.0f);
     */
 
+}
+
+void LfpDisplaySplitter::visibleAreaChanged()
+{
+
+    canvas->redrawAll();
+
+    fullredraw = true;
+
+    refresh();
 }
 
 void LfpDisplaySplitter::refresh()

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -782,15 +782,17 @@ LfpDisplaySplitter::~LfpDisplaySplitter()
 void LfpDisplaySplitter::resized()
 {
 
-    timescale->setBounds(leftmargin,0,getWidth()-scrollBarThickness-leftmargin,30);
+    const int timescaleHeight = 30;
+
+    timescale->setBounds(leftmargin, 0, getWidth()-scrollBarThickness, timescaleHeight);
 
     if (canvas->makeRoomForOptions(splitID))
     {
-        viewport->setBounds(0, 30, getWidth(), getHeight() - 87);
+        viewport->setBounds(0, timescaleHeight, getWidth(), getHeight() - 87);
     }
     else
     {
-        viewport->setBounds(0, 30, getWidth(), getHeight() - 32);
+        viewport->setBounds(0, timescaleHeight, getWidth(), getHeight() - 32);
     }
 
     if (screenBuffer != nullptr)
@@ -806,7 +808,7 @@ void LfpDisplaySplitter::resized()
         if (lfpDisplay->getSingleChannelState())
             lfpDisplay->setChannelHeight(viewport->getHeight(),false);
  
-        lfpDisplay->setBounds(leftmargin,0,
+        lfpDisplay->setBounds(0, 0,
             getWidth()-scrollBarThickness, 
             lfpDisplay->getChannelHeight()*lfpDisplay->drawableChannels.size());
 
@@ -814,7 +816,7 @@ void LfpDisplaySplitter::resized()
     }
     else
     {
-        lfpDisplay->setBounds(leftmargin, 0, getWidth(), getHeight());
+        lfpDisplay->setBounds(0, 0, getWidth(), getHeight());
     }
 
     subprocessorSelection->setBounds(4, 4, 140, 22);
@@ -947,7 +949,6 @@ void LfpDisplaySplitter::updateSettings()
         }
     }
 
-        
     lfpDisplay->setNumChannels(nChans);
 
     for (int i = 0; i < nChans; i++) // update channel metadata
@@ -965,7 +966,7 @@ void LfpDisplaySplitter::updateSettings()
         
     lfpDisplay->rebuildDrawableChannelsList();
 
-    lfpDisplay->setBounds(0, 0, getWidth()-scrollBarThickness*2, lfpDisplay->getTotalHeight());
+    resized();
 
     isLoading = false;
         
@@ -1058,9 +1059,9 @@ void LfpDisplaySplitter::updateScreenBuffer()
     if (isVisible() && displayBuffer != nullptr && !isUpdating)
     {
         // copy new samples from the displayBuffer into the screenBuffer
-        int maxSamples = lfpDisplay->getWidth() - leftmargin;
+        int maxSamples = lfpDisplay->getWidth() - leftmargin; // leftmargin accounts for the fact that the display doesn't start
+                                                              // at the leftmost pixel
 
-        
         int triggerTime = triggerChannel >=0 
                           ? processor->getLatestTriggerTime(splitID)
                           : -1;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -933,10 +933,10 @@ void LfpDisplaySplitter::updateSettings()
     
     if (screenBuffer == nullptr) // not yet initialized
     {
-        screenBuffer = new AudioSampleBuffer(nChans + 1, MAX_N_SAMP);
-        screenBufferMin = new AudioSampleBuffer(nChans + 1, MAX_N_SAMP);
-        screenBufferMean = new AudioSampleBuffer(nChans + 1, MAX_N_SAMP);
-        screenBufferMax = new AudioSampleBuffer(nChans + 1, MAX_N_SAMP);
+        screenBuffer = new AudioSampleBuffer(nChans + 1, getWidth());
+        screenBufferMin = new AudioSampleBuffer(nChans + 1, getWidth());
+        screenBufferMean = new AudioSampleBuffer(nChans + 1, getWidth());
+        screenBufferMax = new AudioSampleBuffer(nChans + 1, getWidth());
     }
     else {
         if (nChans != lfpDisplay->getNumChannels()) // new channel count

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -902,16 +902,6 @@ void LfpDisplaySplitter::updateSettings()
         lfpDisplay->channelInfo[i]->setName(displayBuffer->channelMetadata[i].name);
         lfpDisplay->channelInfo[i]->setGroup(displayBuffer->channelMetadata[i].group);
         lfpDisplay->channelInfo[i]->setDepth(displayBuffer->channelMetadata[i].ypos);
-        //lfpDisplay->setEnabledState(isChannelEnabled[i], i);
-
-       // if (isChannelEnabled[i])
-        //{
-       //     std::cout << "CH" << i << " enabled." << std::endl;
-
-       // }
-       // else {
-       //     std::cout << "CH" << i << " DISABLED." << std::endl;
-      //  }
     }
         
     if (nChans == 0) 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -772,7 +772,7 @@ void LfpDisplaySplitter::resized()
 
     if (nChans > 0)
     {
-        std::cout << "Changing view for display " << splitID << std::endl;
+        //std::cout << "Changing view for display " << splitID << std::endl;
 
         if (lfpDisplay->getSingleChannelState())
             lfpDisplay->setChannelHeight(viewport->getHeight(),false);
@@ -793,7 +793,7 @@ void LfpDisplaySplitter::resized()
 
 void LfpDisplaySplitter::resizeToChannels(bool respectViewportPosition)
 {
-    std::cout << "Resize to channels " << std::endl;
+    //std::cout << "Resize to channels " << std::endl;
 
     lfpDisplay->setBounds(0,0,getWidth()-scrollBarThickness, lfpDisplay->getChannelHeight()*lfpDisplay->drawableChannels.size());
     
@@ -1446,7 +1446,7 @@ void LfpDisplaySplitter::refresh()
     { 
        updateScreenBuffer();
 
-       lfpDisplay->refresh(); // redraws only the new part of the screen buffer
+       lfpDisplay->refresh(); // redraws only the new part of the screen buffer, unless fullredraw is set to true
     }
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -273,7 +273,7 @@ void LfpDisplayCanvas::update()
 
     for (auto split : displaySplits)
     {
-        //split->setInputSubprocessors();
+        //if (split->isVisible())
         split->updateSettings();
     }
 
@@ -321,6 +321,8 @@ void LfpDisplayCanvas::setLayout(SplitLayouts sl)
     selectedLayout = sl;
 
     resized();
+
+    //update();
 }
 
 bool LfpDisplayCanvas::makeRoomForOptions(int splitID)
@@ -794,8 +796,11 @@ void LfpDisplaySplitter::resized()
         viewport->setBounds(0, 30, getWidth(), getHeight() - 32);
     }
 
-    if (screenBuffer->getNumSamples() < getWidth())
-        refreshScreenBuffer();
+    if (screenBuffer != nullptr)
+    {
+        if (screenBuffer->getNumSamples() < getWidth())
+            refreshScreenBuffer();
+    }
        
     if (nChans > 0)
     {

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -273,7 +273,6 @@ void LfpDisplayCanvas::update()
 
     for (auto split : displaySplits)
     {
-        //if (split->isVisible())
         split->updateSettings();
     }
 
@@ -321,8 +320,6 @@ void LfpDisplayCanvas::setLayout(SplitLayouts sl)
     selectedLayout = sl;
 
     resized();
-
-    //update();
 }
 
 bool LfpDisplayCanvas::makeRoomForOptions(int splitID)
@@ -809,7 +806,7 @@ void LfpDisplaySplitter::resized()
         if (lfpDisplay->getSingleChannelState())
             lfpDisplay->setChannelHeight(viewport->getHeight(),false);
  
-        lfpDisplay->setBounds(0,0,
+        lfpDisplay->setBounds(leftmargin,0,
             getWidth()-scrollBarThickness, 
             lfpDisplay->getChannelHeight()*lfpDisplay->drawableChannels.size());
 
@@ -817,7 +814,7 @@ void LfpDisplaySplitter::resized()
     }
     else
     {
-        lfpDisplay->setBounds(0, 0, getWidth(), getHeight());
+        lfpDisplay->setBounds(leftmargin, 0, getWidth(), getHeight());
     }
 
     subprocessorSelection->setBounds(4, 4, 140, 22);
@@ -949,6 +946,7 @@ void LfpDisplaySplitter::updateSettings()
             refreshScreenBuffer();
         }
     }
+
         
     lfpDisplay->setNumChannels(nChans);
 
@@ -971,10 +969,6 @@ void LfpDisplaySplitter::updateSettings()
 
     isLoading = false;
         
-    resized();
-
-    
-
     syncDisplay();
 
     isUpdating = false;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -824,7 +824,7 @@ void LfpDisplaySplitter::resized()
 
 void LfpDisplaySplitter::resizeToChannels(bool respectViewportPosition)
 {
-    std::cout << "Resize to channels!!!" << std::endl;
+    //std::cout << "Resize to channels!!!" << std::endl;
 
     lfpDisplay->setBounds(0, 0, 
         getWidth()-scrollBarThickness, 
@@ -949,7 +949,7 @@ void LfpDisplaySplitter::updateSettings()
         }
     }
 
-    std::cout << "DISPLAY SPLIT " << splitID << " UPDATING SETTINGS." << std::endl;
+   // std::cout << "DISPLAY SPLIT " << splitID << " UPDATING SETTINGS." << std::endl;
 
     lfpDisplay->setNumChannels(nChans);
 
@@ -974,8 +974,8 @@ void LfpDisplaySplitter::updateSettings()
 
     isUpdating = false;
 
-    std::cout << " done " << std::endl;
-    std::cout << "   " << std::endl;
+   // std::cout << " done " << std::endl;
+   // std::cout << "   " << std::endl;
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -210,6 +210,8 @@ public:
     static const int leftmargin = 50; // left margin for lfp plots (so the ch number text doesnt overlap)
 
     Array<bool> isChannelEnabled;
+
+    bool isLoading;
     
     bool  drawClipWarning; // optinally draw (subtle) warning if data is clipped in display
     bool  drawSaturationWarning; // optionally raise hell if the actual data is saturating

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -205,6 +205,7 @@ public:
 
     Array<int> screenBufferIndex;
     Array<int> lastScreenBufferIndex;
+    Array<float> leftOverSamples;
 
     //void scrollBarMoved(ScrollBar *scrollBarThatHasMoved, double newRangeStart);
 
@@ -280,7 +281,8 @@ private:
 
 	uint32 subprocessorId;
 	float displayedSampleRate;
-    
+
+    int samplesPerBufferPass;
     
     ScopedPointer<AudioSampleBuffer> screenBuffer; // subsampled buffer- one int per pixel
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -255,6 +255,7 @@ public:
 private:
 
     bool isSelected;
+    bool isUpdating;
 
     LfpDisplayNode* processor;
     LfpDisplayCanvas* canvas;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -97,6 +97,8 @@ public:
 
     bool optionsDrawerIsOpen;
 
+    void redrawAll();
+
     void select(LfpDisplaySplitter*);
 
     void mouseMove(const MouseEvent&) override;
@@ -226,6 +228,10 @@ public:
     void redraw();
 
     void syncDisplay();
+
+    void syncDisplayBuffer();
+
+    void visibleAreaChanged();
 
     void select();
     void deselect();

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -282,6 +282,7 @@ private:
     float timeOffset;
 
     int triggerChannel;
+    bool reachedEnd;
 
 	uint32 subprocessorId;
 	float displayedSampleRate;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -129,7 +129,8 @@ private:
 
 
 class LfpDisplaySplitter : public Component,
-                           public ComboBoxListener
+                           public ComboBoxListener,
+                           public Timer
 {
 public:
     LfpDisplaySplitter(LfpDisplayNode* node, LfpDisplayCanvas* canvas, DisplayBuffer* displayBuffer, int id);
@@ -138,6 +139,7 @@ public:
     void paint(Graphics& g);
 
     void beginAnimation();
+    void endAnimation();
 
         /** Resizes the LfpDisplay to the size required to fit all channels that are being
         drawn to the screen.
@@ -260,6 +262,8 @@ public:
     void setTimebase(float timebase);
 
     DisplayBuffer* displayBuffer; // sample wise data buffer for display
+
+    void timerCallback();
 
 private:
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -250,6 +250,8 @@ public:
     void setAveraging(bool);
     void resetTrials();
 
+    void setTimebase(float timebase);
+
     DisplayBuffer* displayBuffer; // sample wise data buffer for display
 
 private:

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -207,7 +207,7 @@ public:
     //void scrollBarMoved(ScrollBar *scrollBarThatHasMoved, double newRangeStart);
 
     bool fullredraw; // used to indicate that a full redraw is required. is set false after each full redraw, there is a similar switch for each display;
-    static const int leftmargin = 50; // left margin for lfp plots (so the ch number text doesnt overlap)
+    static const int leftmargin = 60; // left margin for lfp plots (so the ch number text doesnt overlap)
 
     Array<bool> isChannelEnabled;
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -191,8 +191,8 @@ public:
     const float getXCoord(int chan, int samp);
     const float getYCoord(int chan, int samp);
     
-    std::array<float, MAX_N_SAMP_PER_PIXEL> getSamplesPerPixel(int chan, int px);
-    const int getSampleCountPerPixel(int px);
+    //std::array<float, MAX_N_SAMP_PER_PIXEL> getSamplesPerPixel(int chan, int px);
+    //const int getSampleCountPerPixel(int px);
     
     const float getYCoordMin(int chan, int samp);
     const float getYCoordMean(int chan, int samp);
@@ -294,10 +294,10 @@ private:
 
     int scrollBarThickness;
 
-	void resizeSamplesPerPixelBuffer(int numChannels);
-    std::vector<std::array<std::array<float, MAX_N_SAMP_PER_PIXEL>, MAX_N_SAMP>> samplesPerPixel;
+	//void resizeSamplesPerPixelBuffer(int numChannels);
+    //std::vector<std::array<std::array<float, MAX_N_SAMP_PER_PIXEL>, MAX_N_SAMP>> samplesPerPixel;
 
-    int sampleCountPerPixel[MAX_N_SAMP];
+    //Array<int> sampleCountPerPixel;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(LfpDisplaySplitter);
 

--- a/Plugins/LfpDisplayNode/LfpDisplayClasses.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayClasses.h
@@ -4,7 +4,6 @@
 
 namespace LfpViewer {
     constexpr int MAX_N_CHAN = 16;
-    constexpr int MAX_N_SAMP = 5000; // used for screen buffer; this could be resized dynamically depending on the display width
     constexpr int MAX_N_SAMP_PER_PIXEL = 100;
     constexpr int CHANNEL_TYPES = 3;
     enum SplitLayouts {SINGLE = 1, TWO_VERT, THREE_VERT, TWO_HORZ, THREE_HORZ};

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -74,10 +74,15 @@ void LfpDisplayNode::updateSettings()
         if (displayBufferMap.count(id) == 0)
         {
             String name = getSubprocessorName(ch);
+
+            
             displayBuffers.add(new DisplayBuffer(id, name, getDataChannel(ch)->getSampleRate()));
             displayBufferMap[id] = displayBuffers.getLast();
 
             // also add channel positions
+        }
+        else {
+            displayBufferMap[id]->sampleRate = getDataChannel(ch)->getSampleRate();
         }
 
         int depthId = getDataChannel(ch)->findMetaData(MetaDataDescriptor::FLOAT, 1, "depth-value");

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -309,7 +309,7 @@ void LfpDisplayNode::finalizeEventChannels()
         if (latestTrigger[i] == -1 && latestCurrentTrigger[i] > -1) // received a trigger, but not yet acknowledged
         {
             int triggerSample = latestCurrentTrigger[i] + splitDisplays[i]->displayBuffer->displayBufferIndices.getLast();
-            //std::cout << "Setting latest trigger to " << triggerSample << std::endl;
+            std::cout << "Setting latest trigger to " << triggerSample << std::endl;
             latestTrigger.set(i, triggerSample);
         }
     }
@@ -358,5 +358,5 @@ int64 LfpDisplayNode::getLatestTriggerTime(int id) const
 void LfpDisplayNode::acknowledgeTrigger(int id)
 {
   latestTrigger.set(id, -1);
-  //std::cout << "Display " << id << " acknowledging trigger." << std::endl;
+  std::cout << "Display " << id << " acknowledging trigger." << std::endl;
 }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -104,22 +104,29 @@ void LfpDisplayNode::updateSettings()
 
         displayBufferMap[id]->addChannel(getDataChannel(ch)->getName(), ch, channelGroup, channelDepth);
     }
+
+    Array<DisplayBuffer*> toDelete;
     
     for (auto displayBuffer : displayBuffers)
     {
+
         if (displayBuffer->isNeeded)
         {
             displayBuffer->update();
-            //std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
+            std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
         }
         else {
 
-            //std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
+            std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
             displayBufferMap.erase(displayBuffer->id);
-            displayBuffers.removeObject(displayBuffer, true);
-            displayBuffer = nullptr;
-
+            toDelete.add(displayBuffer);
         }
+        
+    }
+
+    for (auto displayBuffer : toDelete)
+    {
+        displayBuffers.removeObject(displayBuffer, true);
     }
 
     //std::cout << "Total display buffers: " << displayBuffers.size() << std::endl;

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -107,9 +107,22 @@ void LfpDisplayNode::updateSettings()
     
     for (auto displayBuffer : displayBuffers)
     {
-        displayBuffer->update();
+        if (displayBuffer->isNeeded)
+        {
+            displayBuffer->update();
+            std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
+        }
+        else {
+
+            std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
+            displayBufferMap.erase(displayBuffer->id);
+            displayBuffers.removeObject(displayBuffer, true);
+            displayBuffer = nullptr;
+
+        }
     }
 
+    std::cout << "Total display buffers: " << displayBuffers.size() << std::endl;
 
     // TODO: add event channels separately, as they may have a different source
 }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -110,11 +110,11 @@ void LfpDisplayNode::updateSettings()
         if (displayBuffer->isNeeded)
         {
             displayBuffer->update();
-            std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
+            //std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
         }
         else {
 
-            std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
+            //std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
             displayBufferMap.erase(displayBuffer->id);
             displayBuffers.removeObject(displayBuffer, true);
             displayBuffer = nullptr;
@@ -122,7 +122,7 @@ void LfpDisplayNode::updateSettings()
         }
     }
 
-    std::cout << "Total display buffers: " << displayBuffers.size() << std::endl;
+    //std::cout << "Total display buffers: " << displayBuffers.size() << std::endl;
 
     // TODO: add event channels separately, as they may have a different source
 }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -113,11 +113,11 @@ void LfpDisplayNode::updateSettings()
         if (displayBuffer->isNeeded)
         {
             displayBuffer->update();
-            std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
+            //std::cout << "Updating displayBuffer with id " << displayBuffer->id << std::endl;
         }
         else {
 
-            std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
+            //std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
             displayBufferMap.erase(displayBuffer->id);
             toDelete.add(displayBuffer);
         }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -79,7 +79,6 @@ void LfpDisplayNode::updateSettings()
             displayBuffers.add(new DisplayBuffer(id, name, getDataChannel(ch)->getSampleRate()));
             displayBufferMap[id] = displayBuffers.getLast();
 
-            // also add channel positions
         }
         else {
             displayBufferMap[id]->sampleRate = getDataChannel(ch)->getSampleRate();

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -60,7 +60,7 @@ AudioProcessorEditor* LfpDisplayNode::createEditor()
 void LfpDisplayNode::updateSettings()
 {
 
-    std::cout << "Setting num inputs on LfpDisplayNode to " << getNumInputs() << std::endl;
+    //std::cout << "Setting num inputs on LfpDisplayNode to " << getNumInputs() << std::endl;
 
     for (auto displayBuffer : displayBuffers)
     {
@@ -149,7 +149,7 @@ String LfpDisplayNode::getSubprocessorName(int channel)
 
             name = ch->getSourceName() + " " + stringValue;
 
-            std::cout << "Sb name: " << name << std::endl;
+           // std::cout << "Sb name: " << name << std::endl;
         }
         else {
 

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -881,83 +881,141 @@ void LfpDisplayOptions::togglePauseButton(bool sendUpdate)
     pauseButton->setToggleState(!pauseButton->getToggleState(), sendUpdate ? sendNotification : dontSendNotification);
 }
 
+void LfpDisplayOptions::setChannelsReversed(bool state)
+{
+    lfpDisplay->setChannelsReversed(state);
+
+    reverseChannelsDisplayButton->setToggleState(state, dontSendNotification);
+
+    if (state)
+    {
+        reverseChannelsDisplayButton->setLabel("ON");
+    }
+    else {
+        reverseChannelsDisplayButton->setLabel("OFF");
+    }
+}
+
+void LfpDisplayOptions::setInputInverted(bool state)
+{
+    lfpDisplay->setInputInverted(state);
+
+    invertInputButton->setToggleState(state, dontSendNotification);
+
+    if (state)
+    {
+        invertInputButton->setLabel("ON");
+    }
+    else {
+        invertInputButton->setLabel("OFF");
+    }
+
+}
+
+void LfpDisplayOptions::setMedianOffset(bool state)
+{
+    if (lfpDisplay->getSpikeRasterPlotting())
+    {
+        medianOffsetPlottingButton->setToggleState(true, dontSendNotification);
+        medianOffsetPlottingButton->setLabel("ON");
+        return;
+    }
+    else
+    {
+        lfpDisplay->setMedianOffsetPlotting(state);
+        medianOffsetPlottingButton->setToggleState(state, dontSendNotification);
+    }
+
+
+    if (state)
+    {
+        medianOffsetPlottingButton->setLabel("ON");
+    }
+    else {
+        medianOffsetPlottingButton->setLabel("OFF");
+    }
+}
+
+void LfpDisplayOptions::setAveraging(bool state)
+{
+    canvasSplit->setAveraging(state);
+
+    averageSignalButton->setToggleState(state, dontSendNotification);
+
+    if (state)
+    {
+        averageSignalButton->setLabel("ON");
+        resetButton->setVisible(true);
+    }
+    else {
+        averageSignalButton->setLabel("OFF");
+        resetButton->setVisible(false);
+    }
+}
+
+void LfpDisplayOptions::setSortByDepth(bool state)
+{
+    lfpDisplay->orderChannelsByDepth(state);
+
+    sortByDepthButton->setToggleState(state, dontSendNotification);
+
+    if (state)
+    {
+        sortByDepthButton->setLabel("ON");
+    }
+    else {
+        sortByDepthButton->setLabel("OFF");
+    }
+}
+
+void LfpDisplayOptions::setShowChannelNumbers(bool state)
+{
+
+    showChannelNumberButton->setToggleState(state, dontSendNotification);
+
+    int numChannels = lfpDisplay->channelInfo.size();
+
+    for (int i = 0; i < numChannels; ++i)
+    {
+        lfpDisplay->channelInfo[i]->repaint();
+    }
+
+    if (state)
+    {
+        showChannelNumberButton->setLabel("ON");
+    }
+    else {
+        showChannelNumberButton->setLabel("OFF");
+    }
+}
+
 void LfpDisplayOptions::buttonClicked(Button* b)
 {
     if (b == invertInputButton)
     {
-        lfpDisplay->setInputInverted(b->getToggleState());
-        
-        if (b->getToggleState())
-        {
-            invertInputButton->setLabel("ON");
-        }
-        else {
-            invertInputButton->setLabel("OFF");
-        }
+        setInputInverted(b->getToggleState());
         return;
     }
     if (b == reverseChannelsDisplayButton)
     {
-        lfpDisplay->setChannelsReversed(b->getToggleState());
-        
-        if (b->getToggleState())
-        {
-            reverseChannelsDisplayButton->setLabel("ON");
-        }
-        else {
-            reverseChannelsDisplayButton->setLabel("OFF");
-        }
+        setChannelsReversed(b->getToggleState());
         return;
     }
     if (b == medianOffsetPlottingButton)
     {
-        if (lfpDisplay->getSpikeRasterPlotting())
-        {
-            medianOffsetPlottingButton->setToggleState(true, dontSendNotification);
-        }
-        else
-        {
-            lfpDisplay->setMedianOffsetPlotting(b->getToggleState());
-        }
-
-        if (b->getToggleState())
-        {
-            medianOffsetPlottingButton->setLabel("ON");
-        }
-        else {
-            medianOffsetPlottingButton->setLabel("OFF");
-        }
-
+        setMedianOffset(b->getToggleState());
         return;
     } 
     
     if (b == averageSignalButton)
     {
-        canvasSplit->setAveraging(b->getToggleState());
-
-        if (b->getToggleState())
-        {
-            averageSignalButton->setLabel("ON");
-            resetButton->setVisible(true);
-        }
-        else {
-            averageSignalButton->setLabel("OFF");
-            resetButton->setVisible(false);
-        }
+        setAveraging(b->getToggleState());
         return;
     }
 
     if (b == sortByDepthButton)
     {
-        lfpDisplay->orderChannelsByDepth(b->getToggleState());
-
-        if (b->getToggleState())
-        {
-            sortByDepthButton->setLabel("ON");
-        }
-        else {
-            sortByDepthButton->setLabel("OFF");
-        }
+        setSortByDepth(b->getToggleState());
         return;
     }
 
@@ -998,23 +1056,11 @@ void LfpDisplayOptions::buttonClicked(Button* b)
 
     if (b == showChannelNumberButton)
     {
-        int numChannels = lfpDisplay->channelInfo.size();
-        for (int i = 0; i < numChannels; ++i)
-        {
-            lfpDisplay->channelInfo[i]->repaint();
-        }
-
-        if (b->getToggleState())
-        {
-            showChannelNumberButton->setLabel("ON");
-        }
-        else {
-            showChannelNumberButton->setLabel("OFF");
-        }
+        setShowChannelNumbers(b->getToggleState());
         return;
     }
 
-    int idx = typeButtons.indexOf((UtilityButton*)b);
+    int idx = typeButtons.indexOf((UtilityButton*) b);
 
     if ((idx >= 0) && (b->getToggleState()))
     {
@@ -1161,6 +1207,9 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
         //    removeChildComponent(lfpDisplay->getColourSchemePtr());
         
         // change the active colour scheme ptr
+
+        std::cout << "Setting color scheme to " << cb->getSelectedId() << std::endl;
+
         lfpDisplay->setActiveColourSchemeIdx(cb->getSelectedId()-1);
         //canvasSplit->repaint();  // setBackgroundColour(lfpDisplay->getColourSchemePtr()->getBackgroundColour());
         
@@ -1467,6 +1516,7 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
     xmlNode->setAttribute("sortByDepth", sortByDepthButton->getToggleState());
     xmlNode->setAttribute("channelSkip", channelDisplaySkipSelection->getSelectedId());
     xmlNode->setAttribute("showChannelNum", showChannelNumberButton->getToggleState());
+    xmlNode->setAttribute("subtractOffset", medianOffsetPlottingButton->getToggleState());
 
     xmlNode->setAttribute("isInverted",invertInputButton->getToggleState());
     
@@ -1474,6 +1524,8 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
     xmlNode->setAttribute("trialAvg", averageSignalButton->getToggleState());
 
     xmlNode->setAttribute("singleChannelView", lfpDisplay->getSingleChannelShown());
+
+    
 
     int eventButtonState = 0;
 
@@ -1518,10 +1570,24 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
         if (xmlNode->hasTagName("LFPDISPLAY" + String(canvasSplit->splitID)))
         {
             uint32 id = xmlNode->getIntAttribute("SubprocessorID");
+
+            std::cout << "Loading options for display " << canvasSplit->splitID << std::endl;
+
+            std::cout << "Saved subprocessor ID: " << id << std::endl;
+
+            std::cout << "Available IDs: " << std::endl;
+
+            for (auto db : processor->getDisplayBuffers())
+            {
+                std::cout << " " << db->id << std::endl;
+            }
+
             if(processor->displayBufferMap.find(id) == processor->displayBufferMap.end())
                 canvasSplit->displayBuffer = processor->getDisplayBuffers().getFirst();   
             else
                 canvasSplit->displayBuffer = processor->displayBufferMap[id];
+
+            std::cout << "Set to ID: " << canvasSplit->displayBuffer->id << std::endl;
             
             StringArray ranges;
             ranges.addTokens(xmlNode->getStringAttribute("Range"),",",String::empty);
@@ -1533,24 +1599,41 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
             selectedVoltageRange[2] = voltageRanges[2].indexOf(ranges[2])+1;
             rangeSelection->setText(ranges[0]);
 
-            timebaseSelection->setText(xmlNode->getStringAttribute("Timebase"), sendNotification);
-            spreadSelection->setText(xmlNode->getStringAttribute("Spread"), sendNotification);
-            colourSchemeOptionSelection->setSelectedId(xmlNode->getIntAttribute("colourScheme"), sendNotification);
-            colorGroupingSelection->setSelectedId(xmlNode->getIntAttribute("colorGrouping"), sendNotification);
+            // TIMEBASE
+            timebaseSelection->setText(xmlNode->getStringAttribute("Timebase"), dontSendNotification);
+            canvasSplit->setTimebase(xmlNode->getStringAttribute("Timebase").getFloatValue());
 
+            // SPREAD
+            spreadSelection->setText(xmlNode->getStringAttribute("Spread"), dontSendNotification);
+
+            //std::cout << "Saved colour scheme: " << xmlNode->getIntAttribute("colourScheme") << std::endl;
+
+            // COLOUR SCHEME
+            lfpDisplay->setActiveColourSchemeIdx(xmlNode->getIntAttribute("colourScheme") - 1);
+            colourSchemeOptionSelection->setSelectedId(xmlNode->getIntAttribute("colourScheme"), dontSendNotification);
+
+            // COLOUR GROUPING
+            colorGroupingSelection->setSelectedId(xmlNode->getIntAttribute("colorGrouping"), dontSendNotification);
+            lfpDisplay->setColorGrouping(colorGroupings[colorGroupingSelection->getSelectedId() - 1].getIntValue());
+
+            // SPIKE RASTER
             spikeRasterSelection->setText(xmlNode->getStringAttribute("spikeRaster"), sendNotification);
+
+
             clipWarningSelection->setSelectedId(xmlNode->getIntAttribute("clipWarning"), sendNotification);
             saturationWarningSelection->setSelectedId(xmlNode->getIntAttribute("satWarning"), sendNotification);
             
-            reverseChannelsDisplayButton->setToggleState(xmlNode->getBoolAttribute("reverseOrder", false), sendNotification);
-            sortByDepthButton->setToggleState(xmlNode->getBoolAttribute("sortByDepth", false), sendNotification);
+            setChannelsReversed(xmlNode->getBoolAttribute("reverseOrder", false));
+            setSortByDepth(xmlNode->getBoolAttribute("sortByDepth", false));
+            setShowChannelNumbers(xmlNode->getBoolAttribute("showChannelNum", false));
+            setInputInverted(xmlNode->getBoolAttribute("isInverted", false));
+            setAveraging(xmlNode->getBoolAttribute("trialAvg", false));
+            setMedianOffset(xmlNode->getBoolAttribute("subtractOffset", false));
+
             channelDisplaySkipSelection->setSelectedId(xmlNode->getIntAttribute("channelSkip"), sendNotification);
-            showChannelNumberButton->setToggleState(xmlNode->getBoolAttribute("showChannelNum", false), sendNotification);
-
-            invertInputButton->setToggleState(xmlNode->getBoolAttribute("isInverted", false), sendNotification);
-
             triggerSourceSelection->setSelectedId(xmlNode->getIntAttribute("triggerSource"), sendNotification);
-            averageSignalButton->setToggleState(xmlNode->getBoolAttribute("trialAvg", false), sendNotification);
+
+            
 
            // drawMethodButton->setToggleState(xmlNode->getBoolAttribute("drawMethod", true), sendNotification);
 
@@ -1583,6 +1666,9 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
             }
 
             lfpDisplay->setSingleChannelView(xmlNode->getIntAttribute("singleChannelView", -1));
+
+            lfpDisplay->setColors();
+            canvasSplit->redraw();
         }
 
         

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1533,23 +1533,23 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
             selectedVoltageRange[2] = voltageRanges[2].indexOf(ranges[2])+1;
             rangeSelection->setText(ranges[0]);
 
-            timebaseSelection->setText(xmlNode->getStringAttribute("Timebase"));
-            spreadSelection->setText(xmlNode->getStringAttribute("Spread"));
-            colourSchemeOptionSelection->setSelectedId(xmlNode->getIntAttribute("colourScheme"));
-            colorGroupingSelection->setSelectedId(xmlNode->getIntAttribute("colorGrouping"));
+            timebaseSelection->setText(xmlNode->getStringAttribute("Timebase"), sendNotification);
+            spreadSelection->setText(xmlNode->getStringAttribute("Spread"), sendNotification);
+            colourSchemeOptionSelection->setSelectedId(xmlNode->getIntAttribute("colourScheme"), sendNotification);
+            colorGroupingSelection->setSelectedId(xmlNode->getIntAttribute("colorGrouping"), sendNotification);
 
-            spikeRasterSelection->setText(xmlNode->getStringAttribute("spikeRaster"));
-            clipWarningSelection->setSelectedId(xmlNode->getIntAttribute("clipWarning"));
-            saturationWarningSelection->setSelectedId(xmlNode->getIntAttribute("satWarning"));
+            spikeRasterSelection->setText(xmlNode->getStringAttribute("spikeRaster"), sendNotification);
+            clipWarningSelection->setSelectedId(xmlNode->getIntAttribute("clipWarning"), sendNotification);
+            saturationWarningSelection->setSelectedId(xmlNode->getIntAttribute("satWarning"), sendNotification);
             
             reverseChannelsDisplayButton->setToggleState(xmlNode->getBoolAttribute("reverseOrder", false), sendNotification);
             sortByDepthButton->setToggleState(xmlNode->getBoolAttribute("sortByDepth", false), sendNotification);
-            channelDisplaySkipSelection->setSelectedId(xmlNode->getIntAttribute("channelSkip"));
+            channelDisplaySkipSelection->setSelectedId(xmlNode->getIntAttribute("channelSkip"), sendNotification);
             showChannelNumberButton->setToggleState(xmlNode->getBoolAttribute("showChannelNum", false), sendNotification);
 
             invertInputButton->setToggleState(xmlNode->getBoolAttribute("isInverted", false), sendNotification);
 
-            triggerSourceSelection->setSelectedId(xmlNode->getIntAttribute("triggerSource"));
+            triggerSourceSelection->setSelectedId(xmlNode->getIntAttribute("triggerSource"), sendNotification);
             averageSignalButton->setToggleState(xmlNode->getBoolAttribute("trialAvg", false), sendNotification);
 
            // drawMethodButton->setToggleState(xmlNode->getBoolAttribute("drawMethod", true), sendNotification);

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -884,6 +884,7 @@ void LfpDisplayOptions::togglePauseButton(bool sendUpdate)
 void LfpDisplayOptions::setChannelsReversed(bool state)
 {
     lfpDisplay->setChannelsReversed(state);
+    canvasSplit->fullredraw = true;
 
     reverseChannelsDisplayButton->setToggleState(state, dontSendNotification);
 
@@ -1575,12 +1576,12 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
 
             std::cout << "Saved subprocessor ID: " << id << std::endl;
 
-            std::cout << "Available IDs: " << std::endl;
+            /*std::cout << "Available IDs: " << std::endl;
 
             for (auto db : processor->getDisplayBuffers())
             {
                 std::cout << " " << db->id << std::endl;
-            }
+            }*/
 
             if(processor->displayBufferMap.find(id) == processor->displayBufferMap.end())
                 canvasSplit->displayBuffer = processor->getDisplayBuffers().getFirst();   

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1590,7 +1590,7 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
         }
     }
 
-    std::cout << "Finished loading LFP options." << std::endl;
+   // std::cout << "Finished loading LFP options." << std::endl;
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1447,15 +1447,8 @@ int LfpDisplayOptions::getRangeStep(DataChannel::DataChannelTypes type)
 
 void LfpDisplayOptions::saveParameters(XmlElement* xml)
 {
-    // TODO: (kelly) add savers for:
-    //      - channel reverse
-    //      - channel zoom slider
-    //      - channel display skip
-   // std::cout << "Saving lfp display params" << std::endl;
 
     XmlElement* xmlNode = xml->createNewChildElement("LFPDISPLAY" + String(canvasSplit->splitID));
-
-    lfpDisplay->reactivateChannels();
 
     xmlNode->setAttribute("SubprocessorID",canvasSplit->subprocessorSelection->getSelectedId());
 
@@ -1480,6 +1473,8 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
     xmlNode->setAttribute("triggerSource", triggerSourceSelection->getSelectedId());
     xmlNode->setAttribute("trialAvg", averageSignalButton->getToggleState());
 
+    xmlNode->setAttribute("singleChannelView", lfpDisplay->getSingleChannelShown());
+
     int eventButtonState = 0;
 
     for (int i = 0; i < 8; i++)
@@ -1490,15 +1485,13 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
         }
     }
 
-    lfpDisplay->reactivateChannels();
-
     xmlNode->setAttribute("EventButtonState", eventButtonState);
 
     String channelDisplayState = "";
 
     for (int i = 0; i < canvasSplit->nChans; i++)
     {
-        if (lfpDisplay->getEnabledState(i))
+        if (lfpDisplay->savedChannelState[i])
         {
             channelDisplayState += "1";
         }
@@ -1506,10 +1499,7 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
         {
             channelDisplayState += "0";
         }
-        //std::cout << channelDisplayState;
     }
-
-    //std::cout << std::endl;
 
     xmlNode->setAttribute("ChannelDisplayState", channelDisplayState);
 
@@ -1591,7 +1581,11 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
                 }
 
             }
+
+            lfpDisplay->setSingleChannelView(xmlNode->getIntAttribute("singleChannelView", -1));
         }
+
+        
     }
 
    // std::cout << "Finished loading LFP options." << std::endl;

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1516,6 +1516,8 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
 void LfpDisplayOptions::loadParameters(XmlElement* xml)
 {
 
+    canvasSplit->isLoading = true;
+
     forEachXmlChildElement(*xml, xmlNode)
     {
 
@@ -1588,7 +1590,7 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
         }
     }
 
-    //std::cout << "Finished loading LFP options." << std::endl;
+    std::cout << "Finished loading LFP options." << std::endl;
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1432,7 +1432,7 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
     //      - channel reverse
     //      - channel zoom slider
     //      - channel display skip
-    std::cout << "Saving lfp display params" << std::endl;
+   // std::cout << "Saving lfp display params" << std::endl;
 
     XmlElement* xmlNode = xml->createNewChildElement("LFPDISPLAY" + String(canvasSplit->splitID));
 
@@ -1500,10 +1500,7 @@ void LfpDisplayOptions::saveParameters(XmlElement* xml)
 
 void LfpDisplayOptions::loadParameters(XmlElement* xml)
 {
-    // TODO: (kelly) add loaders for:
-    //      - channel reverse
-    //      - channel zoom slider
-    //      - channel display skip
+
     forEachXmlChildElement(*xml, xmlNode)
     {
 
@@ -1565,19 +1562,18 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
 
                 if (channelDisplayState.substring(i,i+1).equalsIgnoreCase("1"))
                 {
-                    //std::cout << "LfpDisplayCanvas enabling channel " << i << std::endl;
-                    //lfpDisplay->enableChannel(true, i);
-                    canvasSplit->isChannelEnabled.set(i,true); //lfpDisplay->enableChannel(true, i);
+                    lfpDisplay->setEnabledState(true, i, true);
                 }
                 else
                 {
-                    //lfpDisplay->enableChannel(false, i);
-                    canvasSplit->isChannelEnabled.set(i,false);
+                    lfpDisplay->setEnabledState(false, i, true);
                 }
 
             }
         }
     }
+
+    //std::cout << "Finished loading LFP options." << std::endl;
 
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1308,6 +1308,21 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
 
         //std::cout << "Setting saturation warning to to " << selectedSaturationValueFloat << std::endl;
     }
+    else if (cb == clipWarningSelection)
+    {
+        if (cb->getSelectedId() == 1)
+        {
+            canvasSplit->drawClipWarning = false;
+        }
+        else
+        {
+            canvasSplit->drawClipWarning = true;
+        }
+
+        canvasSplit->redraw();
+
+    //std::cout << "Setting saturation warning to to " << selectedSaturationValueFloat << std::endl;
+    }
     else if (cb == overlapSelection)
     {
         if (cb->getSelectedId())

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1034,19 +1034,19 @@ void LfpDisplayOptions::buttonClicked(Button* b)
 
 void LfpDisplayOptions::setTimebaseAndSelectionText(float timebase)
 {
-    canvasSplit->timebase = timebase;
+    canvasSplit->setTimebase(timebase);
     
     if (canvasSplit->timebase) // if timebase != 0
     {
         if (canvasSplit->timebase < timebases[0].getFloatValue())
         {
             timebaseSelection->setSelectedId(1, dontSendNotification);
-            canvasSplit->timebase = timebases[0].getFloatValue();
+            canvasSplit->setTimebase(timebases[0].getFloatValue());
         }
         else if (canvasSplit->timebase > timebases[timebases.size()-1].getFloatValue())
         {
             timebaseSelection->setSelectedId(timebases.size(), dontSendNotification);
-            canvasSplit->timebase = timebases[timebases.size()-1].getFloatValue();
+            canvasSplit->setTimebase(timebases[timebases.size()-1].getFloatValue());
         }
         else{
             timebaseSelection->setText(String(canvasSplit->timebase, 1), dontSendNotification);
@@ -1057,15 +1057,17 @@ void LfpDisplayOptions::setTimebaseAndSelectionText(float timebase)
         if (selectedSpread == 0)
         {
             timebaseSelection->setText(selectedTimebaseValue, dontSendNotification);
-            canvasSplit->timebase = selectedTimebaseValue.getFloatValue();
+            canvasSplit->setTimebase(selectedTimebaseValue.getFloatValue());
         }
         else
         {
             timebaseSelection->setSelectedId(selectedTimebase,dontSendNotification);
-            canvasSplit->timebase = timebases[selectedTimebase-1].getFloatValue();
+            canvasSplit->setTimebase(timebases[selectedTimebase-1].getFloatValue());
         }
         
     }
+
+    timescale->setTimebase(canvasSplit->timebase);
 }
 
 void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
@@ -1181,12 +1183,14 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
     {
         if (cb->getSelectedId())
         {
-            canvasSplit->timebase = timebases[cb->getSelectedId()-1].getFloatValue();
+            canvasSplit->setTimebase(timebases[cb->getSelectedId() - 1].getFloatValue());
         }
         else
         {
             setTimebaseAndSelectionText(cb->getText().getFloatValue());
         }
+
+        timescale->setTimebase(canvasSplit->timebase);
     }
     else if (cb == rangeSelection)
     {
@@ -1379,7 +1383,7 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
     }
 
 
-    timescale->setTimebase(canvasSplit->timebase);
+    
 }
 
 void LfpDisplayOptions::sliderValueChanged(Slider* sl)

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.h
@@ -126,6 +126,13 @@ public:
     String selectedSaturationValue;
     float selectedSaturationValueFloat; // TODO: this is way ugly - we should refactor all these parameters soon and get them into a nicer format- probably when we do the general plugin parameter overhaul.
 
+    void setChannelsReversed(bool);
+    void setInputInverted(bool);
+    void setMedianOffset(bool);
+    void setAveraging(bool);
+    void setSortByDepth(bool);
+    void setShowChannelNumbers(bool);
+
 private:
 
     LfpDisplayCanvas* canvas;

--- a/Plugins/LfpDisplayNode/LfpViewport.cpp
+++ b/Plugins/LfpDisplayNode/LfpViewport.cpp
@@ -40,6 +40,6 @@ LfpViewport::LfpViewport(LfpDisplaySplitter *split)
 void LfpViewport::visibleAreaChanged(const Rectangle<int>& newVisibleArea)
 {
     canvasSplit->fullredraw = true;
-    canvasSplit->refresh();
+    //canvasSplit->refresh();
 }
 

--- a/Plugins/LfpDisplayNode/LfpViewport.cpp
+++ b/Plugins/LfpDisplayNode/LfpViewport.cpp
@@ -39,8 +39,9 @@ LfpViewport::LfpViewport(LfpDisplaySplitter *split)
 
 void LfpViewport::visibleAreaChanged(const Rectangle<int>& newVisibleArea)
 {
-    canvasSplit->fullredraw = true;
 
-    canvasSplit->refresh();
+    canvasSplit->visibleAreaChanged();
+
+
 }
 

--- a/Plugins/LfpDisplayNode/LfpViewport.cpp
+++ b/Plugins/LfpDisplayNode/LfpViewport.cpp
@@ -40,6 +40,7 @@ LfpViewport::LfpViewport(LfpDisplaySplitter *split)
 void LfpViewport::visibleAreaChanged(const Rectangle<int>& newVisibleArea)
 {
     canvasSplit->fullredraw = true;
-    //canvasSplit->refresh();
+
+    canvasSplit->refresh();
 }
 

--- a/Source/Processors/Merger/MergerEditor.cpp
+++ b/Source/Processors/Merger/MergerEditor.cpp
@@ -170,8 +170,10 @@ void MergerEditor::mouseDown(const MouseEvent& e)
 
         PopupMenu menu;
         int menuItemIndex = 1;
-        int continuousMergeIndexA, continuousMergeIndexB = -1;
-        int inputSelectionIndexA, inputSelectionIndexB = -1;
+        int continuousMergeIndexA = -1;
+        int continuousMergeIndexB = -1;
+        int inputSelectionIndexA = -1;
+        int inputSelectionIndexB = -1;
         
         Array<GenericProcessor*> selectableProcessors = getSelectableProcessors();
         

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -248,7 +248,12 @@ GenericProcessor* EditorViewport::addProcessor(ProcessorDescription description,
     else
     {
         action->perform();
+
+        orphanedActions.add(action);
+
         return action->processor;
+        
+
     }
     
 }

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1779,9 +1779,12 @@ const String EditorViewport::loadStateFromXml(XmlElement* xml)
 void EditorViewport::deleteSelectedProcessors()
 {
     undoManager.beginNewTransaction();
+
+    Array<GenericEditor*> editors = Array(editorArray);
     
-    for (auto editor : editorArray)
+    for (auto editor : editors)
     {
+        std::cout << "Editor name: " << editor->getName() << std::endl;
         if (editor->getSelectionState())
         {
             DeleteProcessor* action = new DeleteProcessor(editor->getProcessor(), this);

--- a/Source/UI/EditorViewport.h
+++ b/Source/UI/EditorViewport.h
@@ -38,13 +38,10 @@
 class GenericEditor;
 class SignalChainTabButton;
 class SignalChainTabComponent;
-//class EditorScrollButton;
 class SignalChainScrollButton;
 class ControlPanel;
 class UIComponent;
-
-enum Action {ADD, MOVE, REMOVE, ACTIVATE, UPDATE};
-
+class AddProcessor;
 
 /**
 
@@ -239,6 +236,8 @@ private:
     OwnedArray<XmlElement> copyBuffer;
     
     Label editorNamingLabel;
+
+    OwnedArray<AddProcessor> orphanedActions;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(EditorViewport);
 

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -215,8 +215,6 @@ void UIComponent::resized()
 
 		if (h < 200)
 			editorViewportButton->setBounds(w-230,h-40+200-h,225,35);
-		//else
-		//    editorViewportButton->setVisible(true);
 	}
 
 	if (signalChainTabComponent != nullptr)


### PR DESCRIPTION
- Prevent re-creating existing LfpChannelDisplays
- Restore clip warning
- Make sure disabled channel settings are reloaded
- Keep view position when resizing displays