### PR TITLE
V0554 recordnode dev

### DIFF
--- a/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.cpp
+++ b/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.cpp
@@ -41,8 +41,6 @@ int BinaryRecording::getSamplesPerBlock()
 	case BINBLOCK_LARGE: blockSamps *= 16; break;
 	default: break;
 	}
-// FIXME - Diagnostics.
-std::cerr << "[BinaryRecording]  getSamplesPerBlock() returns: " << blockSamps << "\n";
 
 	return blockSamps;
 }

--- a/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.cpp
+++ b/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.cpp
@@ -4,6 +4,8 @@
 
 #define MAX_BUFFER_SIZE 40960
 
+#define MIN_SAMPLES_PER_BLOCK 65536
+
 BinaryRecording::BinaryRecording()
 {
     m_bufferSize = MAX_BUFFER_SIZE;
@@ -26,6 +28,23 @@ String BinaryRecording::getProcessorString(const InfoObjectCommon* channelInfo)
     fName += "." + String(channelInfo->getSubProcessorIdx());
 	fName += File::separatorString;
 	return fName;
+}
+
+int BinaryRecording::getSamplesPerBlock()
+{
+	int blockSamps = MIN_SAMPLES_PER_BLOCK;
+
+	switch (m_blockSizeBoost)
+	{
+	case BINBLOCK_SMALL: break;
+	case BINBLOCK_MEDIUM: blockSamps *= 4; break;
+	case BINBLOCK_LARGE: blockSamps *= 16; break;
+	default: break;
+	}
+// FIXME - Diagnostics.
+std::cerr << "[BinaryRecording]  getSamplesPerBlock() returns: " << blockSamps << "\n";
+
+	return blockSamps;
 }
 
 void BinaryRecording::openFiles(File rootFolder, int experimentNumber, int recordingNumber)
@@ -120,6 +139,8 @@ void BinaryRecording::openFiles(File rootFolder, int experimentNumber, int recor
         }
         lastId = indexedDataChannels.size();
     }
+
+    int samplesPerBlock = getSamplesPerBlock();
 
     int nFiles = continuousFileNames.size();
     for (int i = 0; i < nFiles; i++)
@@ -687,13 +708,22 @@ RecordEngineManager* BinaryRecording::getEngineManager()
 {
     RecordEngineManager* man = new RecordEngineManager("RAWBINARY", "Binary",
                                                        &(engineFactory<BinaryRecording>));
-    EngineParameter* param;
-    param = new EngineParameter(EngineParameter::BOOL, 0, "Record TTL full words", true);
-    man->addParameter(param);
+
+    // Parameters are put into an OwnedArray, so allocate them here but don't worry about de-allocating them.
+
+    EngineParameter* paramttl;
+    paramttl = new EngineParameter(EngineParameter::BOOL, BINPARAM_TTLFULLWORDS, "Record TTL full words", true);
+    man->addParameter(paramttl);
+
+    EngineParameter* paramblock;
+    paramblock = new EngineParameter(EngineParameter::INT, BINPARAM_BLOCKSIZE, "Hint for SequentialBlockFile block size", BINBLOCK_SMALL, BINBLOCK_SMALL, BINBLOCK_LARGE);
+    man->addParameter(paramblock);
+
     return man;
 }
 
 void BinaryRecording::setParameter(EngineParameter& parameter)
 {
-	boolParameter(0, m_saveTTLWords);
+	boolParameter(BINPARAM_TTLFULLWORDS, m_saveTTLWords);
+	intParameter(BINPARAM_BLOCKSIZE, m_blockSizeBoost);
 }

--- a/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.h
+++ b/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.h
@@ -12,12 +12,26 @@
 class BinaryRecording : public RecordEngine
 {
 public:
+	enum BinaryRecordingParams
+	{
+		BINPARAM_TTLFULLWORDS = 0,
+		BINPARAM_BLOCKSIZE = 1
+	};
+
+	enum BinaryRecordingBlockScale
+	{
+		BINBLOCK_SMALL = 0,
+		BINBLOCK_MEDIUM = 1,
+		BINBLOCK_LARGE = 2
+	};
+
 	BinaryRecording();
 	~BinaryRecording();
 
 	String getEngineID() const override;
 
 	void openFiles(File rootFolder, int experimentNumber, int recordingNumber) override;
+	int getSamplesPerBlock(void);
 	void closeFiles() override;
 	void resetChannels() override;
 	void writeData(int writeChannel, int realChannel, const float* buffer, int size) override;
@@ -48,6 +62,7 @@ private:
     void increaseEventCounts(EventRecording* rec);
 
     bool m_saveTTLWords{ true };
+    int m_blockSizeBoost{ BINBLOCK_SMALL };
 
 	HeapBlock<float> m_scaledBuffer;
 	HeapBlock<int16> m_intBuffer;
@@ -74,9 +89,6 @@ private:
 
 	int m_recordingNum;
 	Array<int64> m_startTS;
-
-	const int samplesPerBlock{ 1024 * 1024 };
-
 
 };
 #endif

--- a/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.h
+++ b/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.h
@@ -75,7 +75,7 @@ private:
 	int m_recordingNum;
 	Array<int64> m_startTS;
 
-	const int samplesPerBlock{ 4096 };
+	const int samplesPerBlock{ 1024 * 1024 };
 
 
 };

--- a/Source/Processors/RecordNode/BinaryFormat/SequentialBlockFile.h
+++ b/Source/Processors/RecordNode/BinaryFormat/SequentialBlockFile.h
@@ -28,7 +28,7 @@ private:
 
 	//Compile-time params
 	const int streamBufferSize{ 0 };
-	const int blockArrayInitSize{ 128 };
+	const int blockArrayInitSize{ 8 };
 
 };
 #endif // !SEQUENTIALBLOCKFILE_H

--- a/Source/Processors/RecordNode/RecordEngine.cpp
+++ b/Source/Processors/RecordNode/RecordEngine.cpp
@@ -39,6 +39,27 @@ RecordEngine::~RecordEngine() {}
 
 void RecordEngine::setParameter(EngineParameter& parameter) {}
 
+void RecordEngine::setManagerParameter(EngineParameter& parameter)
+{
+	if (manager != nullptr)
+	{
+		for (int i = 0; i < manager->getNumParameters(); ++i)
+			if ( (manager->getParameter(i).id == parameter.id) && (manager->getParameter(i).type == parameter.type) )
+			{
+				// This is a nontrivial structure so it doesn't automatically have an assignment operator.
+				switch (parameter.type)
+				{
+				case EngineParameter::STR: manager->getParameter(i).strParam.value = parameter.strParam.value; break;
+				case EngineParameter::INT: manager->getParameter(i).intParam.value = parameter.intParam.value; break;
+				case EngineParameter::FLOAT: manager->getParameter(i).floatParam.value = parameter.floatParam.value; break;
+				case EngineParameter::BOOL: manager->getParameter(i).boolParam.value = parameter.boolParam.value; break;
+				case EngineParameter::MULTI: manager->getParameter(i).multiParam.value = parameter.multiParam.value; break;
+				default: break;
+				}
+			}
+	}
+}
+
 void RecordEngine::resetChannels() {}
 
 void RecordEngine::registerRecordNode(RecordNode* node)

--- a/Source/Processors/RecordNode/RecordEngine.h
+++ b/Source/Processors/RecordNode/RecordEngine.h
@@ -90,6 +90,10 @@ public:
 	/** Called for registering parameters */
 	virtual void setParameter(EngineParameter& parameter);
 
+	/** Called for indirectly changing parameters. */
+	/** This tells the manager to change its copy of the parameter, which gets propagated back here via setParameter(). */
+	void setManagerParameter(EngineParameter& parameter);
+
 	/** Called when recording starts to open all needed files */
 	virtual void openFiles(File rootFolder, int experimentNumber, int recordingNumber) = 0;
 

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -51,9 +51,9 @@ RecordNode::RecordNode()
 	AudioDeviceManager::AudioDeviceSetup ads;
 	adm.getAudioDeviceSetup(ads);
 	int bufferSize = ads.bufferSize;
+	int blockCount = getBlockCountFromSize(bufferSize);
 
-	//dataQueue = new DataQueue(WRITE_BLOCK_LENGTH, DATA_BUFFER_NBLOCKS);
-	dataQueue = new DataQueue(bufferSize, DATA_BUFFER_NBLOCKS);
+	dataQueue = new DataQueue(bufferSize, blockCount);
 	eventQueue = new EventMsgQueue(EVENT_BUFFER_NEVENTS);
 	spikeQueue = new SpikeMsgQueue(SPIKE_BUFFER_NSPIKES);
 
@@ -80,8 +80,25 @@ RecordNode::~RecordNode()
 
 void RecordNode::updateBlockSize(int newBlockSize)
 {
-	dataQueue = new DataQueue(newBlockSize, DATA_BUFFER_NBLOCKS);
-	LOGD("Updated Record Node buffer size to: ", newBlockSize);
+	int newBlockCount = getBlockCountFromSize(newBlockSize);
+	dataQueue = new DataQueue(newBlockSize, newBlockCount);
+	LOGD("Updated Record Node buffer block size to: ", newBlockSize);
+}
+
+int RecordNode::getBlockCountFromSize(int blockSize)
+{
+	int newCount = DATA_BUFFER_MIN_SAMPLES;
+
+	// This rounds down, so increase the count by one.
+	newCount /= blockSize;
+	newCount++;
+
+	if (newCount < DATA_BUFFER_MIN_BLOCKS)
+		newCount = DATA_BUFFER_MIN_BLOCKS;
+
+	LOGD("Updated Record Node buffer block count to: ", newCount);
+
+	return newCount;
 }
 
 void RecordNode::connectToMessageCenter()

--- a/Source/Processors/RecordNode/RecordNode.h
+++ b/Source/Processors/RecordNode/RecordNode.h
@@ -18,8 +18,9 @@
 
 //#include "taskflow/taskflow.hpp"
 
-#define WRITE_BLOCK_LENGTH		1024
-#define DATA_BUFFER_NBLOCKS		300
+// Formerly 300 blocks, typical block length 1024 samples.
+#define DATA_BUFFER_MIN_SAMPLES		1000000
+#define DATA_BUFFER_MIN_BLOCKS		100
 #define EVENT_BUFFER_NEVENTS	50000
 #define SPIKE_BUFFER_NSPIKES	50000
 
@@ -62,6 +63,7 @@ public:
 
 	/** Update DataQueue block size when Audio Settings buffer size changes */
 	void updateBlockSize(int newBlockSize);
+	int getBlockCountFromSize(int blockSize);
 
     /** If messageCenter event channel is not present in EventChannelArray, add it*/
 	void connectToMessageCenter();

--- a/Source/Processors/RecordNode/RecordNode.h
+++ b/Source/Processors/RecordNode/RecordNode.h
@@ -19,7 +19,7 @@
 //#include "taskflow/taskflow.hpp"
 
 // Formerly 300 blocks, typical block length 1024 samples.
-#define DATA_BUFFER_MIN_SAMPLES		1000000
+#define DATA_BUFFER_MIN_SAMPLES		300000
 #define DATA_BUFFER_MIN_BLOCKS		100
 #define EVENT_BUFFER_NEVENTS	50000
 #define SPIKE_BUFFER_NSPIKES	50000
@@ -46,6 +46,14 @@ class RecordNode : public GenericProcessor, public FilenameComponentListener
 {
 
 public:
+
+    enum MemBufferScale
+    {
+        // These need to be combobox-compatible (nonzero).
+        BUFSIZE_SMALL = 1,
+        BUFSIZE_MEDIUM = 2,
+        BUFSIZE_LARGE = 3
+    };
 
     /** Constructor
       - Creates: DataQueue, EventQueue, SpikeQueue, Synchronizer,
@@ -112,6 +120,7 @@ public:
 	std::vector<RecordEngineManager*> getAvailableRecordEngines();
 
 	void setEngine(int selectedEngineIndex);
+	void setMemBufScale(MemBufferScale newScale);
 	void setRecordEvents(bool);
 	void setRecordSpikes(bool);
 	void setDataDirectory(File);
@@ -186,6 +195,7 @@ public:
 
 	bool recordEvents;
 	bool recordSpikes;
+	MemBufferScale dataBufferScale;
 
 	ScopedPointer<EventMonitor> eventMonitor;
 

--- a/Source/Processors/RecordNode/RecordNodeEditor.h
+++ b/Source/Processors/RecordNode/RecordNodeEditor.h
@@ -128,6 +128,7 @@ public:
     ScopedPointer<FifoDrawerButton> fifoDrawerButton;
 
 	ScopedPointer<ComboBox> engineSelectCombo;
+	ScopedPointer<ComboBox> bufferSizeCombo;
 
 	void setDataDirectory(String dir);
 
@@ -150,6 +151,7 @@ private:
 	ScopedPointer<RecordToggleButton> eventRecord;
 	ScopedPointer<Label> recordSpikesLabel;
 	ScopedPointer<RecordToggleButton> spikeRecord;
+	ScopedPointer<Label> bufferSizeLabelA, bufferSizeLabelB;
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(RecordNodeEditor);
 


### PR DESCRIPTION
Modified RecordNode to have more consistent buffer sizes. This greatly improved stability when trying to record on an I/O-bottlenecked system and with small audio buffer sizes (needed for closed-loop work).

Modified BinaryFormat to use fewer buffers that are much larger. This greatly improved performance when writing to magnetic platter drives. RAM footprint is still acceptable (2 MB/channel per buffer block, 16 MB/channel total pre-allocated).

These changes have been tested with a single 128ch headstage running for several minutes, saving two copies of the data to a magnetic platter disk array at the same time, with an audio buffer duration of 6 ms. A full description of all of the test cases (with and without the code changes) is available upon request.

Long-duration tests (from actual research recording sessions) should be in-hand in the near future, but the bench tests should be sufficient for showing that no bugs were introduced.