### PR TITLE
0.5.4 pre-release

### DIFF
--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -47,6 +47,7 @@ namespace LfpViewer {
 
         ttlState = 0;
 
+       // std::cout << "Subprocessor " << id << " has " << displays.size() << " displays." << std::endl;
         //std::cout << "Display buffer sample rate: " << sampleRate << std::endl;
     }
 
@@ -102,8 +103,28 @@ namespace LfpViewer {
             displayBufferIndices.set(i, 0);
     }
 
+    void DisplayBuffer::addDisplay(int splitID)
+    {
+        if (!displays.contains(splitID))
+             displays.add(splitID);
+
+        std::cout << "Subprocessor " << id << " has " << displays.size() << " displays." << std::endl;
+    }
+
+    void DisplayBuffer::removeDisplay(int splitID)
+    {
+        if (displays.contains(splitID))
+            displays.remove(displays.indexOf(splitID));
+
+       // std::cout << "Subprocessor " << id << " has " << displays.size() << " displays." << std::endl;
+
+    }
+
     void DisplayBuffer::initializeEventChannel(int nSamples)
     {
+        if (displays.size() == 0)
+            return;
+
         const int samplesLeft = BUFFER_LENGTH - displayBufferIndices[numChannels];
 
         if (nSamples < samplesLeft)
@@ -135,6 +156,10 @@ namespace LfpViewer {
 
     void DisplayBuffer::finalizeEventChannel(int nSamples)
     {
+
+        if (displays.size() == 0)
+            return;
+
         const int index = displayBufferIndices[numChannels];
         const int samplesLeft = BUFFER_LENGTH - index;
    
@@ -154,6 +179,10 @@ namespace LfpViewer {
 
     void DisplayBuffer::addEvent(int eventTime, int eventChannel, int eventId, int numSourceSamples)
     {
+
+        if (displays.size() == 0)
+            return;
+
         const int index = (displayBufferIndices[numChannels] + eventTime) % BUFFER_LENGTH;
         const int samplesLeft = BUFFER_LENGTH - index;
         const int nSamples = numSourceSamples - eventTime;
@@ -168,33 +197,34 @@ namespace LfpViewer {
 
         if (nSamples < samplesLeft)
         {
-            copyFrom(numChannels,                            // destChannel
+            copyFrom(numChannels,                     // destChannel
                 index,                                // destStartSample
                 arrayOfOnes,                          // source
                 nSamples,                             // numSamples
-                float(ttlState));                              // gain
+                float(ttlState));                     // gain
         }
         else
         {
             int extraSamples = nSamples - samplesLeft;
 
-            copyFrom(numChannels,                                 // destChannel
+            copyFrom(numChannels,                     // destChannel
                 index,                                // destStartSample
                 arrayOfOnes,                          // source
                 samplesLeft,                          // numSamples
-                float(ttlState));  // gain
+                float(ttlState));                     // gain
 
-            copyFrom(numChannels,                                 // destChannel
+            copyFrom(numChannels,                     // destChannel
                 0,                                    // destStartSample
                 arrayOfOnes,                          // source
                 extraSamples,                         // numSamples
-                float(ttlState));  // gain
+                float(ttlState));                     // gain
         }
     }
 
     void DisplayBuffer::addData(AudioSampleBuffer& buffer, int chan, int nSamples)
     {
-        
+        if (displays.size() == 0)
+            return;
 
         int previousIndex = displayBufferIndices[channelMap[chan]];
         int channelIndex = channelMap[chan];

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -108,7 +108,7 @@ namespace LfpViewer {
         if (!displays.contains(splitID))
              displays.add(splitID);
 
-        std::cout << "Subprocessor " << id << " has " << displays.size() << " displays." << std::endl;
+        //std::cout << "Subprocessor " << id << " has " << displays.size() << " displays." << std::endl;
     }
 
     void DisplayBuffer::removeDisplay(int splitID)

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -87,7 +87,7 @@ namespace LfpViewer {
     {
             
         if (numChannels != previousSize)
-            setSize(numChannels + 1, 20000); // int(sampleRate * BUFFER_LENGTH_S));
+            setSize(numChannels + 1, int(sampleRate * BUFFER_LENGTH_S));
 
         clear();
 

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -195,6 +195,8 @@ namespace LfpViewer {
             ttlState &= ~(1LL << eventChannel);
         }
 
+       // std::cout << "Display buffer received event on " << eventChannel << " at " << eventTime << " with " << numSourceSamples << std::endl;
+
         if (nSamples < samplesLeft)
         {
             copyFrom(numChannels,                     // destChannel

--- a/Plugins/LfpDisplayNode/DisplayBuffer.cpp
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.cpp
@@ -30,7 +30,7 @@ namespace LfpViewer {
 
 
     */
-#define BUFFER_LENGTH 20000
+#define BUFFER_LENGTH_S 1.0f
 
     DisplayBuffer::DisplayBuffer(int id_, String name_, float sampleRate_) : 
         id(id_), name(name_), sampleRate(sampleRate_), isNeeded(true)
@@ -87,7 +87,7 @@ namespace LfpViewer {
     {
             
         if (numChannels != previousSize)
-            setSize(numChannels + 1, BUFFER_LENGTH);
+            setSize(numChannels + 1, 20000); // int(sampleRate * BUFFER_LENGTH_S));
 
         clear();
 
@@ -125,7 +125,7 @@ namespace LfpViewer {
         if (displays.size() == 0)
             return;
 
-        const int samplesLeft = BUFFER_LENGTH - displayBufferIndices[numChannels];
+        const int samplesLeft = getNumSamples() - displayBufferIndices[numChannels];
 
         if (nSamples < samplesLeft)
         {
@@ -161,7 +161,7 @@ namespace LfpViewer {
             return;
 
         const int index = displayBufferIndices[numChannels];
-        const int samplesLeft = BUFFER_LENGTH - index;
+        const int samplesLeft = getNumSamples() - index;
    
         int newIdx = 0;
 
@@ -183,8 +183,8 @@ namespace LfpViewer {
         if (displays.size() == 0)
             return;
 
-        const int index = (displayBufferIndices[numChannels] + eventTime) % BUFFER_LENGTH;
-        const int samplesLeft = BUFFER_LENGTH - index;
+        const int index = (displayBufferIndices[numChannels] + eventTime) % getNumSamples();
+        const int samplesLeft = getNumSamples() - index;
         const int nSamples = numSourceSamples - eventTime;
 
         if (eventId == 1)
@@ -229,7 +229,7 @@ namespace LfpViewer {
         int previousIndex = displayBufferIndices[channelMap[chan]];
         int channelIndex = channelMap[chan];
 
-        const int samplesLeft = BUFFER_LENGTH - displayBufferIndices[channelMap[chan]];
+        const int samplesLeft = getNumSamples() - displayBufferIndices[channelMap[chan]];
 
         int newIndex;
         

--- a/Plugins/LfpDisplayNode/DisplayBuffer.h
+++ b/Plugins/LfpDisplayNode/DisplayBuffer.h
@@ -79,8 +79,6 @@ namespace LfpViewer {
 
         int previousSize;
 
-        //Array<String> channelNames;
-
         float sampleRate;
 
         uint64 ttlState;
@@ -93,6 +91,12 @@ namespace LfpViewer {
         CriticalSection displayMutex;
 
         bool isNeeded;
+
+        void addDisplay(int splitID);
+
+        void removeDisplay(int splitID);
+
+        Array<int> displays;
 
     };
 };

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -214,7 +214,7 @@ void LfpChannelDisplay::pxPaint()
         }
             
         // draw event markers
-        int rawEventState = canvasSplit->getYCoord(canvasSplit->getNumChannels(), i);// get last channel+1 in buffer (represents events)
+        int rawEventState = canvasSplit->getEventState(i);// get event state
             
         for (int ev_ch = 0; ev_ch < 8; ev_ch++) // for all event channels
         {

--- a/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpChannelDisplay.cpp
@@ -214,7 +214,7 @@ void LfpChannelDisplay::pxPaint()
         }
             
         // draw event markers
-        int rawEventState = canvasSplit->getEventState(i);// get event state
+        int rawEventState = canvasSplit->getEventState(i); // get event state
             
         for (int ev_ch = 0; ev_ch < 8; ev_ch++) // for all event channels
         {

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -389,13 +389,13 @@ void LfpDisplay::refresh()
 
         if (fillfrom < fillto)
         {
-            gLfpChannelBitmap.fillRect(fillfrom, 0, (fillto - fillfrom) + 1, lfpChannelBitmap.getHeight()); // just clear one section
+            gLfpChannelBitmap.fillRect(fillfrom, 0, (fillto - fillfrom) + 2, lfpChannelBitmap.getHeight()); // just clear one section
             //std::cout << "Clearing " << fillfrom << " to " << fillto << std::endl;
         }
         else if (fillfrom > fillto) {
 
-            gLfpChannelBitmap.fillRect(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 1, lfpChannelBitmap.getHeight()); // first segment
-            gLfpChannelBitmap.fillRect(0, 0, fillto + 1, lfpChannelBitmap.getHeight()); // second segment
+            gLfpChannelBitmap.fillRect(fillfrom, 0, lfpChannelBitmap.getWidth() - fillfrom + 2, lfpChannelBitmap.getHeight()); // first segment
+            gLfpChannelBitmap.fillRect(0, 0, fillto + 2, lfpChannelBitmap.getHeight()); // second segment
 
             //std::cout << "Clearing " << fillfrom << " to " << lfpChannelBitmap.getWidth() << std::endl;
             //std::cout << "Clearing " << 0 << " to " << fillto << std::endl;

--- a/Plugins/LfpDisplayNode/LfpDisplay.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplay.cpp
@@ -281,7 +281,7 @@ void LfpDisplay::resized()
 {
     int totalHeight = 0;
 
-    std::cout << "LFP display width: " << getWidth() << std::endl;
+   // std::cout << "LFP display width: " << getWidth() << std::endl;
 
 
     //std::cout << "Resizing channels" << std::endl;
@@ -330,7 +330,7 @@ void LfpDisplay::resized()
     else
         lfpChannelBitmap = Image(Image::ARGB, 10, 10, false);
     
-    std::cout << "Bitmap width: " << lfpChannelBitmap.getWidth() << std::endl;
+  //  std::cout << "Bitmap width: " << lfpChannelBitmap.getWidth() << std::endl;
 
 
     //inititalize background

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -810,7 +810,7 @@ LfpDisplaySplitter::~LfpDisplaySplitter()
 void LfpDisplaySplitter::resized()
 {
 
-    std::cout << "Split display " << splitID << " width: " << getWidth() << std::endl;
+    //std::cout << "Split display " << splitID << " width: " << getWidth() << std::endl;
 
     const int timescaleHeight = 30;
 
@@ -1201,7 +1201,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                 if (triggerTime >= 0) 
                 {
  
-                    if (sbi == 0)
+                    if (sbi == 0 || reachedEnd)
                     {
                         const int screenThird = int(maxSamples * ratio / 3);
                         const int dispBufLim = displayBufferSize / 2;
@@ -1227,7 +1227,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                         {
                             numTrials += 1;
                             
-                            std::cout << "Trial number: " << numTrials << std::endl;
+                            /*std::cout << "Trial number: " << numTrials << std::endl;
 
                             std::cout << "maxSamples: " << maxSamples << std::endl;
                             std::cout << "ratio: " << ratio << std::endl;
@@ -1239,7 +1239,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                             std::cout << "pixels to fill: " << pixelsToFill << std::endl;
                             std::cout << "sbi: " << sbi << std::endl;
 
-                            std::cout << std::endl;
+                            std::cout << std::endl;*/
                         }
 
                         // rewind screen buffer to the far left

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -924,6 +924,9 @@ void LfpDisplaySplitter::deselect()
 void LfpDisplaySplitter::updateSettings()
 {
 
+    if (displayBuffer != nullptr)
+        displayBuffer->removeDisplay(splitID);
+
     isUpdating = true;
 
     Array<DisplayBuffer*> availableBuffers = processor->getDisplayBuffers();
@@ -965,6 +968,8 @@ void LfpDisplaySplitter::updateSettings()
         options->setEnabled(true);
     }
     else {
+
+        displayBuffer->addDisplay(splitID);
         
         subprocessorSelection->setSelectedId(displayBuffer->id, dontSendNotification);
         displayBufferSize = displayBuffer->getNumSamples();
@@ -1155,8 +1160,13 @@ void LfpDisplaySplitter::updateScreenBuffer()
 
             if (newSamples == 0)
             {
+                // std::cout << "No new samples." << std::endl;
                 return;
             }
+
+            if (newSamples < 0)
+                newSamples += displayBufferSize;
+
 
             // this number is crucial -- converting from samples to values (in px) for the screen buffer:
             float ratio = sampleRate * timebase / float(maxSamples); // samples / pixel
@@ -1231,7 +1241,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
 
            // HELPFUL FOR DEBUGGING: 
 
-           /* if (channel == 1 && splitID == 1)
+           /*if (channel == 1 && splitID == 0)
                 std::cout << "Split "
                 << splitID << " : "
                 << channel << " : "

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -1222,6 +1222,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                             newSamples += displayBufferSize;
 
                         pixelsToFill = newSamples / ratio;
+                        subSampleOffset = 0;
 
                         if (channel == 0)
                         {

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -888,6 +888,8 @@ void LfpDisplaySplitter::beginAnimation()
 
         numTrials = -1;
 
+        eventState = 0;
+
     }    
 
     startTimer(20);
@@ -1405,6 +1407,10 @@ void LfpDisplaySplitter::updateScreenBuffer()
                             // update event channel
                             if (channel == nChans)
                             {
+                               // if (eventState != sample_max)
+                                //    std::cout << "Event state changed to " << sample_max << " at dbi " << dbi << " & sbi " << sbi << std::endl;
+
+                               // eventState = sample_max;
                                 eventDisplayBuffer->setSample(0, sbi, sample_max);
                             }
                             else {

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -814,7 +814,7 @@ void LfpDisplaySplitter::resized()
 
     const int timescaleHeight = 30;
 
-    timescale->setBounds(leftmargin, 0, getWidth()-scrollBarThickness, timescaleHeight);
+    timescale->setBounds(leftmargin, 0, getWidth() - scrollBarThickness - leftmargin, timescaleHeight);
 
     if (canvas->makeRoomForOptions(splitID))
     {
@@ -1046,6 +1046,9 @@ int LfpDisplaySplitter::getChannelHeight()
 void LfpDisplaySplitter::setTriggerChannel(int ch)
 {
     triggerChannel = ch;
+
+    if (triggerChannel == -1)
+        timescale->setTimebase(timebase);
     
     syncDisplay();
 }
@@ -1146,8 +1149,12 @@ void LfpDisplaySplitter::updateScreenBuffer()
                           : -1;
 
         if (triggerTime > 0)
+        {
             processor->acknowledgeTrigger(splitID);
-            
+
+            //if (lastScreenBufferIndex[0] == screenBufferIndex[0] && screenBufferIndex[0] != 0) // display is stuck
+            //    syncDisplay();
+        }
                 
         for (int channel = 0; channel <= nChans; channel++) // pull one extra channel for event display
         {
@@ -1219,10 +1226,20 @@ void LfpDisplaySplitter::updateScreenBuffer()
                         if (channel == 0)
                         {
                             numTrials += 1;
+                            
+                            std::cout << "Trial number: " << numTrials << std::endl;
+
+                            std::cout << "maxSamples: " << maxSamples << std::endl;
+                            std::cout << "ratio: " << ratio << std::endl;
+                            std::cout << "dispBufLim: " << dispBufLim << std::endl;
+                            std::cout << "screenThird: " << screenThird << std::endl;
+                            std::cout << "triggerTime: " << triggerTime << std::endl;
                             std::cout << "t0: " << t0 << std::endl;
                             std::cout << "newSamples: " << newSamples << std::endl;
                             std::cout << "pixels to fill: " << pixelsToFill << std::endl;
-                            std::cout << "Trial number: " << numTrials << std::endl;
+                            std::cout << "sbi: " << sbi << std::endl;
+
+                            std::cout << std::endl;
                         }
 
                         // rewind screen buffer to the far left
@@ -1233,6 +1250,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                         if (channel == nChans) // all channels have been reset
                         {
                             triggerTime = -1;
+                            timescale->setTimebase(timebase, float(std::min(screenThird, dispBufLim)) / sampleRate);
                         }
                     }
                     
@@ -1421,6 +1439,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
                             {
                                 if (channel == nChans)
                                     reachedEnd = true;
+
                                 break;
                             }
                         }

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.cpp
@@ -1191,8 +1191,8 @@ void LfpDisplaySplitter::updateScreenBuffer()
 
             float subSampleOffset = leftOverSamples[channel];
             
-            if (ratio > 1)
-                pixelsToFill += subSampleOffset; // keep track of fractional pixels left over from the last round
+            //if (ratio > 1)
+            pixelsToFill += subSampleOffset; // keep track of fractional pixels left over from the last round
 
 
             if (triggerChannel >= 0)
@@ -1270,7 +1270,7 @@ void LfpDisplaySplitter::updateScreenBuffer()
 
            // HELPFUL FOR DEBUGGING: 
 
-           /*if (channel == 1 && splitID == 0)
+            /*if (channel == 0)
                 std::cout << "Split "
                 << splitID << " : "
                 << channel << " : "
@@ -1319,28 +1319,33 @@ void LfpDisplaySplitter::updateScreenBuffer()
                         if (ratio < 1.0) // less than one sample per pixel
                         {
 
-                            float alpha = subSampleOffset;
-                            float invAlpha = 1.0f - alpha;
-
-                            float val0 = displayBuffer->getSample(channel, dbi);
-                            float val1 = displayBuffer->getSample(channel, (dbi + 1) % displayBufferSize);
-
-                            float val = invAlpha * val0 + alpha * val1;
-
-                            subSampleOffset += ratio;
-
                             if (channel == nChans)
                             {
                                 eventDisplayBuffer->setSample(0, sbi, displayBuffer->getSample(channel, dbi));
                             }
                             else {
+
+                                float alpha = subSampleOffset;
+                                float invAlpha = 1.0f - alpha;
+
+                                int lastIndex = dbi - 1;
+                                
+                                if (lastIndex < 0)
+                                    lastIndex = displayBufferSize;
+
+                                float val0 = displayBuffer->getSample(channel, lastIndex);
+                                float val1 = displayBuffer->getSample(channel, dbi);
+
+                                float val = invAlpha * val0 + alpha * val1;
+
                                 screenBufferMean->addSample(channel, sbi, val);
                                 screenBufferMin->addSample(channel, sbi, val);
                                 screenBufferMax->addSample(channel, sbi, val);
                             }
 
+                            subSampleOffset += ratio;
 
-                            if (subSampleOffset > 1.0f)
+                            if (subSampleOffset > 1.0f) // go to next pixel
                             {
                                 subSampleOffset -= 1.0f;
                                 dbi += 1;

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -291,6 +291,8 @@ private:
 	float displayedSampleRate;
 
     int samplesPerBufferPass;
+
+    int eventState;
     
     ScopedPointer<AudioSampleBuffer> eventDisplayBuffer; // buffer for event data
 

--- a/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayCanvas.h
@@ -105,6 +105,8 @@ public:
     void mouseDrag(const MouseEvent&) override;
     void mouseUp(const MouseEvent&) override;
 
+    void removeBufferForDisplay(int);
+
 private:
 
     LfpDisplayNode* processor;
@@ -194,6 +196,7 @@ public:
 
     const float getXCoord(int chan, int samp);
     const float getYCoord(int chan, int samp);
+    const float getEventState(int samp);
     
     //std::array<float, MAX_N_SAMP_PER_PIXEL> getSamplesPerPixel(int chan, int px);
     //const int getSampleCountPerPixel(int px);
@@ -289,15 +292,13 @@ private:
 
     int samplesPerBufferPass;
     
-    ScopedPointer<AudioSampleBuffer> screenBuffer; // subsampled buffer- one int per pixel
+    ScopedPointer<AudioSampleBuffer> eventDisplayBuffer; // buffer for event data
 
     //'define 3 buffers for min mean and max for better plotting of spikes
     // not pretty, but 'AudioSampleBuffer works only for channels X samples
     ScopedPointer<AudioSampleBuffer> screenBufferMin; // like screenBuffer but holds min/mean/max values per pixel
     ScopedPointer<AudioSampleBuffer> screenBufferMean; // like screenBuffer but holds min/mean/max values per pixel
     ScopedPointer<AudioSampleBuffer> screenBufferMax; // like screenBuffer but holds min/mean/max values per pixel
-
-    MidiBuffer* eventBuffer;
 
     void refreshScreenBuffer();
     void updateScreenBuffer();

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.cpp
@@ -212,6 +212,17 @@ void LfpDisplayEditor::resized()
     syncButton->setBounds(40, 80, 110, 30);
 }
 
+void LfpDisplayEditor::removeBufferForDisplay(int splitID)
+{
+    if (canvas != nullptr)
+    {
+        LfpDisplayCanvas* cv = (LfpDisplayCanvas*) canvas.get();
+
+        cv->removeBufferForDisplay(splitID);
+    }
+        
+}
+
 
 void LfpDisplayEditor::saveVisualizerParameters(XmlElement* xml)
 {

--- a/Plugins/LfpDisplayNode/LfpDisplayEditor.h
+++ b/Plugins/LfpDisplayNode/LfpDisplayEditor.h
@@ -80,6 +80,8 @@ public:
 
     void resized() override;
 
+    void removeBufferForDisplay(int);
+
 private:
         
     LfpDisplayNode* lfpProcessor;

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -322,7 +322,7 @@ void LfpDisplayNode::finalizeEventChannels()
         if (latestTrigger[i] == -1 && latestCurrentTrigger[i] > -1) // received a trigger, but not yet acknowledged
         {
             int triggerSample = latestCurrentTrigger[i] + splitDisplays[i]->displayBuffer->displayBufferIndices.getLast();
-            std::cout << "Setting latest trigger to " << triggerSample << std::endl;
+            //std::cout << "Setting latest trigger to " << triggerSample << std::endl;
             latestTrigger.set(i, triggerSample);
         }
     }
@@ -371,5 +371,5 @@ int64 LfpDisplayNode::getLatestTriggerTime(int id) const
 void LfpDisplayNode::acknowledgeTrigger(int id)
 {
   latestTrigger.set(id, -1);
-  std::cout << "Display " << id << " acknowledging trigger." << std::endl;
+  //std::cout << "Display " << id << " acknowledging trigger." << std::endl;
 }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -120,6 +120,12 @@ void LfpDisplayNode::updateSettings()
             //std::cout << "Erasing displayBuffer with id " << displayBuffer->id << std::endl;
             displayBufferMap.erase(displayBuffer->id);
             toDelete.add(displayBuffer);
+
+            for (auto splitID : displayBuffer->displays)
+            {
+                LfpDisplayEditor* ed = (LfpDisplayEditor*)getEditor();
+                ed->removeBufferForDisplay(splitID);
+            }
         }
         
     }

--- a/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayNode.cpp
@@ -135,6 +135,7 @@ void LfpDisplayNode::updateSettings()
         displayBuffers.removeObject(displayBuffer, true);
     }
 
+   
     //std::cout << "Total display buffers: " << displayBuffers.size() << std::endl;
 
     // TODO: add event channels separately, as they may have a different source
@@ -289,17 +290,17 @@ void LfpDisplayNode::handleEvent(const EventChannel* eventInfo, const MidiMessag
             for (auto displayBuffer : displayBuffers)
             {
                 displayBuffer->addEvent(eventTime, eventChannel, eventId,
-                    getNumSourceSamples(eventSourceNodeId)
+                    getNumSourceSamples(displayBuffer->id)
                 );
                 
             }
 
         }
 
-        //         std::cout << "Received event from " << eventSourceNodeId
-        //                   << " on channel " << eventChannel
-        //                   << " with value " << eventId
-        //                   << " at timestamp " << event.getTimeStamp() << std::endl;
+       /*          std::cout << "Received event from " << eventSourceNodeId
+                           << " on channel " << eventChannel
+                           << " with value " << eventId
+                           << " at timestamp " << event.getTimeStamp() << std::endl;*/
     }
 }
 

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1576,6 +1576,9 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
 
             std::cout << "Saved subprocessor ID: " << id << std::endl;
 
+            if (canvasSplit->displayBuffer != nullptr)
+                canvasSplit->displayBuffer->removeDisplay(canvasSplit->splitID);
+
             /*std::cout << "Available IDs: " << std::endl;
 
             for (auto db : processor->getDisplayBuffers())
@@ -1583,10 +1586,12 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
                 std::cout << " " << db->id << std::endl;
             }*/
 
-            if(processor->displayBufferMap.find(id) == processor->displayBufferMap.end())
+            if (processor->displayBufferMap.find(id) == processor->displayBufferMap.end())
                 canvasSplit->displayBuffer = processor->getDisplayBuffers().getFirst();   
             else
                 canvasSplit->displayBuffer = processor->displayBufferMap[id];
+
+            canvasSplit->displayBuffer->addDisplay(canvasSplit->splitID);
 
             std::cout << "Set to ID: " << canvasSplit->displayBuffer->id << std::endl;
             

--- a/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
+++ b/Plugins/LfpDisplayNode/LfpDisplayOptions.cpp
@@ -1133,8 +1133,6 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
         {
             auto val = fabsf(cb->getText().getFloatValue());
 
-            std::cout << "Spike raster thresh: " << val << std::endl;
-            
             if (val == 0) // if value is zero, just disable plotting and set text to "Off"
             {
                 cb->setSelectedItemIndex(0, dontSendNotification);
@@ -1161,7 +1159,6 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
             if (!medianOffsetPlottingButton->getToggleState())
             {
                 medianOffsetPlottingButton->setToggleState(true, sendNotification);
-                //lfpDisplay->setMedianOffsetPlotting(true);
                 medianOffsetOnForSpikeRaster = true;
             }
             else {
@@ -1172,7 +1169,6 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
         }
         else if (cb->getSelectedItemIndex() == 0) // if "Off"
         {
-            std::cout << "Spike raster off" << std::endl;
 
             lfpDisplay->setSpikeRasterPlotting(false);
 
@@ -1187,8 +1183,6 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
         {
             auto val = cb->getText().getFloatValue();
 
-            std::cout << "Spike raster thresh: " << val << std::endl;
-            
             lfpDisplay->setSpikeRasterThreshold(val);
 
             if (!medianOffsetPlottingButton->getToggleState())
@@ -1203,29 +1197,8 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
     }
     else if (cb == colourSchemeOptionSelection)
     {
-        // hide the old colour scheme config options if they are displayed
-        //if (lfpDisplay->getColourSchemePtr()->hasConfigurableElements())
-        //    removeChildComponent(lfpDisplay->getColourSchemePtr());
-        
-        // change the active colour scheme ptr
-
-        std::cout << "Setting color scheme to " << cb->getSelectedId() << std::endl;
-
         lfpDisplay->setActiveColourSchemeIdx(cb->getSelectedId()-1);
-        //canvasSplit->repaint();  // setBackgroundColour(lfpDisplay->getColourSchemePtr()->getBackgroundColour());
-        
-        // show the new colour scheme's config options if has any
-        
-        //if (lfpDisplay->getColourSchemePtr()->hasConfigurableElements())
-        //{
-            //lfpDisplay->getColourSchemePtr()->setBounds(colourSchemeOptionLabel->getX(),
-            //                                            colourSchemeOptionLabel->getBottom(),
-            //                                            200,
-           //                                             110);
-            //addAndMakeVisible(lfpDisplay->getColourSchemePtr());
-        //}
-        
-        // update the lfpDisplay's colors and redraw
+
         lfpDisplay->setColors();
         canvasSplit->redraw();
     }
@@ -1283,7 +1256,6 @@ void LfpDisplayOptions::comboBoxChanged(ComboBox* cb)
         }
         selectedVoltageRange[selectedChannelType] = cb->getSelectedId();
         selectedVoltageRangeValues[selectedChannelType] = cb->getText();
-        //std::cout << "Setting range to " << voltageRanges[cb->getSelectedId()-1].getFloatValue() << std::endl;
         canvasSplit->redraw();
     }
     else if (cb == spreadSelection)
@@ -1572,9 +1544,9 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
         {
             uint32 id = xmlNode->getIntAttribute("SubprocessorID");
 
-            std::cout << "Loading options for display " << canvasSplit->splitID << std::endl;
+            //std::cout << "Loading options for display " << canvasSplit->splitID << std::endl;
 
-            std::cout << "Saved subprocessor ID: " << id << std::endl;
+            //std::cout << "Saved subprocessor ID: " << id << std::endl;
 
             if (canvasSplit->displayBuffer != nullptr)
                 canvasSplit->displayBuffer->removeDisplay(canvasSplit->splitID);
@@ -1593,7 +1565,7 @@ void LfpDisplayOptions::loadParameters(XmlElement* xml)
 
             canvasSplit->displayBuffer->addDisplay(canvasSplit->splitID);
 
-            std::cout << "Set to ID: " << canvasSplit->displayBuffer->id << std::endl;
+            //std::cout << "Set to ID: " << canvasSplit->displayBuffer->id << std::endl;
             
             // RANGE
             StringArray ranges;

--- a/Plugins/LfpDisplayNode/LfpTimescale.cpp
+++ b/Plugins/LfpDisplayNode/LfpTimescale.cpp
@@ -183,9 +183,11 @@ void LfpTimescale::setTimebase(float timebase_, float offset_)
         stepSize = 0.005;
     else if (timebase > 0.025 && timebase <= 0.1)
         stepSize = 0.01;
-    else if (timebase > 0.1 && timebase < 0.5)
+    else if (timebase > 0.1 && timebase <= 0.25)
         stepSize = 0.025;
-    else if (timebase >= 0.5 && timebase < 2)
+    else if (timebase > 0.25 && timebase <= 0.5)
+        stepSize = 0.1;
+    else if (timebase > 0.5 && timebase < 2)
         stepSize = 0.25;
     else if (timebase >= 2 && timebase < 5)
         stepSize = 0.5;

--- a/Plugins/LfpDisplayNode/LfpTimescale.cpp
+++ b/Plugins/LfpDisplayNode/LfpTimescale.cpp
@@ -171,8 +171,6 @@ void LfpTimescale::setTimebase(float timebase_, float offset_)
     timebase = timebase_;
     offset = offset_;
 
-    std::cout << "offset: " << offset << std::endl;
-
     labels.clear();
     isMajor.clear();
     fractionWidth.clear();
@@ -214,27 +212,6 @@ void LfpTimescale::setTimebase(float timebase_, float offset_)
         time += stepSize;
         index++;
     }
-    
-    /*const int minWidth = 60;
-    labelIncrement = 0.005f;
-
-    if (timebase < 5)
-    
-    while (getWidth() != 0 &&                                   // setTimebase can be called before LfpTimescale has width
-           getWidth() / (timebase / labelIncrement) < minWidth) // so, if width is 0 then don't iterate for scale factor
-    {
-//        std::cout << getWidth() / (timebase / labelIncrement) << " is smaller than minimum width, calculating new step size" << std::endl;
-        if (labelIncrement < 0.2)
-            labelIncrement *= 2;
-        else
-            labelIncrement += 0.2f;
-    }
-    
-    for (float i = labelIncrement; i < timebase; i += labelIncrement)
-    {
-        String labelString = String(i * ((timebase >= 2)?(1):(1000.0f)));
-        labels.add(labelString.substring(0,6));
-    }*/
 
     repaint();
 

--- a/Plugins/LfpDisplayNode/LfpTimescale.cpp
+++ b/Plugins/LfpDisplayNode/LfpTimescale.cpp
@@ -45,6 +45,7 @@ using namespace LfpViewer;
 LfpTimescale::LfpTimescale(LfpDisplaySplitter* c, LfpDisplay* lfpDisplay)
     : canvasSplit(c)
     , lfpDisplay(lfpDisplay)
+    , offset(0.0f)
 {
 
     font = Font("Default", 16, Font::plain);
@@ -64,18 +65,17 @@ void LfpTimescale::paint(Graphics& g)
 
     const String timeScaleUnitLabel = (timebase >= 2) ? ("s") : ("ms");
 
-    for (int i = 1; i < labels.size(); i++)
+    int startIndex; 
+
+    if (offset > 0)
+        startIndex = 0;
+    else
+        startIndex = 1;
+
+    for (int i = startIndex; i < labels.size(); i++)
     {
 
         float lineHeight;
-
-        /*if (isMajor[i])
-        {
-            lineHeight = getHeight() / 2;
-        }
-        else {
-            lineHeight = getHeight() / 4;
-        }*/
 
         g.drawLine(getWidth() * fractionWidth[i],
             0,
@@ -92,43 +92,6 @@ void LfpTimescale::paint(Graphics& g)
         
     }
 
-    /*for (int i = 0; i < steps; i++)
-    {
-        
-        // TODO: (kelly) added an extra spatial dimension to the timeline ticks, may be overkill
-        if (i == 0)
-        {
-            
-        }
-        if (i != 0 && i % 4 == 0)
-        {
-            g.drawLine(getWidth()/steps*i,
-                       0,
-                       getWidth()/steps*i,
-                       getHeight(),
-                       3.0f);
-        }
-        else if (i != 0 && i % 2 == 0)
-        {
-            g.drawLine(getWidth()/steps*i,
-                       getHeight(),
-                       getWidth()/steps*i,
-                       getHeight() / 2,
-                       3.0f);
-        }
-        else
-        {
-            g.drawLine(getWidth()/steps*i,
-                       getHeight(),
-                       getWidth()/steps*i,
-                       3 * getHeight()/4,
-                       2.0f);
-        }
-        
-        if (i != 0 && i % 2 == 0)
-            g.drawText(labels[i-1],getWidth()/steps*i+3,0,100,getHeight(),Justification::left, false);
-
-    }*/
 }
 
 void LfpTimescale::mouseUp(const MouseEvent &e)
@@ -203,9 +166,12 @@ void LfpTimescale::mouseDrag(const juce::MouseEvent &e)
     }
 }
 
-void LfpTimescale::setTimebase(float t)
+void LfpTimescale::setTimebase(float timebase_, float offset_)
 {
-    timebase = t;
+    timebase = timebase_;
+    offset = offset_;
+
+    std::cout << "offset: " << offset << std::endl;
 
     labels.clear();
     isMajor.clear();
@@ -233,12 +199,12 @@ void LfpTimescale::setTimebase(float t)
     float time = 0;
     int index = 0;
 
-    while (time < timebase)
+    while ((time + offset) < timebase)
     {
         String labelString = String(time * ((timebase >= 2) ? (1) : (1000.0f)));
         labels.add(labelString.substring(0, 6));
 
-        fractionWidth.add(time / timebase);
+        fractionWidth.add((time + offset) / timebase);
         
         if (index % 2 == 0)
             isMajor.add(true);

--- a/Plugins/LfpDisplayNode/LfpTimescale.h
+++ b/Plugins/LfpDisplayNode/LfpTimescale.h
@@ -54,7 +54,7 @@ public:
     
     void mouseUp(const MouseEvent &e) override;
 
-    void setTimebase(float t);
+    void setTimebase(float t, float offset = 0.0f);
 
 private:
 
@@ -62,6 +62,7 @@ private:
     LfpDisplay* lfpDisplay;
 
     float timebase;
+    float offset;
     float labelIncrement;
     float numIncrements;
 

--- a/Plugins/PhaseDetector/PhaseDetector.cpp
+++ b/Plugins/PhaseDetector/PhaseDetector.cpp
@@ -47,7 +47,7 @@ AudioProcessorEditor* PhaseDetector::createEditor()
 {
     editor = new PhaseDetectorEditor (this, true);
 
-    std::cout << "Creating editor." << std::endl;
+    //std::cout << "Creating editor." << std::endl;
 
     return editor;
 }

--- a/Plugins/PhaseDetector/PhaseDetectorEditor.cpp
+++ b/Plugins/PhaseDetector/PhaseDetectorEditor.cpp
@@ -230,7 +230,7 @@ DetectorInterface::DetectorInterface(PhaseDetector* pd, Colour c, int id) :
 
     sineWave.startNewSubPath(5,35);
 
-    std::cout << "Creating sine wave" << std::endl;
+    //std::cout << "Creating sine wave" << std::endl;
 
     for (double i = 0; i < 2*PI; i += PI/10)
     {
@@ -239,7 +239,7 @@ DetectorInterface::DetectorInterface(PhaseDetector* pd, Colour c, int id) :
 
     sineWave.addEllipse(2,35,4,4);
 
-    std::cout << "Creating phase buttons" << std::endl;
+    //std::cout << "Creating phase buttons" << std::endl;
 
     for (int phase = 0; phase < 4; phase++)
     {
@@ -255,7 +255,7 @@ DetectorInterface::DetectorInterface(PhaseDetector* pd, Colour c, int id) :
         addAndMakeVisible(phaseButton);
     }
 
-    std::cout << "Creating combo boxes" << std::endl;
+    //std::cout << "Creating combo boxes" << std::endl;
 
 
     inputSelector = new ComboBox();
@@ -270,7 +270,7 @@ DetectorInterface::DetectorInterface(PhaseDetector* pd, Colour c, int id) :
     gateSelector->addItem("-",1);
     gateSelector->addListener(this);
 
-    std::cout << "Populating combo boxes" << std::endl;
+    //std::cout << "Populating combo boxes" << std::endl;
 
 
     for (int i = 1; i < 9; i++)
@@ -294,11 +294,11 @@ DetectorInterface::DetectorInterface(PhaseDetector* pd, Colour c, int id) :
     addAndMakeVisible(outputSelector);
 
 
-    std::cout << "Updating channels" << std::endl;
+   // std::cout << "Updating channels" << std::endl;
 
     updateChannels(processor->getNumInputs());
 
-    std::cout << "Updating processor" << std::endl;
+   // std::cout << "Updating processor" << std::endl;
 
 
     processor->addModule();

--- a/Source/Processors/FileReader/BinaryFileSource/BinaryFileSource.cpp
+++ b/Source/Processors/FileReader/BinaryFileSource/BinaryFileSource.cpp
@@ -35,14 +35,26 @@ bool BinaryFileSource::Open(File file)
 {
 	m_jsonData = JSON::parse(file);
 	if (m_jsonData.isVoid())
+	{
+		std::cout << "Invalid JSON." << std::endl;
 		return false;
+	}
+		
 
 	if (m_jsonData["GUI version"].isVoid())
+	{
+		std::cout << "No GUI version." << std::endl;
 		return false;
+	}
+		
 	
 	var cont = m_jsonData["continuous"];
 	if (cont.isVoid() || cont.size() <= 0)
+	{
+		std::cout << "No continuous data found." << std::endl;
 		return false;
+	}
+		
 
 	m_rootPath = file.getParentDirectory();
 

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -542,7 +542,24 @@ void ProcessorGraph::updateViews(GenericProcessor* processor)
         processor = processor->getSourceNode();
         
         if (rootProcessor != nullptr)
+        {
             LOGDD("  Source: ", rootProcessor->getName());
+
+           
+        }
+
+        if (processor != nullptr)
+        {
+            if (processor->isSplitter())
+            {
+                SplitterEditor* sp = (SplitterEditor*)processor->getEditor();
+                GenericEditor* ed = rootProcessor->getEditor();
+
+                LOGDD("  Switching splitter to view: ", ed->getName())
+                sp->switchDest(sp->getPathForEditor(ed));
+            }
+        }
+           
     }
     
     processor = rootProcessor;

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -956,7 +956,7 @@ void ProcessorGraph::updateConnections()
                 }
             }
 
-            std::cout << std::endl;
+           // std::cout << std::endl;
 
             source->wasConnected = true;
 

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -739,7 +739,14 @@ void ProcessorGraph::restoreParameters()
         }
     }
     
-    // then update everyone's settings
+    // load source node parameters
+    for (auto p : rootNodes)
+    {
+        p->loadFromXml();
+        
+    }
+
+    // update everyone's settings
     for (auto p : rootNodes)
     {
         updateSettings(p, true);

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -163,12 +163,12 @@ GenericProcessor* ProcessorGraph::createProcessor(ProcessorDescription& descript
     LOGD("Creating processor with name: ", description.processorName);
     
     if (sourceNode != nullptr)
-        LOGD("Source node: ", sourceNode->getName());
+        LOGDD("Source node: ", sourceNode->getName());
     //else
      //   LOGD("No source node.");
     
     if (destNode != nullptr)
-        LOGD("Dest node: ", destNode->getName());
+        LOGDD("Dest node: ", destNode->getName());
     //else
     //    LOGD("No dest node.");
     
@@ -727,7 +727,7 @@ void ProcessorGraph::restoreParameters()
     
     isLoadingSignalChain = true;
 
-    LOGD("Restoring parameters for each processor...");
+    LOGDD("Restoring parameters for each processor...");
     
     // first connect the mergers
     for (auto p : getListOfProcessors())
@@ -884,7 +884,7 @@ void ProcessorGraph::updateConnections()
 
     for (int n = 0; n < rootNodes.size(); n++) // cycle through the tabs
     {
-        LOGD("Signal chain: ", n);
+        LOGDD("Signal chain: ", n);
         std::cout << std::endl;
 
         //GenericEditor* sourceEditor = (GenericEditor*) tabs[n]->getEditor();
@@ -892,7 +892,7 @@ void ProcessorGraph::updateConnections()
 
         while (source != nullptr)// && destEditor->isEnabled())
         {
-            LOGD("Source node: ", source->getName(), ".");
+            LOGDD("Source node: ", source->getName(), ".");
             GenericProcessor* dest = (GenericProcessor*) source->getDestNode();
 
             if (source->isReady())
@@ -945,7 +945,7 @@ void ProcessorGraph::updateConnections()
                 }
                 else
                 {
-                    LOGD("     No dest node.");
+                    LOGDD("     No dest node.");
                 }
             }
 
@@ -959,7 +959,7 @@ void ProcessorGraph::updateConnections()
                 // (but if it leads to a splitter that is still in the stack, it may still be
                 // used as a source for the unexplored branch.)
 
-                LOGD(dest->getName(), " ", dest->getNodeId(), " has already been connected.");
+                LOGDD(dest->getName(), " ", dest->getNodeId(), " has already been connected.");
                 dest = nullptr;
             }
 

--- a/Source/Processors/RecordNode/RecordEngine.cpp
+++ b/Source/Processors/RecordNode/RecordEngine.cpp
@@ -274,7 +274,7 @@ RecordEngine* RecordEngineManager::instantiateEngine()
 {
 	if (creator)
 	{
-		LOGD("Got creator");
+		LOGDD("Got creator");
 		return creator();
 	}
 	//Built-in engines

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -411,7 +411,7 @@ void RecordNode::updateSubprocessorMap()
 				for (int i = 0; i < count; i++)
 				{
 					dataChannelStates[sourceID][subProcIdx].push_back(CONTINUOUS_CHANNELS_ON_BY_DEFAULT);
-					dataChannelOrder[originalSize+i] = originalSize + i;
+					dataChannelOrder[ch + originalSize + i] = originalSize + i;
 				}
 			} //else if less, remove n channels from dataChannelStates
 			else if (count < dataChannelStates[sourceID][subProcIdx].size())
@@ -585,7 +585,7 @@ void RecordNode::startRecording()
 		int srcIndex = chan->getSourceNodeID();
 		int subIndex = chan->getSubProcessorIdx();
 
-		//LOGD("Channel: ", ch, " Source Node: ", srcIndex, " Sub Index: ", subIndex, " Order: ", dataChannelOrder[ch]);
+		LOGDD("Channel: ", ch, " Source Node: ", srcIndex, " Sub Index: ", subIndex, " Order: ", dataChannelOrder[ch]);
 
 		if (dataChannelStates[srcIndex][subIndex][dataChannelOrder[ch]])
 		{

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -331,6 +331,7 @@ void RecordNode::updateChannelStates(int srcIndex, int subProcIdx, std::vector<b
 // called by updateSettings (could be refactored)
 void RecordNode::updateSubprocessorMap()
 {
+	//std::cout << "UPDATE SUBPROCESSOR MAP" << std::endl;
 
 	bool refreshEditor = false;
     
@@ -379,14 +380,23 @@ void RecordNode::updateSubprocessorMap()
             {
                 dataChannelStates[sourceID][dataChannelArray[ch]->getSubProcessorIdx()].push_back(CONTINUOUS_CHANNELS_ON_BY_DEFAULT);
                 dataChannelOrder[ch] = orderInSubprocessor++;
+
+				//std::cout << " Channel " << ch << ", " << " order: " << dataChannelOrder[ch] << ", record state: " << dataChannelStates[sourceID][subProcIdx].back() << std::endl;
+
+
                 ch++;
+
+
             }
 			refreshEditor = true;
+
+
         }
         else
 		{
 			// check if channel count has changed for existing source
 			int count = 0;
+			int originalSize = dataChannelStates[sourceID][subProcIdx].size();
 
 			for (int i = 0; i < dataChannelArray.size(); i++)
 			{
@@ -394,12 +404,14 @@ void RecordNode::updateSubprocessorMap()
 					count++;
 			}
 			//If channel count is greater, add new channels to dataChannelStates
-			if (count > dataChannelStates[sourceID][subProcIdx].size())
+			if (count > originalSize)
 			{
 				count = count - dataChannelStates[sourceID][subProcIdx].size();
-				for (int i=0; i<count; i++)
+
+				for (int i = 0; i < count; i++)
 				{
 					dataChannelStates[sourceID][subProcIdx].push_back(CONTINUOUS_CHANNELS_ON_BY_DEFAULT);
+					dataChannelOrder[originalSize+i] = originalSize + i;
 				}
 			} //else if less, remove n channels from dataChannelStates
 			else if (count < dataChannelStates[sourceID][subProcIdx].size())
@@ -414,8 +426,13 @@ void RecordNode::updateSubprocessorMap()
 			{
 				//else do nothing
 			}
+
 			ch += count;
+
+			//std::cout << " Channel " << ch << " record state: " << dataChannelStates[sourceID][subProcIdx].back() << std::endl;
 		}
+
+		
         
     }
 
@@ -568,13 +585,15 @@ void RecordNode::startRecording()
 		int srcIndex = chan->getSourceNodeID();
 		int subIndex = chan->getSubProcessorIdx();
 
-		LOGDD("Channel: ", ch, " Source Node: ", srcIndex, " Sub Index: ", subIndex);
+		//LOGD("Channel: ", ch, " Source Node: ", srcIndex, " Sub Index: ", subIndex, " Order: ", dataChannelOrder[ch]);
 
 		if (dataChannelStates[srcIndex][subIndex][dataChannelOrder[ch]])
 		{
 
 			int chanOrderInProcessor = subIndex * dataChannelStates[srcIndex][subIndex].size() + dataChannelOrder[ch];
 			channelMap.add(ch);
+
+			//LOGD("  RECORD!");
 
 			//TODO: This logic will not work after a channel mapper with channels mapped from different subprocessors!
 			if (chan->getSourceNodeID() != lastProcessor || chan->getSubProcessorIdx() != lastSubProcessor)

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -341,7 +341,7 @@ void RecordNode::updateSubprocessorMap()
 	int originalChannelCount = numChannels;
     int ch = 0;
 
-    while (ch < dataChannelArray.size())
+    while (ch < dataChannelArray.size()) 
     {
         
         DataChannel* chan = dataChannelArray[ch];
@@ -390,7 +390,7 @@ void RecordNode::updateSubprocessorMap()
             }
 			refreshEditor = true;
 
-
+			LOGDD("RecordNode found ", orderInSubprocessor, " channels in ", sourceID, ".", subProcIdx);
         }
         else
 		{
@@ -400,24 +400,27 @@ void RecordNode::updateSubprocessorMap()
 
 			for (int i = 0; i < dataChannelArray.size(); i++)
 			{
+
+				//std::cout << "Channel " << i << ": " << dataChannelArray[i]->getSourceNodeID() << "." << dataChannelArray[i]->getSubProcessorIdx() << std::endl;
 				if (dataChannelArray[i]->getSourceNodeID() == sourceID && dataChannelArray[i]->getSubProcessorIdx() == subProcIdx)
+				{
+					dataChannelOrder[ch + count] = count;
 					count++;
+				}
+					
 			}
 			//If channel count is greater, add new channels to dataChannelStates
 			if (count > originalSize)
 			{
-				count = count - dataChannelStates[sourceID][subProcIdx].size();
-
-				for (int i = 0; i < count; i++)
+				for (int i = 0; i < count - originalSize; i++)
 				{
 					dataChannelStates[sourceID][subProcIdx].push_back(CONTINUOUS_CHANNELS_ON_BY_DEFAULT);
-					dataChannelOrder[ch + originalSize + i] = originalSize + i;
+					
 				}
 			} //else if less, remove n channels from dataChannelStates
 			else if (count < dataChannelStates[sourceID][subProcIdx].size())
 			{
-				count = dataChannelStates[sourceID][subProcIdx].size() - count;
-				for (int i=0; i<count; i++)
+				for (int i = 0; i < originalSize - count; i++)
 				{
 					dataChannelStates[sourceID][subProcIdx].pop_back();
 				}
@@ -426,6 +429,8 @@ void RecordNode::updateSubprocessorMap()
 			{
 				//else do nothing
 			}
+
+			LOGDD("RecordNode found ", count, " channels in ", sourceID, ".", subProcIdx);
 
 			ch += count;
 

--- a/Source/Processors/RecordNode/RecordNodeEditor.cpp
+++ b/Source/Processors/RecordNode/RecordNodeEditor.cpp
@@ -181,6 +181,7 @@ void RecordNodeEditor::loadCustomParameters(XmlElement* xml)
 			eventRecord->setToggleState((bool)(xmlNode->getStringAttribute("recordEvents").getIntValue()), juce::NotificationType::sendNotification);
 			spikeRecord->setToggleState((bool)(xmlNode->getStringAttribute("recordSpikes").getIntValue()), juce::NotificationType::sendNotification);
 
+			//std::cout << "Loading RecordNode settings" << std::endl;
 
 			forEachXmlChildElement(*xmlNode, subNode)
 			{
@@ -203,6 +204,7 @@ void RecordNodeEditor::loadCustomParameters(XmlElement* xml)
 
 						for (int ch = 0; ch < recordNode->dataChannelStates[srcID][subIdx].size(); ch++)
 						{
+							//std::cout << "Setting channel " << ch << " to " << recordStates->getIntAttribute("CH" + String(ch)) << std::endl;
 							recordNode->dataChannelStates[srcID][subIdx][ch] = recordStates->getIntAttribute("CH" + String(ch));
 						}
 

--- a/Source/Processors/RecordNode/RecordNodeEditor.cpp
+++ b/Source/Processors/RecordNode/RecordNodeEditor.cpp
@@ -204,7 +204,7 @@ void RecordNodeEditor::loadCustomParameters(XmlElement* xml)
 
 						for (int ch = 0; ch < recordNode->dataChannelStates[srcID][subIdx].size(); ch++)
 						{
-							//std::cout << "Setting channel " << ch << " to " << recordStates->getIntAttribute("CH" + String(ch)) << std::endl;
+							//std::cout << "Setting channel " << ch << " : " << srcID << " : " << subIdx << " to " << recordStates->getIntAttribute("CH" + String(ch)) << std::endl;
 							recordNode->dataChannelStates[srcID][subIdx][ch] = recordStates->getIntAttribute("CH" + String(ch));
 						}
 

--- a/Source/Processors/Splitter/Splitter.cpp
+++ b/Source/Processors/Splitter/Splitter.cpp
@@ -68,13 +68,13 @@ void Splitter::setSplitterDestNode(GenericProcessor* dn)
 
     if (activePath == 0)
     {
-        LOGD("Setting destination node A.");
+        LOGDD("Setting destination node A.");
         destNodeA = dn;
     }
     else
     {
         destNodeB = dn;
-        LOGD("Setting destination node B.");
+        LOGDD("Setting destination node B.");
 
     }
 }
@@ -89,12 +89,12 @@ void Splitter::switchIO(int destNum)
     if (destNum == 0)
     {
         destNode = destNodeA;
-//LOGDD("Dest node: ", getDestNode());
+        LOGDD("Dest node: ", getDestNode(0));
     }
     else
     {
         destNode = destNodeB;
-//LOGDD("Dest node: ", getDestNode());
+        LOGDD("Dest node: ", getDestNode(1));
     }
 
     // getEditorViewport()->makeEditorVisible(getEditor(), false);

--- a/Source/Processors/Splitter/SplitterEditor.cpp
+++ b/Source/Processors/Splitter/SplitterEditor.cpp
@@ -145,8 +145,14 @@ int SplitterEditor::getPathForEditor(GenericEditor* editor)
     {
         if (processor->getDestNode(pathNum) != nullptr)
         {
+            LOGDD(" PATH ", pathNum, " editor: ", processor->getDestNode(pathNum)->getEditor()->getName());
+
             if (processor->getDestNode(pathNum)->getEditor() == editor)
-                return processor->getPath();
+            {
+                LOGDD(" MATCHING PATH: ", pathNum);
+                return pathNum;
+            }
+                
         }
     }
 

--- a/Source/UI/DataViewport.cpp
+++ b/Source/UI/DataViewport.cpp
@@ -74,7 +74,7 @@ int DataViewport::addTabToDataViewport(String name, Component* component, Generi
 
     editorArray.add(editor);
 
-    LOGD("Adding tab with index ", tabIndex);
+    LOGDD("Adding tab with index ", tabIndex);
 
     setCurrentTabIndex(tabArray.size()-1);
 

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -66,7 +66,7 @@ EditorViewport::EditorViewport(SignalChainTabComponent* s_)
 
 EditorViewport::~EditorViewport()
 {
-
+    copyBuffer.clear();
 }
 
 void EditorViewport::resized()
@@ -598,6 +598,7 @@ bool EditorViewport::canPaste()
 
 void EditorViewport::copy(Array<XmlElement*> copyInfo)
 {
+
     copyBuffer.clear();
     copyBuffer.addArray(copyInfo);
     

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -624,7 +624,7 @@ void EditorViewport::paste()
                 
         }
         
-        LOGD("Insertion point: ", insertionPoint);
+        LOGDD("Insertion point: ", insertionPoint);
 
         if (foundSelected)
         {
@@ -1065,7 +1065,7 @@ void SignalChainTabButton::clicked()
 {
     if (getToggleState())
     {
-        LOGD("Tab button clicked: ", num);
+        LOGDD("Tab button clicked: ", num);
         
         AccessClass::getProcessorGraph()->viewSignalChain(num);
     }
@@ -1252,14 +1252,14 @@ void SignalChainTabComponent::buttonClicked(Button* button)
 {
     if (button == upButton)
     {
-        LOGD("Up button pressed.");
+        LOGDD("Up button pressed.");
 
         if (topTab > 0)
             topTab -= 1;
     }
     else if (button == downButton)
     {
-        LOGD("Down button pressed.");
+        LOGDD("Down button pressed.");
         
         if (numberOfTabs > 4)
         {
@@ -1722,16 +1722,16 @@ const String EditorViewport::loadStateFromXml(XmlElement* xml)
                 {
                     int processorNum = processor->getIntAttribute("number");
 
-                    LOGD("SWITCHING number ", processorNum);
+                    LOGDD("SWITCHING number ", processorNum);
 
                     for (int n = 0; n < splitPoints.size(); n++)
                     {
 
-                        LOGD("Trying split point ", n,  ", load order: ", splitPoints[n]->loadOrder);
+                        LOGDD("Trying split point ", n,  ", load order: ", splitPoints[n]->loadOrder);
 
                         if (splitPoints[n]->loadOrder == processorNum)
                         {
-                            LOGD("Switching splitter destination.");
+                            LOGDD("Switching splitter destination.");
                             SplitterEditor* editor = (SplitterEditor*) splitPoints[n]->getEditor();
                             editor->switchDest(1);
                             AccessClass::getProcessorGraph()->updateViews(splitPoints[n]);

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -1727,7 +1727,7 @@ const String EditorViewport::loadStateFromXml(XmlElement* xml)
                     for (int n = 0; n < splitPoints.size(); n++)
                     {
 
-                        LOGD("Trying split point ", ", load order: ", splitPoints[n]->loadOrder);
+                        LOGD("Trying split point ", n,  ", load order: ", splitPoints[n]->loadOrder);
 
                         if (splitPoints[n]->loadOrder == processorNum)
                         {
@@ -1735,6 +1735,12 @@ const String EditorViewport::loadStateFromXml(XmlElement* xml)
                             SplitterEditor* editor = (SplitterEditor*) splitPoints[n]->getEditor();
                             editor->switchDest(1);
                             AccessClass::getProcessorGraph()->updateViews(splitPoints[n]);
+
+                            /*std::cout << "Editor array: " << std::endl;
+                            for (auto ed : editorArray)
+                            {
+                                std::cout << " " << ed->getName() << std::endl;
+                            }*/
                             
                             splitPoints.remove(n);
                         }

--- a/Source/UI/EditorViewportActions.cpp
+++ b/Source/UI/EditorViewportActions.cpp
@@ -59,7 +59,7 @@ AddProcessor::~AddProcessor()
    
 bool AddProcessor::perform()
 {
-    LOGD("Performing add processor.");
+    LOGDD("Performing add processor.");
     GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(sourceNodeId);
     
     GenericProcessor* destProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(destNodeId);
@@ -88,7 +88,7 @@ bool AddProcessor::perform()
 
 bool AddProcessor::undo()
 {
-    LOGD("Undoing add processor.");
+    LOGDD("Undoing add processor.");
     Array<GenericProcessor*> processorToDelete;
     
     processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(nodeId);
@@ -132,7 +132,7 @@ DeleteProcessor::~DeleteProcessor()
    
 bool DeleteProcessor::perform()
 {
-    LOGD("Peforming delete processor.");
+    LOGDD("Peforming delete processor.");
     Array<GenericProcessor*> processorToDelete;
     
     processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(nodeId);
@@ -145,7 +145,7 @@ bool DeleteProcessor::perform()
 
 bool DeleteProcessor::undo()
 {
-    LOGD("Undoing delete processor.");
+    LOGDD("Undoing delete processor.");
     ProcessorDescription description = editorViewport->getDescriptionFromXml(settings, false, false);
 
     GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(sourceNodeId);
@@ -219,7 +219,7 @@ MoveProcessor::~MoveProcessor()
    
 bool MoveProcessor::perform()
 {
-    LOGD("Peforming move processor.");
+    LOGDD("Peforming move processor.");
     
     GenericProcessor* processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(nodeId);
     
@@ -239,7 +239,7 @@ bool MoveProcessor::undo()
 {
     GenericProcessor* processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(nodeId);
     
-    LOGD("Undoing move processor.");
+    LOGDD("Undoing move processor.");
     GenericProcessor* sourceProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(originalSourceNodeId);
     
     GenericProcessor* destProcessor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(originalDestNodeId);
@@ -278,7 +278,7 @@ ClearSignalChain::~ClearSignalChain()
     
 bool ClearSignalChain::perform()
 {
-    LOGD("Performing clear signal chain.");
+    LOGDD("Performing clear signal chain.");
     AccessClass::getProcessorGraph()->clearSignalChain();
     
     return true;
@@ -286,7 +286,7 @@ bool ClearSignalChain::perform()
 
 bool ClearSignalChain::undo()
 {
-    LOGD("Undoing clear signal chain.");
+    LOGDD("Undoing clear signal chain.");
     editorViewport->loadStateFromXml(settings);
     
     return true;
@@ -311,7 +311,7 @@ LoadSignalChain::~LoadSignalChain()
     
 bool LoadSignalChain::perform()
 {
-    LOGD("Performing load signal chain.");
+    LOGDD("Performing load signal chain.");
     error = editorViewport->loadStateFromXml(newSettings);
     
     return true;
@@ -319,7 +319,7 @@ bool LoadSignalChain::perform()
 
 bool LoadSignalChain::undo()
 {
-    LOGD("Undoing load signal chain.");
+    LOGDD("Undoing load signal chain.");
     error = editorViewport->loadStateFromXml(oldSettings);
     
     return true;
@@ -358,16 +358,16 @@ bool LoadPluginSettings::perform()
     
     if (oldPluginType.equalsIgnoreCase(newPluginType))
     {
-        LOGD("Performing load plugin settings.");
-        LOGD("Getting processor");
+        LOGDD("Performing load plugin settings.");
+        LOGDD("Getting processor");
         GenericProcessor* processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(processorId);
         
         
-        LOGD("Updating NodeId");
+        LOGDD("Updating NodeId");
         newSettings->setAttribute("NodeId", processorId);
-        LOGD("Setting parameters");
+        LOGDD("Setting parameters");
         processor->parametersAsXml = newSettings;
-        LOGD("Loading parameters");
+        LOGDD("Loading parameters");
         processor->loadCustomParametersFromXml();
 
         // need to replicate internals of loadFromXml(), because this can't be called twice for the
@@ -412,7 +412,7 @@ bool LoadPluginSettings::perform()
 
 bool LoadPluginSettings::undo()
 {
-    LOGD("Undoing load plugin settings.");
+    LOGDD("Undoing load plugin settings.");
     GenericProcessor* processor = AccessClass::getProcessorGraph()->getProcessorWithNodeId(processorId);
     
     processor->parametersAsXml = oldSettings;


### PR DESCRIPTION
### Summary of changes

#### LFP Viewer
- Improve drawing for low-sample-rate sources (<5 kHz)
- Minimize size of `screenBuffer` and `displayBuffer` to lower memory footprint
- Improve performance of triggered display mode

#### Bug fixes
- Fix bug when loading signal chains with multiple splitters. Closes #436 
- Fix record status bug with Rhythm FPGA / Intan Rec. Controller ADC channels. Closes #438 
