### PR TITLE
Reduce number of warnings for MSVC builds

### DIFF
--- a/JuceLibraryCode/AppConfig.h
+++ b/JuceLibraryCode/AppConfig.h
@@ -19,6 +19,12 @@
 
 // (You can add your own code in this section, and the Introjucer will not overwrite it)
 
+#ifdef _MSC_VER
+//class 'type1' needs to have dll-interface to be used by clients of class 'type2'
+//non-DLL-interface class 'class_1' used as base for DLL-interface class 'class_2'
+#pragma warning (disable : 4251 4275)
+#endif
+
 // [END_USER_CODE_SECTION]
 
 //==============================================================================

--- a/Source/Processors/Serial/ofConstants.h
+++ b/Source/Processors/Serial/ofConstants.h
@@ -40,7 +40,7 @@
 #endif
 #define WIN32_LEAN_AND_MEAN
 
-#if (_MSC_VER)
+#if (_MSC_VER) && !defined(NOMINMAX)
 #define NOMINMAX
 //http://stackoverflow.com/questions/1904635/warning-c4003-and-errors-c2589-and-c2059-on-x-stdnumeric-limitsintmax
 #endif


### PR DESCRIPTION
Remove tens of thousands of uninteresting warnings wrt use of dllexport.

This makes it somewhat easier to see warnings from the actual code.