### PR TITLE
Update HTTP directory field

### DIFF
--- a/Source/CoreServices.cpp
+++ b/Source/CoreServices.cpp
@@ -142,9 +142,14 @@ namespace CoreServices
 		return getControlPanel()->getRecordingParentDirectory();
 	}
 
-	void setRecordingDirectoryBasename(String dir)
+	void setRecordingDirectoryBaseText(String text)
 	{
-		getControlPanel()->setRecordingDirectoryBasename(dir);
+		getControlPanel()->setRecordingDirectoryBaseText(text);
+	}
+
+	String getRecordingDirectoryBaseText()
+	{
+		return getControlPanel()->getRecordingDirectoryBaseText();
 	}
 
 	String getRecordingDirectoryName()

--- a/Source/CoreServices.h
+++ b/Source/CoreServices.h
@@ -106,8 +106,11 @@ PLUGIN_API void setRecordingParentDirectory(String dir);
 /** Returns the default recording directory.*/
 PLUGIN_API File getRecordingParentDirectory();
 
+/** Gets the basename for the recording directory (does not affect prepend/append text) */
+PLUGIN_API String getRecordingDirectoryBaseText();
+
 /** Sets new basename for the recording directory (does not affect prepend/append text) */
-PLUGIN_API void setRecordingDirectoryBasename(String dir);
+PLUGIN_API void setRecordingDirectoryBaseText(String text);
 
 /** Returns the full name of the current recording directory (empty string if none has started) */
 PLUGIN_API String getRecordingDirectoryName();

--- a/Source/UI/ControlPanel.cpp
+++ b/Source/UI/ControlPanel.cpp
@@ -1250,7 +1250,18 @@ void ControlPanel::setRecordingDirectoryAppendText(String text)
     }
 }
 
-void ControlPanel::setRecordingDirectoryBasename(String text)
+String ControlPanel::getRecordingDirectoryBaseText()
+{
+    for (auto& field : filenameFields) //loops in order through prepend, main, append 
+    {
+        if (field->type == FilenameFieldComponent::Type::MAIN)
+        {
+            return field->value;
+        }
+    }
+}
+
+void ControlPanel::setRecordingDirectoryBaseText(String text)
 {
     for (auto& field : filenameFields) //loops in order through prepend, main, append 
     {

--- a/Source/UI/ControlPanel.h
+++ b/Source/UI/ControlPanel.h
@@ -388,9 +388,12 @@ public:
     /** Returns the current parent recording diretory*/
     File getRecordingParentDirectory();
 
+    /** Gets the base name of the recording directory */
+    String getRecordingDirectoryBaseText();
+
     /** Sets the base name of the recording directory (overrides the auto-generated text,
         but not prepend or append text)*/
-    void setRecordingDirectoryBasename(String text);
+    void setRecordingDirectoryBaseText(String text);
 
     /** Gets the name of the current recording directory (including prepend and append text)
     

--- a/Source/Utils/OpenEphysHttpServer.h
+++ b/Source/Utils/OpenEphysHttpServer.h
@@ -717,7 +717,7 @@ private:
         
         (*ret)["parent_directory"] = CoreServices::getRecordingParentDirectory().getFullPathName().toStdString();
 
-        (*ret)["current_directory_name"] = CoreServices::getRecordingDirectoryName().toStdString();
+        (*ret)["base_text"] = CoreServices::getRecordingDirectoryName().toStdString();
 
         (*ret)["prepend_text"] = CoreServices::getRecordingDirectoryPrependText().toStdString();
 

--- a/Source/Utils/OpenEphysHttpServer.h
+++ b/Source/Utils/OpenEphysHttpServer.h
@@ -192,7 +192,7 @@ public:
                     std::string base_text = request_json["base_text"];
                     LOGD("Found 'base_text': ", base_text);
                     const MessageManagerLock mml;
-                    CoreServices::setRecordingDirectoryBasename(String(base_text));
+                    CoreServices::setRecordingDirectoryBaseText(String(base_text));
                 }
                 catch (json::exception& e) {
                     LOGD("'base_text' not specified'");
@@ -717,7 +717,7 @@ private:
         
         (*ret)["parent_directory"] = CoreServices::getRecordingParentDirectory().getFullPathName().toStdString();
 
-        (*ret)["base_text"] = CoreServices::getRecordingDirectoryName().toStdString();
+        (*ret)["base_text"] = CoreServices::getRecordingDirectoryBaseText().toStdString();
 
         (*ret)["prepend_text"] = CoreServices::getRecordingDirectoryPrependText().toStdString();
 


### PR DESCRIPTION
`base_text` looks like the correct var name

`current_directory_name` appears unused

[Fix directory naming via HTTPServer · open-ephys/plugin-GUI@626f50d · GitHub](https://github.com/open-ephys/plugin-GUI/commit/626f50dc8a082808a56783e1ae5ea47ee0e4dcf8#diff-cf1044d55166de06cac7f30258205bd55a4f80593c69c3809fa458c142c2c07dR193)