### PR TITLE
Add isReady check to processors so threads can prevent acquisition start

### DIFF
--- a/Source/Processors/DataThreads/DataThread.h
+++ b/Source/Processors/DataThreads/DataThread.h
@@ -94,7 +94,7 @@ public:
     /** Create the DataThread custom editor, if any*/
     virtual std::unique_ptr<GenericEditor> createEditor(SourceNode* sn);
 
-    /** Allows the DataThread plugin to respond to broadcast messages sent by other processors 
+    /** Allows the DataThread plugin to respond to broadcast messages sent by other processors
           during acquisition */
     virtual void handleBroadcastMessage(String msg) { }
 
@@ -113,6 +113,9 @@ public:
 
     /** Returns the address of the DataBuffer that the input source will fill.*/
     DataBuffer* getBufferAddress(int streamIdx) const;
+    
+    /** Returns true if the dataThread configuration is valid and the thread is ready for acquisition*/
+    virtual bool isReady(){return true;};
 
 protected:
 

--- a/Source/Processors/GenericProcessor/GenericProcessor.h
+++ b/Source/Processors/GenericProcessor/GenericProcessor.h
@@ -482,6 +482,9 @@ public:
     /** Determines whether the processor's editor appears colored or grayed out*/
     bool isEnabled;
     
+    /** Determines if a processor is ready for acquisition*/
+    virtual bool isReady() {return true;};
+        
     
     /** Pointer to the processor's editor. */
     std::unique_ptr<GenericEditor> editor;

--- a/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
+++ b/Source/Processors/ProcessorGraph/ProcessorGraph.cpp
@@ -1400,7 +1400,7 @@ bool ProcessorGraph::isReady()
         {
             GenericProcessor* p = (GenericProcessor*)node->getProcessor();
 
-            if (!p->isEnabled)
+            if (!p->isEnabled || !p->isReady())
             {
                 LOGD(" ", p->getName(), " is not ready to start acquisition.");
                 AccessClass::getUIComponent()->disableCallbacks();

--- a/Source/Processors/SourceNode/SourceNode.cpp
+++ b/Source/Processors/SourceNode/SourceNode.cpp
@@ -223,6 +223,9 @@ bool SourceNode::isSourcePresent() const
     return dataThread && dataThread->foundInputSource();
 }
 
+bool SourceNode::isReady(){
+    return dataThread->isReady();
+}
 
 bool SourceNode::startAcquisition()
 {

--- a/Source/Processors/SourceNode/SourceNode.h
+++ b/Source/Processors/SourceNode/SourceNode.h
@@ -94,6 +94,9 @@ public:
 
     /** Passes initialize command to the DataThread*/
     void initialize(bool signalChainIsLoading) override;
+    
+    /** Indicates if a node's DataThread is ready for acquisition */
+    bool isReady() override;
 
 private:
 


### PR DESCRIPTION
Currently there is no way for a Processor to prevent acquisition from starting. Nodes can be disabled but there is no way to flash an error when a Plugin in a signal chain has an invalid configuration and the user presses the start button.

For my UG3 Interface Plugin, I want to show an AlertBox if a user has too many channels selected and they try to start acquisition.

This fix allows for this functionality by checking processor validity before any of the other acquisition processes start. The interface methods added are all virtual so only DataThreads that would like to add this check need any additional logic.