### PR TITLE
Bugfixes

### DIFF
--- a/Source/Processors/Editors/VisualizerEditor.cpp
+++ b/Source/Processors/Editors/VisualizerEditor.cpp
@@ -300,6 +300,13 @@ void VisualizerEditor::saveCustomParameters (XmlElement* xml)
     {
         canvas->saveVisualizerParameters (xml);
     }
+    else
+    {
+        tabSelector->setToggleState(true, sendNotification);
+        canvas->saveVisualizerParameters(xml);
+        tabSelector->setToggleState(false, sendNotification);
+    }
+
 }
 
 

--- a/Source/Processors/RecordNode/RecordNodeEditor.cpp
+++ b/Source/Processors/RecordNode/RecordNodeEditor.cpp
@@ -717,7 +717,9 @@ void FifoMonitor::timerCallback()
 	if (srcID < 0) /* Disk space monitor */
 	{
 		float diskSpace = (float)recordNode->getDataDirectory().getBytesFreeOnVolume() / recordNode->getDataDirectory().getVolumeTotalSize();
-		setFillPercentage(1.0f - diskSpace);
+
+		if (diskSpace > 0)
+			setFillPercentage(1.0f - diskSpace);
 	}
 	else /* Subprocessor monitor */
 	{


### PR DESCRIPTION
Fixes VisualizerEditors not saving their editor state if a canvas/interface has not yet been opened. 
Fixes RecordNode disk space monitor showing a negative value if the record path does not exist. 