### PR TITLE
V0554 arduino dev

### DIFF
--- a/Plugins/ArduinoOutput/ArduinoOutput.h
+++ b/Plugins/ArduinoOutput/ArduinoOutput.h
@@ -29,6 +29,13 @@
 #include "serial/ofArduino.h"
 
 
+/* Magic constants for parameter indices. */
+#define ARDOUT_PARAM_DIGOUT 0
+#define ARDOUT_PARAM_INBANKIDX 1
+#define ARDOUT_PARAM_INBIT 2
+#define ARDOUT_PARAM_GATEBANKIDX 3
+#define ARDOUT_PARAM_GATEBIT 4
+
 
 /**
     *UNDER CONSTRUCTION*
@@ -64,15 +71,11 @@ public:
     /** Creates the ArduinoOutputEditor. */
     AudioProcessorEditor* createEditor() override;
 
-    void setOutputChannel (int);
-    void setInputChannel  (int);
-    void setGateChannel   (int);
-
     void setDevice (String deviceString);
 
-    int outputChannel;
-    int inputChannel;
-    int gateChannel;
+    int ardDigOutput;
+    int inputBankIdx, inputBit;
+    int gateBankIdx, gateBit;
 
 
 private:

--- a/Plugins/ArduinoOutput/ArduinoOutputEditor.cpp
+++ b/Plugins/ArduinoOutput/ArduinoOutputEditor.cpp
@@ -23,6 +23,7 @@
 
 #include "ArduinoOutputEditor.h"
 #include <stdio.h>
+#include <string>
 
 
 ArduinoOutputEditor::ArduinoOutputEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors=true)

--- a/Plugins/ArduinoOutput/ArduinoOutputEditor.cpp
+++ b/Plugins/ArduinoOutput/ArduinoOutputEditor.cpp
@@ -27,7 +27,10 @@
 
 ArduinoOutputEditor::ArduinoOutputEditor(GenericProcessor* parentNode, bool useDefaultParameterEditors=true)
     : GenericEditor(parentNode, useDefaultParameterEditors)
-
+    , cachedInputChannel    ("bogus")
+    , cachedOutputChannel   ("bogus")
+    , cachedGateChannel     ("bogus")
+    , cachedDevice          ("bogus")
 {
 
     // accumulator = 0;
@@ -62,15 +65,11 @@ ArduinoOutputEditor::ArduinoOutputEditor(GenericProcessor* parentNode, bool useD
     addAndMakeVisible(deviceSelector);
 
     inputChannelSelector = new ComboBox();
-    inputChannelSelector->setBounds(10,30,55,20);
+    inputChannelSelector->setBounds(10,30,125,20);
     inputChannelSelector->addListener(this);
-    inputChannelSelector->addItem("Trig",1);
+    inputChannelSelector->addItem("(no trigger)",-1);
 
-    for (int i = 0; i < 16; i++)
-        inputChannelSelector->addItem(String(i+1),i+2); // start numbering at one for
-    // user-visible channels
-
-    inputChannelSelector->setSelectedId(1, dontSendNotification);
+    inputChannelSelector->setSelectedItemIndex(0, dontSendNotification);
     addAndMakeVisible(inputChannelSelector);
 
     outputChannelSelector = new ComboBox();
@@ -85,15 +84,11 @@ ArduinoOutputEditor::ArduinoOutputEditor(GenericProcessor* parentNode, bool useD
     addAndMakeVisible(outputChannelSelector);
 
     gateChannelSelector = new ComboBox();
-    gateChannelSelector->setBounds(10,55,55,20);
+    gateChannelSelector->setBounds(10,55,125,20);
     gateChannelSelector->addListener(this);
-    gateChannelSelector->addItem("Gate",1);
+    gateChannelSelector->addItem("(no gate)",-1);
 
-    for (int i = 0; i < 16; i++)
-        gateChannelSelector->addItem(String(i+1),i+2); // start numbering at one for
-    // user-visible channels
-
-    gateChannelSelector->setSelectedId(1, dontSendNotification);
+    gateChannelSelector->setSelectedItemIndex(0, dontSendNotification);
     addAndMakeVisible(gateChannelSelector);
 
 }
@@ -115,16 +110,165 @@ void ArduinoOutputEditor::comboBoxChanged(ComboBox* comboBoxThatHasChanged)
     if (comboBoxThatHasChanged == deviceSelector)
     {
         arduino->setDevice(deviceSelector->getText());
+        cachedDevice = deviceSelector->getText();
     } else if (comboBoxThatHasChanged == outputChannelSelector)
     {
-        arduino->setOutputChannel(outputChannelSelector->getSelectedId()-1);
+        arduino->setParameter(ARDOUT_PARAM_DIGOUT,
+            outputChannelSelector->getSelectedId()-1);
+        cachedOutputChannel = outputChannelSelector->getText();
     } else if (comboBoxThatHasChanged == inputChannelSelector)
     {
-        arduino->setInputChannel(inputChannelSelector->getSelectedId()-1);
+        int lutidx = inputChannelSelector->getSelectedId();
+        cachedInputChannel = inputChannelSelector->getText();
+        // Entry 0 is special; valid values are 1..(size-1).
+        if ( (lutidx > 0) && (lutidx < ttlBankIdxLUT.size()) )
+        {
+            arduino->setParameter(ARDOUT_PARAM_INBANKIDX,
+                ttlBankIdxLUT[lutidx]);
+            arduino->setParameter(ARDOUT_PARAM_INBIT, ttlBitLUT[lutidx]);
+        }
+        else
+        {
+            arduino->setParameter(ARDOUT_PARAM_INBANKIDX, -1);
+            arduino->setParameter(ARDOUT_PARAM_INBIT, -1);
+        }
     } else if (comboBoxThatHasChanged == gateChannelSelector)
     {
-        arduino->setGateChannel(gateChannelSelector->getSelectedId()-1);
+        int lutidx = gateChannelSelector->getSelectedId();
+        cachedGateChannel = gateChannelSelector->getText();
+        // Entry 0 is special; valid values are 1..(size-1).
+        if ( (lutidx > 0) && (lutidx < ttlBankIdxLUT.size()) )
+        {
+            arduino->setParameter(ARDOUT_PARAM_GATEBANKIDX,
+                ttlBankIdxLUT[lutidx]);
+            arduino->setParameter(ARDOUT_PARAM_GATEBIT, ttlBitLUT[lutidx]);
+        }
+        else
+        {
+            arduino->setParameter(ARDOUT_PARAM_GATEBANKIDX, -1);
+            arduino->setParameter(ARDOUT_PARAM_GATEBIT, -1);
+        }
     }
+}
+
+void ArduinoOutputEditor::updateSettings()
+{
+    // Rebuild the comboboxes and the TTL channel lookup tables.
+
+    ttlBankIdxLUT.clear();
+    ttlBitLUT.clear();
+
+    inputChannelSelector->clear(dontSendNotification);
+    gateChannelSelector->clear(dontSendNotification);
+
+
+    // The first entry is the "no signal selected" entry.
+    // Store a combobox value of -1, since JUCE doesn't like 0.
+    // Special-case that when looking up LUT entries.
+
+    ttlBankIdxLUT.add(-1);
+    ttlBitLUT.add(-1);
+    int lutidx = 0;
+
+    inputChannelSelector->addItem("(no trigger)", -1);
+    gateChannelSelector->addItem("(no gate)", -1);
+
+
+    int chanCount = arduino->getTotalEventChannels();
+
+    for (int cidx = 0; cidx < chanCount; cidx++)
+    {
+        const EventChannel* theChannel = arduino->getEventChannel(cidx);
+        EventChannel::EventChannelTypes thisType = theChannel->getChannelType();
+        int thisBitCount = theChannel->getNumChannels();
+        String thisName = theChannel->getName();
+
+        if (EventChannel::TTL == thisType)
+        {
+            for (int bidx = 0; bidx < thisBitCount; bidx++)
+            {
+                // Name labels have the form "Bank:Bit (bank name)".
+                std::string thisChanLabel = std::to_string(cidx) + ":"
+                    + std::to_string(bidx) + " (" + thisName.toStdString()
+                    + ")";
+
+                lutidx++;
+                ttlBankIdxLUT.add(cidx);
+                ttlBitLUT.add(bidx);
+
+                // The comboboxes store lookup table indices.
+                inputChannelSelector->addItem(thisChanLabel, lutidx);
+                gateChannelSelector->addItem(thisChanLabel, lutidx);
+            }
+        }
+    }
+
+    // Force reasonable defaults for the GUI.
+    inputChannelSelector->setSelectedItemIndex(0, dontSendNotification);
+    gateChannelSelector->setSelectedItemIndex(0, dontSendNotification);
+
+    // Set reasonable defaults for the parent in case our cached values
+    // are no longer valid. Don't touch the cache itself.
+    arduino->setParameter(ARDOUT_PARAM_INBANKIDX, -1);
+    arduino->setParameter(ARDOUT_PARAM_INBIT, -1);
+    arduino->setParameter(ARDOUT_PARAM_GATEBANKIDX, -1);
+    arduino->setParameter(ARDOUT_PARAM_GATEBIT, -1);
+
+    // Restore any previously configured items that remain valid.
+    RestoreSelectionsFromCache();
+}
+
+void ArduinoOutputEditor::saveCustomParameters(XmlElement *xml)
+{
+    xml->setAttribute("Type", "ArduinoOutput");
+    xml->setAttribute("InputChannel", cachedInputChannel);
+    xml->setAttribute("OutputChannel", cachedOutputChannel);
+    xml->setAttribute("GateChannel", cachedGateChannel);
+    xml->setAttribute("Device", cachedDevice);
+}
+
+void ArduinoOutputEditor::loadCustomParameters(XmlElement *xml)
+{
+    cachedInputChannel = xml->getStringAttribute("InputChannel");
+    cachedOutputChannel = xml->getStringAttribute("OutputChannel");
+    cachedGateChannel = xml->getStringAttribute("GateChannel");
+    cachedDevice = xml->getStringAttribute("Device");
+
+    // Adjust the comboboxes to reflect the config's selections, if possible.
+    RestoreSelectionsFromCache();
+}
+
+void ArduinoOutputEditor::RestoreSelectionsFromCache()
+{
+    // This is intended to update selections after updateSettings() has
+    // reset the comboboxes, or after we've loaded config from XML.
+
+    // We do want to send notifications, to propagate configuration to
+    // the processor.
+
+    // If the cached item isn't found in the combobox, both are left as-is.
+
+    int idx;
+
+    for (idx = 0; idx < inputChannelSelector->getNumItems(); idx++)
+        if ( inputChannelSelector->getItemText(idx) == cachedInputChannel )
+            inputChannelSelector->setSelectedItemIndex( idx,
+                sendNotificationAsync);
+
+    for (idx = 0; idx < outputChannelSelector->getNumItems(); idx++)
+        if ( outputChannelSelector->getItemText(idx) == cachedOutputChannel )
+            outputChannelSelector->setSelectedItemIndex( idx,
+                sendNotificationAsync);
+
+    for (idx = 0; idx < gateChannelSelector->getNumItems(); idx++)
+        if ( gateChannelSelector->getItemText(idx) == cachedGateChannel )
+            gateChannelSelector->setSelectedItemIndex( idx,
+                sendNotificationAsync);
+
+    for (idx = 0; idx < deviceSelector->getNumItems(); idx++)
+        if ( deviceSelector->getItemText(idx) == cachedDevice )
+            deviceSelector->setSelectedItemIndex( idx,
+                sendNotificationAsync);
 }
 
 void ArduinoOutputEditor::timerCallback()

--- a/Plugins/ArduinoOutput/ArduinoOutputEditor.h
+++ b/Plugins/ArduinoOutput/ArduinoOutputEditor.h
@@ -53,6 +53,11 @@ public:
 
     void comboBoxChanged(ComboBox* comboBoxThatHasChanged);
 
+    void updateSettings() override;
+
+    void saveCustomParameters(XmlElement *xml) override;
+    void loadCustomParameters(XmlElement *xml) override;
+
     ArduinoOutput* arduino;
 
     ofSerial serial;
@@ -64,6 +69,16 @@ private:
     ScopedPointer<ComboBox> outputChannelSelector;
     ScopedPointer<ComboBox> gateChannelSelector;
     ScopedPointer<ComboBox> deviceSelector;
+
+    String cachedInputChannel;
+    String cachedOutputChannel;
+    String cachedGateChannel;
+    String cachedDevice;
+
+    Array<int> ttlBankIdxLUT;
+    Array<int> ttlBitLUT;
+
+    void RestoreSelectionsFromCache();
 
     void timerCallback();
 


### PR DESCRIPTION
Quality-of-life improvements to v0.5 Arduino Output plugin. It properly handles TTL inputs in multiple streams, gives human-readable output channel names, loads/saves configuration properly, and caches configured signal selections by human-readable name to attempt to rebuild configuration after geometry changes (so that you don't necessarily lose configuration when editing signal chain components upstream).

![arduino-output-mod-20230201](https://user-images.githubusercontent.com/71090515/217113425-cfe7a67c-a56e-4da0-93e4-03475c402acb.png)
