### PR TITLE
Disconnect MessageCenter when RecordNode disabled

### DIFF
--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -564,6 +564,11 @@ bool RecordNode::enable()
 
 }
 
+bool RecordNode::disable()
+{
+	disconnectMessageCenter();
+}
+
 // called by GenericProcessor::setRecording()
 void RecordNode::startRecording()
 {
@@ -702,8 +707,6 @@ void RecordNode::stopRecording()
 	}
 
 	eventMonitor->displayStatus();
-
-	disconnectMessageCenter();
 
 }
 

--- a/Source/Processors/RecordNode/RecordNode.h
+++ b/Source/Processors/RecordNode/RecordNode.h
@@ -81,6 +81,7 @@ public:
 
 	void updateSettings() override;
     bool enable() override;
+	bool disable() override;
 	int getNumSubProcessors() const override;
 
 	void prepareToPlay(double sampleRate, int estimatedSamplesPerBlock);


### PR DESCRIPTION
Disconnect the ```MessageCenter``` only when ```RecordNode``` stops acquisition instead of when ```RecordNode``` stops recording. This allows the ```MessageCenter``` to stay connected between recordings. 