### PR TITLE
Fix nullptr dereferencing when plugin not found

### DIFF
--- a/Source/Processors/PlaceholderProcessor/PlaceholderProcessor.cpp
+++ b/Source/Processors/PlaceholderProcessor/PlaceholderProcessor.cpp
@@ -33,6 +33,8 @@ PlaceholderProcessor::PlaceholderProcessor (String pName, String lName, int lVer
     , m_isSourceProcessor   (pSource)
     , m_isSinkProcessor     (pSink)
 {
+    // We're used to express 'no such processor' so disable by default.
+    isEnabled = false;
 }
 
 

--- a/Source/Processors/PlaceholderProcessor/PlaceholderProcessorEditor.cpp
+++ b/Source/Processors/PlaceholderProcessor/PlaceholderProcessorEditor.cpp
@@ -39,7 +39,6 @@ PlaceholderProcessorEditor::PlaceholderProcessorEditor(GenericProcessor* parentN
 	addAndMakeVisible(nameLabel);
 
 	desiredWidth = 180;
-	setEnabledState(false);
 }
 
 PlaceholderProcessorEditor::~PlaceholderProcessorEditor()


### PR DESCRIPTION
Don't call setEnabledState() in the editor's constructor because it
forwards to the processor's setEnabledState() which in turn calls the
editor's enable(), but editor is still nullptr at that point since
it's being constructed.
Doesn't change the initial intent of creating the plugin in a disabled
state but fixes crash when loading configurations which refer to
non-existing plugins for instance.