### PR TITLE
Fixing some bugs responsible for seemingly random crashes

### DIFF
--- a/Plugins/BasicSpikeDisplay/SpikeDetector/SpikeDetector.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDetector/SpikeDetector.cpp
@@ -308,7 +308,7 @@ void SpikeDetector::setChannelThreshold (int electrodeNum, int channelNum, float
     currentElectrode = electrodeNum;
     currentChannelIndex = channelNum;
 
-    std::cout << "Setting electrode " << electrodeNum << " channel threshold " << channelNum << " to " << thresh << std::endl;
+    //std::cout << "Setting electrode " << electrodeNum << " channel threshold " << channelNum << " to " //<< thresh << std::endl;
 
     setParameter (99, thresh);
 }

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
@@ -157,22 +157,22 @@ void SpikeDisplayCanvas::processSpikeEvents()
 
 }
 
-bool SpikeDisplayCanvas::keyPressed(const KeyPress& key)
-{
+//bool SpikeDisplayCanvas::keyPressed(const KeyPress& key)
+//{
 
-    KeyPress c = KeyPress::createFromDescription("c");
+    //KeyPress c = KeyPress::createFromDescription("c");
 
-    if (key.isKeyCode(c.getKeyCode())) // C
-    {
-        spikeDisplay->clear();
+    //if (key.isKeyCode(c.getKeyCode())) // C
+    //{
+     //   spikeDisplay->clear();//
 
-        std::cout << "Clearing display" << std::endl;
-        return true;
-    }
+     //   std::cout << "Clearing display" << std::endl;
+     //   return true;
+    //}
 
-    return false;
+    //return false;
 
-}
+//}
 
 void SpikeDisplayCanvas::buttonClicked(Button* button)
 {

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
@@ -968,11 +968,11 @@ void WaveAxes::plotSpike(const SpikeEvent* s, Graphics& g)
     int dataSize =s->getChannelInfo()->getDataSize();
     
     // prevent crashes when acquisition is not active,
-    // or immediately after acquisition
-    if (((sampIdx + nSamples) > dataSize) ||
-        (nSamples < 0) ||
-        (dataSize > 500) ||
-        (dataSize < 0))
+    // or immediately after acquisition starts
+    if (   (dataSize < 1)
+        || (dataSize > 500)
+        || (sampIdx + nSamples > dataSize)
+        || (nSamples < 0))
     {
         return;
     }

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.cpp
@@ -91,8 +91,11 @@ void SpikeDisplayCanvas::update()
     int nPlots = processor->getNumElectrodes();
     processor->removeSpikePlots();
 
+    //std::cout << "Adding new plots" << std::endl;
     if (nPlots != spikeDisplay->getNumPlots())
     {
+        
+        //std::cout << "  Different number detected" << std::endl;
         spikeDisplay->removePlots();
 
         for (int i = 0; i < nPlots; i++)
@@ -104,14 +107,16 @@ void SpikeDisplayCanvas::update()
     }
     else
     {
+        //std::cout << "Same number detected" << std::endl;
         for (int i = 0; i < nPlots; i++)
         {
             processor->addSpikePlotForElectrode(spikeDisplay->getSpikePlot(i), i);
         }
     }
 
+    //std::cout << "Resized" << std::endl;
     spikeDisplay->resized();
-    spikeDisplay->repaint();
+    
 }
 
 
@@ -934,10 +939,8 @@ void WaveAxes::paint(Graphics& g)
 
     }
 
-    
     plotSpike(spikeBuffer[spikeIndex], g);
-
-
+    
     spikesReceivedSinceLastRedraw = 0;
 
 }
@@ -960,8 +963,20 @@ void WaveAxes::plotSpike(const SpikeEvent* s, Graphics& g)
 
     // type corresponds to channel so we need to calculate the starting
     // sample based upon which channel is getting plotted
-    int sampIdx = nSamples*type; //spikeBuffer[0].nSamples * type; //
-
+    int sampIdx = nSamples*type; //spikeBuffer[0].nSamples * type;
+    
+    int dataSize =s->getChannelInfo()->getDataSize();
+    
+    // prevent crashes when acquisition is not active,
+    // or immediately after acquisition
+    if (((sampIdx + nSamples) > dataSize) ||
+        (nSamples < 0) ||
+        (dataSize > 500) ||
+        (dataSize < 0))
+    {
+        return;
+    }
+        
     int dSamples = 1;
 
     float x = 0.0f;
@@ -970,8 +985,6 @@ void WaveAxes::plotSpike(const SpikeEvent* s, Graphics& g)
 	for (int i = 0; i < nSamples - 1; i++)
 	{
 		//std::cout << s.data[sampIdx] << std::endl;
-
-
 
 		float s1, s2;
 
@@ -990,9 +1003,6 @@ void WaveAxes::plotSpike(const SpikeEvent* s, Graphics& g)
 			s1,
 			x + dx,
 			s2);
-
-
-
 
 		sampIdx += dSamples;
 		x += dx;

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.h
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayCanvas.h
@@ -91,7 +91,7 @@ public:
 
     void resized();
 
-    bool keyPressed(const KeyPress& key);
+    //bool keyPressed(const KeyPress& key);
 
     void buttonClicked(Button* button);
 

--- a/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayNode.cpp
+++ b/Plugins/BasicSpikeDisplay/SpikeDisplayNode/SpikeDisplayNode.cpp
@@ -51,12 +51,11 @@ AudioProcessorEditor* SpikeDisplayNode::createEditor()
 
 void SpikeDisplayNode::updateSettings()
 {
-    //std::cout << "Setting num inputs on SpikeDisplayNode to " << getNumInputs() << std::endl;
-
     electrodes.clear();
+    
 	for (int i = 0; i < spikeChannelArray.size(); ++i)
 	{
-
+        
 		Electrode* elec = new Electrode();
 		elec->numChannels = spikeChannelArray[i]->getNumChannels();
 		elec->bitVolts = spikeChannelArray[i]->getChannelBitVolts(0); //lets assume all channels have the same bitvolts
@@ -78,7 +77,6 @@ void SpikeDisplayNode::updateSettings()
 
 bool SpikeDisplayNode::enable()
 {
-    std::cout << "SpikeDisplayNode::enable()" << std::endl;
     SpikeDisplayEditor* editor = (SpikeDisplayEditor*) getEditor();
 
 	//CoreServices::RecordNode::registerSpikeSource(this);
@@ -95,7 +93,6 @@ bool SpikeDisplayNode::enable()
 
 bool SpikeDisplayNode::disable()
 {
-    std::cout << "SpikeDisplayNode disabled!" << std::endl;
 
     SpikeDisplayEditor* editor = (SpikeDisplayEditor*) getEditor();
     editor->disable();

--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -177,10 +177,14 @@ void GenericProcessor::setSourceNode(GenericProcessor* sn)
 void GenericProcessor::setDestNode(GenericProcessor* dn)
 {
 	
-    if (this->isSplitter())
+    if (isSplitter())
+    {
         setSplitterDestNode(dn);
+    }
     else
+    {
         destNode = dn;
+    }
 
 }
 

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -538,16 +538,20 @@ void ProcessorGraph::updateViews(GenericProcessor* processor)
     if (processor != nullptr)
         LOGDD("Processor to view: ", processor->getName());
     
-    while (processor != nullptr)
+    for (int i = 0; i < 99; i++)
     {
+        if (processor == nullptr)
+            break;
+        
         rootProcessor = processor;
         processor = processor->getSourceNode();
+        
+        if (rootProcessor == processor)
+            break;
         
         if (rootProcessor != nullptr)
         {
             LOGDD("  Source: ", rootProcessor->getName());
-
-           
         }
 
         if (processor != nullptr)
@@ -561,13 +565,15 @@ void ProcessorGraph::updateViews(GenericProcessor* processor)
                 sp->switchDest(sp->getPathForEditor(ed));
             }
         }
-           
     }
     
     processor = rootProcessor;
 
-    while (processor != nullptr)
+    for (int i = 0; i < 99; i++)
     {
+        if (processor == nullptr)
+            break;
+        
         editorArray.add(processor->getEditor());
         
         LOGDD(" Adding ", processor->getName(), " to editor array.");
@@ -586,6 +592,7 @@ void ProcessorGraph::updateViews(GenericProcessor* processor)
         }
         
         processor = processor->getDestNode();
+        
     }
     
     AccessClass::getEditorViewport()->updateVisibleEditors(editorArray,

--- a/Source/Processors/Splitter/Splitter.cpp
+++ b/Source/Processors/Splitter/Splitter.cpp
@@ -89,12 +89,12 @@ void Splitter::switchIO(int destNum)
     if (destNum == 0)
     {
         destNode = destNodeA;
-        LOGDD("Dest node: ", getDestNode(0));
+        LOGDD("   Dest node: ", getDestNode(0));
     }
     else
     {
         destNode = destNodeB;
-        LOGDD("Dest node: ", getDestNode(1));
+        LOGDD("   Dest node: ", getDestNode(1));
     }
 
     // getEditorViewport()->makeEditorVisible(getEditor(), false);

--- a/Source/Processors/Splitter/SplitterEditor.cpp
+++ b/Source/Processors/Splitter/SplitterEditor.cpp
@@ -199,4 +199,5 @@ void SplitterEditor::switchDest()
         pipelineSelectorA->setToggleState(false, dontSendNotification);
 
     }
+    
 }

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -981,6 +981,19 @@ void EditorViewport::mouseUp(const MouseEvent& e)
 
         somethingIsBeingDraggedOver = false;
         componentWantsToMove = false;
+        
+        if (!getScreenBounds().contains(e.getScreenPosition()))
+        {
+            undoManager.beginNewTransaction();
+            
+             DeleteProcessor* action = new DeleteProcessor(
+                                                       editorArray           [indexOfMovingComponent]->getProcessor(),
+                                                           this);
+             
+             undoManager.perform(action);
+            
+            return;
+        }
 
         if (indexOfMovingComponent != insertionPoint)
         {
@@ -1735,12 +1748,6 @@ const String EditorViewport::loadStateFromXml(XmlElement* xml)
                             SplitterEditor* editor = (SplitterEditor*) splitPoints[n]->getEditor();
                             editor->switchDest(1);
                             AccessClass::getProcessorGraph()->updateViews(splitPoints[n]);
-
-                            /*std::cout << "Editor array: " << std::endl;
-                            for (auto ed : editorArray)
-                            {
-                                std::cout << " " << ed->getName() << std::endl;
-                            }*/
                             
                             splitPoints.remove(n);
                         }
@@ -1796,7 +1803,7 @@ void EditorViewport::deleteSelectedProcessors()
     
     for (auto editor : editors)
     {
-        std::cout << "Editor name: " << editor->getName() << std::endl;
+        //std::cout << "Editor name: " << editor->getName() << std::endl;
         if (editor->getSelectionState())
         {
             DeleteProcessor* action = new DeleteProcessor(editor->getProcessor(), this);


### PR DESCRIPTION
Fixes a crash that's happening whenever a key press event is sent to the Spike Viewer. Pressing "c" no longer clears the active spikes, but this can also be accomplished by pressing the "clear plots" button.