### PR TITLE
V0554 intan fixes

### DIFF
--- a/Plugins/IntanRecordingController/RHD2000Editor.cpp
+++ b/Plugins/IntanRecordingController/RHD2000Editor.cpp
@@ -590,7 +590,7 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
 	impedanceData->valid = false;
 
     // add headstage-specific controls (currently just an enable/disable button)
-    for (int i = 0; i < 8; i++)
+    for (int i = 0; i < INTAN_EDITOR_PORT_SLOTS; i++)
     {
         HeadstageOptionsInterface* hsOptions = new HeadstageOptionsInterface(board, this, i);
         headstageOptionsInterfaces.add(hsOptions);
@@ -834,7 +834,7 @@ void RHD2000Editor::buttonEvent(Button* button)
     {
         board->scanPorts();
 
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < INTAN_EDITOR_PORT_SLOTS; i++)
         {
             headstageOptionsInterfaces[i]->checkEnabledState();
         }

--- a/Plugins/IntanRecordingController/RHD2000Editor.cpp
+++ b/Plugins/IntanRecordingController/RHD2000Editor.cpp
@@ -572,7 +572,8 @@ void FPGAcanvas::updateImpedance(Array<int> streams, Array<int> channels, Array<
 
 /***********************************************************************/
 
-#define HS_WIDTH 70
+#define HS_WIDTH 90
+#define HS_PANEL_WIDTH (2*HS_WIDTH)
 
 RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
                              RHD2000Thread* board_,
@@ -581,7 +582,7 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
     : VisualizerEditor(parentNode, useDefaultParameterEditors), board(board_)
 {
     canvas = nullptr;
-	desiredWidth = 340 + HS_WIDTH;
+	desiredWidth = 270 + HS_PANEL_WIDTH;
     tabText = "FPGA";
     measureWhenRecording = false;
     saveImpedances = false;
@@ -595,18 +596,18 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
         HeadstageOptionsInterface* hsOptions = new HeadstageOptionsInterface(board, this, i);
         headstageOptionsInterfaces.add(hsOptions);
         addAndMakeVisible(hsOptions);
-		hsOptions->setBounds(3 + (i / 4)*HS_WIDTH, 28 + (i % 4) * 20, 70, 18);
+		hsOptions->setBounds(3 + (i / 4)*HS_WIDTH, 28 + (i % 4) * 20, 90, 18);
     }
 
     // add sample rate selection
     sampleRateInterface = new SampleRateInterface(board, this);
     addAndMakeVisible(sampleRateInterface);
-	sampleRateInterface->setBounds(80 + HS_WIDTH, 25, 110, 50);
+	sampleRateInterface->setBounds(10 + HS_PANEL_WIDTH, 25, 110, 50);
 
     // add Bandwidth selection
     bandwidthInterface = new BandwidthInterface(board, this);
     addAndMakeVisible(bandwidthInterface);
-	bandwidthInterface->setBounds(80 + HS_WIDTH, 58, 80, 50);
+	bandwidthInterface->setBounds(10 + HS_PANEL_WIDTH, 58, 80, 50);
 
     // add DSP selection
   //  dspInterface = new DSPInterface(board, this);
@@ -626,7 +627,7 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
         ElectrodeButton* button = new ElectrodeButton(-1);
         electrodeButtons.add(button);
 
-		button->setBounds(200 + i * 25 + HS_WIDTH, 40, 25, 15);
+		button->setBounds(130 + i * 25 + HS_PANEL_WIDTH, 40, 25, 15);
         button->setChannelNum(-1);
         button->setToggleState(false, dontSendNotification);
         button->setRadioGroupId(999);
@@ -645,7 +646,7 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
     }
 
     audioLabel = new Label("audio label", "Audio out");
-	audioLabel->setBounds(190 + HS_WIDTH, 25, 75, 15);
+	audioLabel->setBounds(120 + HS_PANEL_WIDTH, 25, 75, 15);
     audioLabel->setFont(Font("Small Text", 10, Font::plain));
     audioLabel->setColour(Label::textColourId, Colours::darkgrey);
     addAndMakeVisible(audioLabel);
@@ -653,11 +654,11 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
     // add HW audio parameter selection
     audioInterface = new AudioInterface(board, this);
     addAndMakeVisible(audioInterface);
-	audioInterface->setBounds(179 + HS_WIDTH, 58, 70, 50);
+	audioInterface->setBounds(109 + HS_PANEL_WIDTH, 58, 70, 50);
 
     adcButton = new UtilityButton("ADC 1-8", Font("Small Text", 13, Font::plain));
     adcButton->setRadius(3.0f);
-	adcButton->setBounds(179 + HS_WIDTH, 108, 70, 18);
+	adcButton->setBounds(109 + HS_PANEL_WIDTH, 108, 70, 18);
     adcButton->addListener(this);
     adcButton->setClickingTogglesState(true);
     adcButton->setTooltip("Enable/disable ADC channels");
@@ -666,7 +667,7 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
     // add DSP Offset Button
     dspoffsetButton = new UtilityButton("DSP", Font("Very Small Text", 13, Font::plain));
     dspoffsetButton->setRadius(3.0f); // sets the radius of the button's corners
-	dspoffsetButton->setBounds(80 + HS_WIDTH, 108, 30, 18); // sets the x position, y position, width, and height of the button
+	dspoffsetButton->setBounds(10 + HS_PANEL_WIDTH, 108, 30, 18); // sets the x position, y position, width, and height of the button
     dspoffsetButton->addListener(this);
     dspoffsetButton->setClickingTogglesState(true); // makes the button toggle its state when clicked
     dspoffsetButton->setTooltip("Enable/disable DSP offset removal");
@@ -676,17 +677,17 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
     // add DSP Frequency Selection field
     dspInterface = new DSPInterface(board, this);
     addAndMakeVisible(dspInterface);
-	dspInterface->setBounds(110 + HS_WIDTH, 108, 60, 50);
+	dspInterface->setBounds(40 + HS_PANEL_WIDTH, 108, 60, 50);
 
     ttlSettleLabel = new Label("TTL Settle","TTL Settle");
     ttlSettleLabel->setFont(Font("Small Text", 11, Font::plain));
-	ttlSettleLabel->setBounds(255 + HS_WIDTH, 80, 70, 20);
+	ttlSettleLabel->setBounds(185 + HS_PANEL_WIDTH, 80, 70, 20);
     ttlSettleLabel->setColour(Label::textColourId, Colours::darkgrey);
     addAndMakeVisible(ttlSettleLabel);
 
 
     ttlSettleCombo = new ComboBox("FastSettleComboBox");
-	ttlSettleCombo->setBounds(260 + HS_WIDTH, 100, 60, 18);
+	ttlSettleCombo->setBounds(190 + HS_PANEL_WIDTH, 100, 60, 18);
     ttlSettleCombo->addListener(this);
     ttlSettleCombo->addItem("-",1);
     for (int k=0; k<8; k++)
@@ -698,7 +699,7 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
 
     dacTTLButton = new UtilityButton("DAC TTL", Font("Small Text", 13, Font::plain));
     dacTTLButton->setRadius(3.0f);
-	dacTTLButton->setBounds(260 + HS_WIDTH, 25, 65, 18);
+	dacTTLButton->setBounds(190 + HS_PANEL_WIDTH, 25, 65, 18);
     dacTTLButton->addListener(this);
     dacTTLButton->setClickingTogglesState(true);
     dacTTLButton->setTooltip("Enable/disable DAC Threshold TTL Output");
@@ -706,12 +707,12 @@ RHD2000Editor::RHD2000Editor(GenericProcessor* parentNode,
 
     dacHPFlabel = new Label("DAC HPF","DAC HPF");
     dacHPFlabel->setFont(Font("Small Text", 11, Font::plain));
-	dacHPFlabel->setBounds(260 + HS_WIDTH, 42, 65, 20);
+	dacHPFlabel->setBounds(190 + HS_PANEL_WIDTH, 42, 65, 20);
     dacHPFlabel->setColour(Label::textColourId, Colours::darkgrey);
     addAndMakeVisible(dacHPFlabel);
 
     dacHPFcombo = new ComboBox("dacHPFCombo");
-	dacHPFcombo->setBounds(260 + HS_WIDTH, 60, 60, 18);
+	dacHPFcombo->setBounds(190 + HS_PANEL_WIDTH, 60, 60, 18);
     dacHPFcombo->addListener(this);
     dacHPFcombo->addItem("OFF",1);
     int HPFvalues[10] = {50,100,200,300,400,500,600,700,800,900};
@@ -832,7 +833,8 @@ void RHD2000Editor::buttonEvent(Button* button)
 {
     if (button == rescanButton && !acquisitionIsActive)
     {
-        board->scanPorts();
+        // Do not force 30 ksps; scan at the rate that's configured.
+        board->scanPorts(false);
 
         for (int i = 0; i < INTAN_EDITOR_PORT_SLOTS; i++)
         {
@@ -1260,6 +1262,14 @@ HeadstageOptionsInterface::HeadstageOptionsInterface(RHD2000Thread* board_,
     hsButton2->addListener(this);
     addAndMakeVisible(hsButton2);
 
+    delayButton = new UtilityButton("0", Font("Small Text", 13, Font::plain));
+    delayButton->setRadius(3.0f);
+    delayButton->setBounds(63,1,20,17);
+    delayButton->setClickingTogglesState(true);
+    delayButton->setToggleState(false, sendNotification);
+    delayButton->addListener(this);
+    addAndMakeVisible(delayButton);
+
     checkEnabledState();
 }
 
@@ -1299,8 +1309,30 @@ void HeadstageOptionsInterface::checkEnabledState()
         hsButton2->setEnabledState(false);
     }
 
-    repaint();
+    delayButton->setEnabledState(isEnabled);
 
+    repaint();
+}
+
+int HeadstageOptionsInterface::getCableDelayAdjustment()
+{
+    bool result;
+
+    result = 0;
+
+    // NOTE - Interface stays the same if we switch this to a spinner.
+    // Delay is 0 if the button isn't toggled and +1 if it is.
+    if (delayButton->getToggleState())
+        result = 1;
+
+    return result;
+}
+
+void HeadstageOptionsInterface::setCableDelayAdjustment(int newdelay)
+{
+    // NOTE - Interface stays the same if we switch this to a spinner.
+    // Button is pressed if delay is greater than 0 and up otherwise.
+    delayButton->setToggleState((newdelay > 0), sendNotification);
 }
 
 void HeadstageOptionsInterface::buttonClicked(Button* button)
@@ -1337,6 +1369,23 @@ void HeadstageOptionsInterface::buttonClicked(Button* button)
             board->setNumChannels(hsNumber2, channelsOnHs2);
             //board->updateChannels();
             editor->updateSettings();
+        }
+        else if (button == delayButton)
+        {
+            if (delayButton->getToggleState())
+            {
+                delayButton->setLabel("+1");
+                board->setHeadstageDelayAdjust(hsNumber1, 1);
+                board->setHeadstageDelayAdjust(hsNumber2, 1);
+                board->scanPorts(false);
+            }
+            else
+            {
+                delayButton->setLabel("0");
+                board->setHeadstageDelayAdjust(hsNumber1, 0);
+                board->setHeadstageDelayAdjust(hsNumber2, 0);
+                board->scanPorts(false);
+            }
         }
 
 		CoreServices::updateSignalChain(editor);

--- a/Plugins/IntanRecordingController/RHD2000Editor.h
+++ b/Plugins/IntanRecordingController/RHD2000Editor.h
@@ -26,6 +26,9 @@
 
 #include <VisualizerEditorHeaders.h>
 
+// Number of ports displayed in the GUI.
+#define INTAN_EDITOR_PORT_SLOTS 8
+
 namespace IntanRecordingController
 {
 

--- a/Plugins/IntanRecordingController/RHD2000Editor.h
+++ b/Plugins/IntanRecordingController/RHD2000Editor.h
@@ -234,6 +234,9 @@ namespace IntanRecordingController
 
 		void checkEnabledState();
 
+		int getCableDelayAdjustment();
+		void setCableDelayAdjustment(int newdelay);
+
 	private:
 
 		int hsNumber1, hsNumber2;
@@ -247,6 +250,7 @@ namespace IntanRecordingController
 
 		ScopedPointer<UtilityButton> hsButton1;
 		ScopedPointer<UtilityButton> hsButton2;
+		ScopedPointer<UtilityButton> delayButton;
 
 	};
 

--- a/Plugins/IntanRecordingController/RHD2000Thread.cpp
+++ b/Plugins/IntanRecordingController/RHD2000Thread.cpp
@@ -98,7 +98,7 @@ RHD2000Thread::RHD2000Thread(SourceNode* sn) : DataThread(sn),
     desiredUpperBandwidth(7500.0f),
     desiredLowerBandwidth(1.0f),
     boardSampleRate(30000.0f),
-    savedSampleRateIndex(16),
+    savedSampleRateIndex(Rhd2000EvalBoardUsb3::SampleRate30000Hz),
     cableLengthPortA(0.914f), cableLengthPortB(0.914f), cableLengthPortC(0.914f), cableLengthPortD(0.914f), // default is 3 feet (0.914 m),
     audioOutputL(-1), audioOutputR(-1) ,numberingScheme(1),
 	newScan(true)

--- a/Plugins/IntanRecordingController/RHD2000Thread.cpp
+++ b/Plugins/IntanRecordingController/RHD2000Thread.cpp
@@ -58,6 +58,13 @@ using namespace IntanRecordingController;
 #define S_DEBUG(x) {}
 #endif
 
+//#define DELAY_DEBUG
+#ifdef DELAY_DEBUG
+#define DEL_DEBUG(x) do { x } while(false);
+#else
+#define DEL_DEBUG(x) {}
+#endif
+
 // Allocates memory for a 3-D array of doubles.
 void allocateDoubleArray3D(std::vector<std::vector<std::vector<double> > >& array3D,
                            int xSize, int ySize, int zSize)
@@ -116,6 +123,9 @@ RHD2000Thread::RHD2000Thread(SourceNode* sn) : DataThread(sn),
 
     for (int i=0; i < MAX_NUM_HEADSTAGES; i++)
         headstagesArray.add(new RHDHeadstage(i));
+
+    cableLengthAdjustments.clear();
+    cableLengthAdjustments.insertMultiple(0, 0, MAX_NUM_HEADSTAGES);
 
     evalBoard = new Rhd2000EvalBoardUsb3;
     sourceBuffers.add(new DataBuffer(2, 10000)); // start with 2 channels and automatically resize
@@ -477,8 +487,10 @@ void RHD2000Thread::initializeBoard()
 
 }
 
-void RHD2000Thread::scanPorts()
+void RHD2000Thread::scanPorts(bool wantForcedRate)
 {
+	int savedSampleRateCopy;
+
 	if (!deviceFound) //Safety to avoid crashes if board not present
 	{
 		return;
@@ -516,7 +528,17 @@ void RHD2000Thread::scanPorts()
 	chipId.insertMultiple(0, -1, MAX_NUM_HEADSTAGES);
 	Array<int> tmpChipId(chipId);
 
-	setSampleRate(Rhd2000EvalBoardUsb3::SampleRate30000Hz, true); // set to 30 kHz temporarily
+	savedSampleRateCopy = savedSampleRateIndex;
+	// Set either 30 ksps or the nominal configured rate.
+	// Don't re-scan (avoid recursion loop).
+	if (wantForcedRate)
+	{
+		setSampleRate(Rhd2000EvalBoardUsb3::SampleRate30000Hz, false);
+	}
+	else
+	{
+		setSampleRate(savedSampleRateIndex, false);
+	}
 
 	// Enable all data streams, and set sources to cover one or two chips
 	// on Ports A-D.
@@ -573,6 +595,13 @@ void RHD2000Thread::scanPorts()
 
 	for (delay = 0; delay < 16; delay++)//(delay = 0; delay < 16; ++delay)
 	{
+		DEL_DEBUG(
+		if (delay < 10)
+			std::cout << "Delay  " << delay << ":   ";
+		else
+			std::cout << "Delay " << delay << ":   ";
+		)
+
 		evalBoard->setCableDelay(Rhd2000EvalBoardUsb3::PortA, delay);
 		evalBoard->setCableDelay(Rhd2000EvalBoardUsb3::PortB, delay);
 		evalBoard->setCableDelay(Rhd2000EvalBoardUsb3::PortC, delay);
@@ -620,8 +649,15 @@ void RHD2000Thread::scanPorts()
 					indexSecondGoodDelay.set(hs, delay);
 					tmpChipId.set(hs, id);
 				}
+				DEL_DEBUG(std::cout << 'Y';)
+			}
+			else
+			{
+				DEL_DEBUG(std::cout << '-';)
 			}
 		}
+
+		DEL_DEBUG(std::cout << std::endl;)
 	}
 	PRINT_ARRAYS;
 	S_DEBUG(
@@ -696,13 +732,23 @@ void RHD2000Thread::scanPorts()
     {
         if (sumGoodDelays[hs] == 1 || sumGoodDelays[hs] == 2)
         {
-            optimumDelay.set(hs,indexFirstGoodDelay[hs]);
+            optimumDelay.set(hs,indexFirstGoodDelay[hs] + cableLengthAdjustments[hs]);
         }
         else if (sumGoodDelays[hs] > 2)
         {
-            optimumDelay.set(hs,indexSecondGoodDelay[hs]);
+            optimumDelay.set(hs,indexSecondGoodDelay[hs] + cableLengthAdjustments[hs]);
         }
+
+//        DEL_DEBUG(std::cout << "hs " << hs << " delay:  " << optimumDelay[hs] << std::endl;)
     }
+
+    DEL_DEBUG(
+    for (hs = 0; (hs+1) < MAX_NUM_HEADSTAGES; hs += 2)
+    {
+        std::cout << "Port " << ( (char) ('A' + (hs>>1)) ) << " delay:   "
+            << max(optimumDelay[hs],optimumDelay[hs+1]) << std::endl;
+    }
+    )
 
     evalBoard->setCableDelay(Rhd2000EvalBoardUsb3::PortA,
                              max(optimumDelay[0],optimumDelay[1]));
@@ -721,6 +767,7 @@ void RHD2000Thread::scanPorts()
 	evalBoard->setCableDelay(Rhd2000EvalBoardUsb3::PortH,
 							max(optimumDelay[14], optimumDelay[15]));
 
+    // NOTE - These human-readable cable lengths are no longer used for anything.
     cableLengthPortA =
         evalBoard->estimateCableLengthMeters(max(optimumDelay[0],optimumDelay[1]));
     cableLengthPortB =
@@ -738,9 +785,19 @@ void RHD2000Thread::scanPorts()
 	cableLengthPortH =
 		evalBoard->estimateCableLengthMeters(max(optimumDelay[14], optimumDelay[15]));
 
-    setSampleRate(savedSampleRateIndex); // restore saved sample rate
+    // Make sure we're at the original sampling rate.
+    // Don't re-scan (avoid recursion loop).
+    setSampleRate(savedSampleRateCopy, false);
+
+    // setSampleRate() calls this, so we don't need it here.
     //updateRegisters();
+
     newScan = true;
+}
+
+void RHD2000Thread::setHeadstageDelayAdjust(int hsnum, int adjustval)
+{
+  cableLengthAdjustments.set(hsnum, adjustval);
 }
 
 int RHD2000Thread::deviceId(Rhd2000DataBlockUsb3* dataBlock, int stream, int& register59Value)
@@ -1221,13 +1278,11 @@ void RHD2000Thread::enableAdcs(bool t)
 }
 
 
-void RHD2000Thread::setSampleRate(int sampleRateIndex, bool isTemporary)
+void RHD2000Thread::setSampleRate(int sampleRateIndex, bool wantRescan)
 {
 	impedanceThread->stopThreadSafely();
-    if (!isTemporary)
-    {
-        savedSampleRateIndex = sampleRateIndex;
-    }
+
+    savedSampleRateIndex = sampleRateIndex;
 
     int numUsbBlocksToRead = 0; // placeholder - make this change the number of blocks that are read in RHD2000Thread::updateBuffer()
 
@@ -1334,17 +1389,13 @@ void RHD2000Thread::setSampleRate(int sampleRateIndex, bool isTemporary)
 
     // Now that we have set our sampling rate, we can set the MISO sampling delay
     // which is dependent on the sample rate.
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortA, cableLengthPortA);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortB, cableLengthPortB);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortC, cableLengthPortC);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortD, cableLengthPortD);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortE, cableLengthPortE);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortF, cableLengthPortF);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortG, cableLengthPortG);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortH, cableLengthPortH);
+    // Do this by re-probing at the sampling rate we just set.
+    if (wantRescan)
+    {
+        scanPorts(false);
+    }
 
     updateRegisters();
-
 }
 
 void RHD2000Thread::updateRegisters()

--- a/Plugins/IntanRecordingController/RHD2000Thread.cpp
+++ b/Plugins/IntanRecordingController/RHD2000Thread.cpp
@@ -99,7 +99,14 @@ RHD2000Thread::RHD2000Thread(SourceNode* sn) : DataThread(sn),
     desiredLowerBandwidth(1.0f),
     boardSampleRate(30000.0f),
     savedSampleRateIndex(Rhd2000EvalBoardUsb3::SampleRate30000Hz),
-    cableLengthPortA(0.914f), cableLengthPortB(0.914f), cableLengthPortC(0.914f), cableLengthPortD(0.914f), // default is 3 feet (0.914 m),
+    cableLengthPortA(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortB(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortC(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortD(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortE(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortF(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortG(DEFAULT_CABLE_LENGTH_METERS),
+    cableLengthPortH(DEFAULT_CABLE_LENGTH_METERS),
     audioOutputL(-1), audioOutputR(-1) ,numberingScheme(1),
 	newScan(true)
 {
@@ -408,10 +415,10 @@ void RHD2000Thread::initializeBoard()
 	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortB, cableLengthPortB);
 	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortC, cableLengthPortC);
 	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortD, cableLengthPortD);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortE, cableLengthPortA);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortF, cableLengthPortB);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortG, cableLengthPortC);
-	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortH, cableLengthPortD);
+	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortE, cableLengthPortE);
+	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortF, cableLengthPortF);
+	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortG, cableLengthPortG);
+	evalBoard->setCableLengthMeters(Rhd2000EvalBoardUsb3::PortH, cableLengthPortH);
 
     // Select RAM Bank 0 for AuxCmd3 initially, so the ADC is calibrated.
 	evalBoard->selectAuxCommandBank(Rhd2000EvalBoardUsb3::PortA, Rhd2000EvalBoardUsb3::AuxCmd3, 0);

--- a/Plugins/IntanRecordingController/RHD2000Thread.h
+++ b/Plugins/IntanRecordingController/RHD2000Thread.h
@@ -38,6 +38,9 @@
 
 #define MAX_NUM_CHANNELS MAX_NUM_DATA_STREAMS*35
 
+// default is 3 feet (0.914 m)
+#define DEFAULT_CABLE_LENGTH_METERS 0.914f
+
 namespace IntanRecordingController
 {
 

--- a/Plugins/IntanRecordingController/RHD2000Thread.h
+++ b/Plugins/IntanRecordingController/RHD2000Thread.h
@@ -92,7 +92,7 @@ namespace IntanRecordingController
 		bool isHeadstageEnabled(int hsNum) const;
 		int getChannelsInHeadstage(int hsNum) const;
 
-		void setSampleRate(int index, bool temporary = false);
+		void setSampleRate(int index, bool wantRescan = true);
 
 		double setUpperBandwidth(double upper); // set desired BW, returns actual BW
 		double setLowerBandwidth(double lower);
@@ -107,7 +107,8 @@ namespace IntanRecordingController
 		void setTTLoutputMode(bool state);
 		void setDAChpf(float cutoff, bool enabled);
 
-		void scanPorts();
+		void scanPorts(bool wantForcedRate = true);
+		void setHeadstageDelayAdjust(int hsnum, int adjustval);
 		void enableAdcs(bool);
 
 		bool isReady() override;
@@ -201,6 +202,9 @@ namespace IntanRecordingController
 
 		int deviceId(Rhd2000DataBlockUsb3* dataBlock, int stream, int& register59Value);
 
+		Array<int> cableLengthAdjustments;
+
+		// FIXME - No longer used for anything.
 		double cableLengthPortA, cableLengthPortB, cableLengthPortC, cableLengthPortD;
 		double cableLengthPortE, cableLengthPortF, cableLengthPortG, cableLengthPortH;
 


### PR DESCRIPTION
Minor bug fixes without changes to functionality (cable length fixes will be a separate pull request).
- Fixed channel counts not rendering for ports E..H.
- Fixed initialization of placeholder cable lengths for ports E..H (they were from lengths A..D).
- Fixed constructor initialization of cable length variables (lengths E..H weren't being initialized).
- Moved default cable length magic value to a header macro.
- Moved number of GUI port slots magic value to a header macro (and fixed inconsistent values per rendering bug).
- Replaced sampling rate index magic value with enum value per other sampling rate indices.
Bench-tested with a recording controller and headstage, but not stress-tested.