### PR TITLE
Add testing infrastructure to GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ include(HelperFunctions.cmake)
 set(BASE_BUILD_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Build)
 set(JUCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/JuceLibraryCode)
 set(RESOURCES_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Resources)
+set(PLUGINS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Plugins)
+set(SOURCE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/Source)
+set(TEST_HELPERS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/TestHelpers)
 
 configure_file(${JUCE_DIRECTORY}/JuceHeader.h.in ${JUCE_DIRECTORY}/JuceHeader.h)
 configure_file(${RESOURCES_DIRECTORY}/Build-files/resources.rc.in ${RESOURCES_DIRECTORY}/Build-files/resources.rc)
@@ -53,35 +56,58 @@ else()
 endif()
 
 
+set(JUCE_SOURCE
+    ${JUCE_DIRECTORY}/AppConfig.h
+    ${JUCE_DIRECTORY}/JuceHeader.h
+    ${JUCE_DIRECTORY}/BinaryData.h
+    ${JUCE_DIRECTORY}/BinaryData.cpp
+    ${JUCE_DIRECTORY}/include_juce_audio_basics.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_audio_devices.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_audio_formats.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_audio_processors.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_audio_utils.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_core.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_cryptography.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_data_structures.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_events.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_graphics.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_gui_basics.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_gui_extra.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_opengl.${JUCE_FILES_EXTENSION}
+    ${JUCE_DIRECTORY}/include_juce_osc.cpp
+    ${JUCE_DIRECTORY}/include_juce_video.${JUCE_FILES_EXTENSION}
+)
+
 #create executable and add JUCE components
-add_executable(open-ephys
-	${JUCE_DIRECTORY}/AppConfig.h
-	${JUCE_DIRECTORY}/JuceHeader.h
-	${JUCE_DIRECTORY}/BinaryData.h
-	${JUCE_DIRECTORY}/BinaryData.cpp
-	${JUCE_DIRECTORY}/include_juce_audio_basics.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_audio_devices.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_audio_formats.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_audio_processors.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_audio_utils.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_core.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_cryptography.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_data_structures.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_events.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_graphics.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_gui_basics.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_gui_extra.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_opengl.${JUCE_FILES_EXTENSION}
-	${JUCE_DIRECTORY}/include_juce_osc.cpp
-	${JUCE_DIRECTORY}/include_juce_video.${JUCE_FILES_EXTENSION}
-	)
+add_executable(open-ephys ${JUCE_SOURCE})
  if(MSVC)
 	target_sources(open-ephys PRIVATE ${RESOURCES_DIRECTORY}/Build-files/resources.rc)
  endif()
 
 
+
 target_include_directories(open-ephys PRIVATE ${JUCE_DIRECTORY} ${JUCE_DIRECTORY}/modules)
 target_compile_features(open-ephys PUBLIC cxx_auto_type cxx_generalized_initializers cxx_std_17)
+
+if(BUILD_TESTS)
+	add_definitions(-DBUILD_TESTS)
+	add_library(gui_testable_source SHARED ${JUCE_SOURCE})
+	set_property(TARGET gui_testable_source APPEND PROPERTY COMPILE_DEFINITIONS "JUCE_API=__declspec(dllexport)")
+	if(MSVC)
+		target_compile_options(gui_testable_source PRIVATE /sdl- /nologo /MP /W0 /bigobj)
+	endif()
+	target_include_directories(gui_testable_source PRIVATE ${JUCE_DIRECTORY} ${JUCE_DIRECTORY}/modules)
+	target_compile_features(gui_testable_source PUBLIC cxx_auto_type cxx_generalized_initializers cxx_std_17)
+
+	set(BIN_TESTS_DIR ${CMAKE_BINARY_DIR}/TestBin)
+
+	set_target_properties( gui_testable_source PROPERTIES RUNTIME_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/TestBin/common )
+	set_target_properties( gui_testable_source PROPERTIES LIBRARY_OUTPUT_DIRECTORY  ${CMAKE_BINARY_DIR}/TestBin/common )
+
+	add_custom_command(TARGET gui_testable_source POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E make_directory "${BIN_TESTS_DIR}"
+		)
+endif()
 
 file(GLOB _bitfiles "${RESOURCES_DIRECTORY}/Bitfiles/*.bit")
 file(GLOB _xmlfiles "${RESOURCES_DIRECTORY}/Configs/*.xml")
@@ -226,7 +252,30 @@ elseif(APPLE)
 		"-framework Security"
 		"-framework WebKit"
 	)
-
+if(BUILD_TESTS)
+    target_link_libraries(gui_testable_source
+        "-framework Accelerate"
+        "-framework AudioToolbox"
+        "-framework AVKit"
+        "-framework AVFoundation"
+        "-framework Carbon"
+        "-framework Cocoa"
+        "-framework CoreAudio"
+        "-framework CoreAudioKit"
+        "-framework CoreMedia"
+        "-framework CoreMIDI"
+        "-framework DiscRecording"
+        "-framework Foundation"
+        "-framework IOKit"
+        "-framework Metal"
+        "-framework MetalKit"
+        "-framework OpenGL"
+        "-framework QTKit"
+        "-framework QuartzCore"
+        "-framework Security"
+        "-framework WebKit"
+    )
+endif()
 	set_target_properties(open-ephys PROPERTIES
 		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
 		XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO
@@ -243,6 +292,7 @@ elseif(APPLE)
 		)
 		set_source_files_properties(${MAC_RESOURCE_FILES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 		target_sources(open-ephys PRIVATE ${MAC_RESOURCE_FILES})
+
 
 else()
 	message( FATAL_ERROR "Unsupported OS")
@@ -261,5 +311,19 @@ foreach( src_file IN ITEMS ${SRC_FILES})
 	source_group("${group_name}" FILES "${src_file}")
 endforeach()
 
+#remove Main.cpp from open_ephys sources and add to API library
+list(REMOVE_ITEM SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/Source/Main.cpp)
+
+
+if(BUILD_TESTS)
+target_sources(gui_testable_source PRIVATE ${SRC_FILES})
+endif()
+
 #Add plugin build files
 add_subdirectory(Plugins)
+
+
+if(BUILD_TESTS)
+add_subdirectory(TestHelpers)
+add_subdirectory(Tests)
+endif()

--- a/JuceLibraryCode/modules/juce_audio_processors/utilities/juce_PluginHostType.cpp
+++ b/JuceLibraryCode/modules/juce_audio_processors/utilities/juce_PluginHostType.cpp
@@ -36,7 +36,7 @@ Image JUCE_API getIconFromApplication (const String&, const int);
 
 AudioProcessor::WrapperType PluginHostType::jucePlugInClientCurrentWrapperType = AudioProcessor::wrapperType_Undefined;
 std::function<bool (AudioProcessor&)> PluginHostType::jucePlugInIsRunningInAudioSuiteFn = nullptr;
-String PluginHostType::hostIdReportedByWrapper;
+String PluginHostType::hostIdReportedByWrapper = String("");
 
 bool PluginHostType::isInterAppAudioConnected() const
 {

--- a/JuceLibraryCode/modules/juce_core/text/juce_Identifier.cpp
+++ b/JuceLibraryCode/modules/juce_core/text/juce_Identifier.cpp
@@ -23,7 +23,7 @@
 namespace juce
 {
 
-Identifier::Identifier() noexcept {}
+Identifier::Identifier()  noexcept : name(String("")) {}
 Identifier::~Identifier() noexcept {}
 
 Identifier::Identifier (const Identifier& other) noexcept  : name (other.name) {}

--- a/JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.cpp
+++ b/JuceLibraryCode/modules/juce_core/text/juce_LocalisedStrings.cpp
@@ -77,7 +77,7 @@ namespace
     {
         LeakAvoidanceTrick()
         {
-            const std::unique_ptr<LocalisedStrings> dummy (new LocalisedStrings (String(), false));
+            const std::unique_ptr<LocalisedStrings> dummy (new LocalisedStrings (String(""), false));
         }
     };
 

--- a/JuceLibraryCode/modules/juce_graphics/fonts/juce_Font.cpp
+++ b/JuceLibraryCode/modules/juce_graphics/fonts/juce_Font.cpp
@@ -35,8 +35,8 @@ namespace FontValues
 
     const float defaultFontHeight = 14.0f;
     float minimumHorizontalScale = 0.7f;
-    String fallbackFont;
-    String fallbackFontStyle;
+    String fallbackFont = String("");
+    String fallbackFontStyle = String("");
 }
 
 using GetTypefaceForFont = Typeface::Ptr (*)(const Font&);

--- a/JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToggleButton.h
+++ b/JuceLibraryCode/modules/juce_gui_basics/buttons/juce_ToggleButton.h
@@ -77,6 +77,7 @@ public:
     };
 
     /** @internal */
+    
     std::unique_ptr<AccessibilityHandler> createAccessibilityHandler() override;
 
 protected:

--- a/Plugins/ArduinoOutput/CMakeLists.txt
+++ b/Plugins/ArduinoOutput/CMakeLists.txt
@@ -16,5 +16,9 @@ add_sources(${PLUGIN_NAME}
 if(MSVC)
 	target_link_libraries(${PLUGIN_NAME} Winmm.lib)
 endif()
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 #optional: create IDE groups
 plugin_create_filters()

--- a/Plugins/ArduinoOutput/Tests/ArduinoOutputTests.cpp
+++ b/Plugins/ArduinoOutput/Tests/ArduinoOutputTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../ArduinoOutput.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class ArduinoOutputTests : public ProcessorTest {
+protected:
+    ArduinoOutputTests() : ProcessorTest(1, 150) {
+    }
+
+    ~ArduinoOutputTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Plugins/ArduinoOutput/Tests/CMakeLists.txt
+++ b/Plugins/ArduinoOutput/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    ArduinoOutputTests.cpp
+)

--- a/Plugins/BasicSpikeDisplay/CMakeLists.txt
+++ b/Plugins/BasicSpikeDisplay/CMakeLists.txt
@@ -23,6 +23,10 @@ add_sources(${PLUGIN_NAME}
 	SpikeDisplayNode/SpikeDisplayNode.cpp
 	SpikeDisplayNode/SpikeDisplayNode.h
 	)
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 	
 #optional: create IDE groups
 plugin_create_filters()

--- a/Plugins/BasicSpikeDisplay/Tests/CMakeLists.txt
+++ b/Plugins/BasicSpikeDisplay/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    SpikeDetectorNodeTests.cpp
+)

--- a/Plugins/BasicSpikeDisplay/Tests/SpikeDetectorNodeTests.cpp
+++ b/Plugins/BasicSpikeDisplay/Tests/SpikeDetectorNodeTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../SpikeDisplayNode/SpikeDisplayNode.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class SpikeDetectorNodeTests : public ProcessorTest {
+protected:
+    SpikeDetectorNodeTests() : ProcessorTest(1, 150) {
+    }
+
+    ~SpikeDetectorNodeTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Plugins/ChannelMappingNode/CMakeLists.txt
+++ b/Plugins/ChannelMappingNode/CMakeLists.txt
@@ -12,6 +12,10 @@ add_sources(${PLUGIN_NAME}
 	ChannelMappingEditor.h
 	PrbFormat.h
 	)
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 	
 #optional: create IDE groups
 #plugin_create_filters()

--- a/Plugins/ChannelMappingNode/Tests/CMakeLists.txt
+++ b/Plugins/ChannelMappingNode/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    ChannelMappingNodeTests.cpp
+)

--- a/Plugins/ChannelMappingNode/Tests/ChannelMappingNodeTests.cpp
+++ b/Plugins/ChannelMappingNode/Tests/ChannelMappingNodeTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../ChannelMappingNode.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class ChannelMappingNodeTests : public ProcessorTest {
+protected:
+    ChannelMappingNodeTests() : ProcessorTest(1, 150) {
+    }
+
+    ~ChannelMappingNodeTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Plugins/CommonAverageRef/CMakeLists.txt
+++ b/Plugins/CommonAverageRef/CMakeLists.txt
@@ -11,6 +11,10 @@ add_sources(${PLUGIN_NAME}
 	CommonAverageRefEditor.cpp
 	CommonAverageRefEditor.h
 	)
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 	
 #optional: create IDE groups
 #plugin_create_filters()

--- a/Plugins/CommonAverageRef/Tests/CMakeLists.txt
+++ b/Plugins/CommonAverageRef/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    CommonAverageRefTests.cpp
+)

--- a/Plugins/CommonAverageRef/Tests/CommonAverageRefTests.cpp
+++ b/Plugins/CommonAverageRef/Tests/CommonAverageRefTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../CommonAverageRef.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class CommonAverageRefTests : public ProcessorTest {
+protected:
+    CommonAverageRefTests() : ProcessorTest(1, 150) {
+    }
+
+    ~CommonAverageRefTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Plugins/FilterNode/CMakeLists.txt
+++ b/Plugins/FilterNode/CMakeLists.txt
@@ -11,6 +11,10 @@ add_sources(${PLUGIN_NAME}
 	FilterEditor.cpp
 	FilterEditor.h
 	)
-	
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
+
+
 #optional: create IDE groups
 #plugin_create_filters()

--- a/Plugins/FilterNode/FilterNode.cpp
+++ b/Plugins/FilterNode/FilterNode.cpp
@@ -65,8 +65,8 @@ void BandpassFilterSettings::setFilterParameters(double lowCut, double highCut, 
 }
 
 
-FilterNode::FilterNode()
-    : GenericProcessor  ("Bandpass Filter")
+FilterNode::FilterNode(bool headless)
+    : GenericProcessor  ("Bandpass Filter", headless)
 {
 
     addFloatParameter(Parameter::STREAM_SCOPE, "high_cut", "Filter high cut", 6000, 0.1, 15000, false);

--- a/Plugins/FilterNode/FilterNode.h
+++ b/Plugins/FilterNode/FilterNode.h
@@ -62,12 +62,12 @@ public:
 
     @see GenericProcessor, FilterEditor
 */
-class FilterNode : public GenericProcessor
+class TESTABLE FilterNode : public GenericProcessor
 {
 public:
 
     /** The class constructor, used to initialize any members. */
-    FilterNode();
+    FilterNode(bool headless = false);
 
     /** The class destructor, used to deallocate memory. */
     ~FilterNode() { }

--- a/Plugins/FilterNode/Tests/CMakeLists.txt
+++ b/Plugins/FilterNode/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    FilterNodeTests.cpp
+)

--- a/Plugins/FilterNode/Tests/FilterNodeTests.cpp
+++ b/Plugins/FilterNode/Tests/FilterNodeTests.cpp
@@ -1,0 +1,85 @@
+//
+//  FilterNode_Tests.cpp
+//  FilterNode_tests
+//
+//  Created by Allen Munk on 3/15/23.
+//
+
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../FilterNode.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+#include <cmath>
+class FilterNodeTests : public ProcessorTest {
+protected:
+    FilterNodeTests() : ProcessorTest(1, 150) {
+        uut = std::make_unique<FilterNode>(true);
+    }
+
+    ~FilterNodeTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+        uut->setSourceNode(sn.get());
+        uut->update();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+    
+    std::unique_ptr<FilterNode> uut;
+    std::unique_ptr<AudioBuffer<float>> signal;
+    
+    void buildSineWave(int frequency){
+        const DataStream* stream = uut -> getDataStreams().getFirst();
+        signal = std::make_unique<AudioBuffer<float>>(stream->getContinuousChannels().size(), frequency);
+        for(int i = 0; i < frequency; i++){
+            signal -> addSample(0, i, 10*sin((2*3.1415*i)/frequency));
+        }
+    }
+    
+    void setHighCut(float value){
+        Parameter* highCut = uut->getParameter("high_cut");
+        highCut -> currentValue = value;
+        uut->parameterChangeRequest(highCut);
+    }
+    
+    void setLowCut(float value){
+        uint16 streamId = uut->getDataStreams().getFirst()->getStreamId();
+        Parameter* lowCut = uut->getParameter("low_cut");
+        lowCut -> currentValue = value;
+        uut->parameterChangeRequest(lowCut);
+    }
+    
+    void dumpAllSamples() {
+            for(int i = 0; i < signal -> getNumSamples(); i++) {
+                for(int j = 0; j < signal -> getNumChannels(); j++) {
+                    std::cout << signal -> getSample(j, i) << std::endl;
+                }
+            }
+    }
+
+};
+
+TEST_F(FilterNodeTests, ContructorTest) {
+    ASSERT_EQ(uut -> getDisplayName(), "Bandpass Filter");
+}
+
+TEST_F(FilterNodeTests, CutoffTest) {
+    buildSineWave(150);
+
+    setHighCut(60);
+    setLowCut(10);
+    AccessClass::ExternalProcessorAccessor::injectNumSamples(uut.get(), uut -> getDataStreams().getFirst() -> getStreamId(), 150);
+    uut->process(*(signal.get()));
+
+    
+}

--- a/Plugins/Headers/ProcessorHeaders.h
+++ b/Plugins/Headers/ProcessorHeaders.h
@@ -30,4 +30,5 @@ Should be included in the source files which declare a processor class.
 #include "../../Source/Processors/GenericProcessor/GenericProcessor.h"
 #include "../../Source/Processors/Events/Event.h"
 #include "../../Source/Processors/Events/Spike.h"
+#include "../../Source/TestableExport.h"
 #include "DspLib.h"

--- a/Plugins/LfpDisplayNode/CMakeLists.txt
+++ b/Plugins/LfpDisplayNode/CMakeLists.txt
@@ -57,6 +57,10 @@ add_sources(${PLUGIN_NAME}
 	ColourSchemes/LightBackgroundColourScheme.cpp
 	ColourSchemes/LightBackgroundColourScheme.h
 	)
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 	
 #optional: create IDE groups
 plugin_create_filters()

--- a/Plugins/LfpDisplayNode/Tests/CMakeLists.txt
+++ b/Plugins/LfpDisplayNode/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    LfpDisplayNodeTests.cpp
+)

--- a/Plugins/LfpDisplayNode/Tests/LfpDisplayNodeTests.cpp
+++ b/Plugins/LfpDisplayNode/Tests/LfpDisplayNodeTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../LfpDisplayNode.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class LfpDisplayNodeTests : public ProcessorTest {
+protected:
+    LfpDisplayNodeTests() : ProcessorTest(1, 150) {
+    }
+
+    ~LfpDisplayNodeTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Plugins/PhaseDetector/CMakeLists.txt
+++ b/Plugins/PhaseDetector/CMakeLists.txt
@@ -11,6 +11,10 @@ add_sources(${PLUGIN_NAME}
 	PhaseDetectorEditor.cpp
 	PhaseDetectorEditor.h
 	)
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 	
 #optional: create IDE groups
 #plugin_create_filters()

--- a/Plugins/PhaseDetector/Tests/CMakeLists.txt
+++ b/Plugins/PhaseDetector/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    PhaseDetectorTests.cpp
+)

--- a/Plugins/PhaseDetector/Tests/PhaseDetectorTests.cpp
+++ b/Plugins/PhaseDetector/Tests/PhaseDetectorTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../PhaseDetector.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class PhaseDetectorTests : public ProcessorTest {
+protected:
+    PhaseDetectorTests() : ProcessorTest(1, 150) {
+    }
+
+    ~PhaseDetectorTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Plugins/PluginRules.cmake
+++ b/Plugins/PluginRules.cmake
@@ -1,16 +1,39 @@
 #common options for default plug-ins
 unset(PROJECT_FOLDER)
 unset(PLUGIN_NAME)
+set(INSTALL_GTEST OFF)
 get_filename_component(PROJECT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
 get_filename_component(PLUGIN_NAME ${PROJECT_FOLDER} NAME)
 
 if (APPLE)
-	add_library(${PLUGIN_NAME} MODULE OpenEphysLib.cpp)
+	if(BUILD_TESTS)
+		add_library(${PLUGIN_NAME} SHARED OpenEphysLib.cpp)
+	else()
+		add_library(${PLUGIN_NAME} MODULE OpenEphysLib.cpp)
+	endif()
 else()
 	add_library(${PLUGIN_NAME} SHARED OpenEphysLib.cpp)
 endif()
 
-add_dependencies(${PLUGIN_NAME} open-ephys)
+if(BUILD_TESTS)
+	include(FetchContent)
+	FetchContent_Declare(
+			googletest
+			GIT_REPOSITORY    https://github.com/google/googletest.git
+			GIT_TAG           release-1.12.1
+	)
+
+	FetchContent_MakeAvailable(googletest)
+	enable_testing()
+
+	add_executable(
+			${PLUGIN_NAME}_tests
+	)
+	target_compile_features(${PLUGIN_NAME}_tests PRIVATE cxx_std_17)
+else()
+	add_dependencies(${PLUGIN_NAME} open-ephys)
+endif()
+
 target_include_directories(${PLUGIN_NAME} PRIVATE ${JUCE_DIRECTORY} ${JUCE_DIRECTORY}/modules ${PLUGIN_HEADER_PATH})
 target_compile_features(${PLUGIN_NAME} PUBLIC cxx_auto_type cxx_generalized_initializers)
 
@@ -19,8 +42,12 @@ target_compile_features(${PLUGIN_NAME} PRIVATE cxx_std_17)
 
 #Libraries and compiler options
 if(MSVC)
-	target_link_libraries(${PLUGIN_NAME} $<TARGET_FILE_DIR:open-ephys>/open-ephys.lib)
-	target_compile_options(${PLUGIN_NAME} PRIVATE /sdl- /W0)
+	if(BUILD_TESTS)
+ 		target_link_libraries(${PLUGIN_NAME} gui_testable_source)
+ 	else()
+ 		target_link_libraries(${PLUGIN_NAME} $<TARGET_FILE_DIR:open-ephys>/open-ephys.lib)
+ 	endif()	
+ 	target_compile_options(${PLUGIN_NAME} PRIVATE /sdl- /W0)
 elseif(LINUX)
 	target_link_libraries(${PLUGIN_NAME} GL X11 Xext Xinerama asound dl freetype pthread rt)
 	set_property(TARGET ${PLUGIN_NAME} APPEND_STRING PROPERTY LINK_FLAGS
@@ -45,9 +72,29 @@ elseif(APPLE)
 		)
 endif()
 
+if(BUILD_TESTS)
+	add_dependencies(${PLUGIN_NAME}_tests ${PLUGIN_NAME} gui_testable_source test_helpers)
+	target_link_libraries(${PLUGIN_NAME}_tests PRIVATE ${PLUGIN_NAME} gtest_main test_helpers PUBLIC gui_testable_source)
+	target_include_directories(${PLUGIN_NAME}_tests PRIVATE ${JUCE_DIRECTORY} ${JUCE_DIRECTORY}/modules ${PLUGIN_HEADER_PATH} ${TEST_HELPERS_DIRECTORY}/include)
+	add_test(NAME ${PLUGIN_NAME}_tests  COMMAND ${PLUGIN_NAME}_tests)
+
+	get_target_property(PLUGIN_BASES gui_testable_source SOURCES)
+	source_group("Plugin Base Classes" FILES ${PLUGIN_BASES})
+endif()
+
 #output folders
-set_property(TARGET ${PLUGIN_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${BIN_PLUGIN_DIR})
-set_property(TARGET ${PLUGIN_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${BIN_PLUGIN_DIR})
+if(BUILD_TESTS)
+ 	set_property(TARGET ${PLUGIN_NAME}_tests PROPERTY RUNTIME_OUTPUT_DIRECTORY ${BIN_TESTS_DIR}/${PLUGIN_NAME})
+ 	set_property(TARGET ${PLUGIN_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${BIN_TESTS_DIR}/${PLUGIN_NAME})
+ 	set_property(TARGET ${PLUGIN_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${BIN_TESTS_DIR}/${PLUGIN_NAME})
+
+ 	add_custom_command(TARGET ${PLUGIN_NAME}_tests POST_BUILD
+ 				COMMAND ${CMAKE_COMMAND} -E copy_directory ${BIN_TESTS_DIR}/common ${BIN_TESTS_DIR}/${PLUGIN_NAME})
+ else()
+ 	set_property(TARGET ${PLUGIN_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${BIN_PLUGIN_DIR})
+ 	set_property(TARGET ${PLUGIN_NAME} PROPERTY LIBRARY_OUTPUT_DIRECTORY ${BIN_PLUGIN_DIR})
+ endif()
+
 
 
 #This function is to be called to organize filters in VisualStudio and XCode in plugins with subfilders
@@ -55,7 +102,7 @@ function(plugin_create_filters)
 get_target_property(PLUGIN_SRC_FILES ${PLUGIN_NAME} SOURCES)
 
 foreach( plugin_src_file IN ITEMS ${PLUGIN_SRC_FILES})
-	if (NOT ${plugin_src_file} STREQUAL "OpenEphysLib.cpp")
+	if (NOT ${plugin_src_file} STREQUAL "OpenEphysLib.cpp" )
 		get_filename_component(plugin_src_path "${plugin_src_file}" PATH)
 		file(RELATIVE_PATH plugin_src_path_rel "${CMAKE_CURRENT_SOURCE_DIR}" "${plugin_src_path}")
 		string(REPLACE "/" "\\" plugin_group_name "${plugin_src_path_rel}")

--- a/Plugins/RecordControl/CMakeLists.txt
+++ b/Plugins/RecordControl/CMakeLists.txt
@@ -11,6 +11,10 @@ add_sources(${PLUGIN_NAME}
 	RecordControlEditor.cpp
 	RecordControlEditor.h
 	)
+
+if(BUILD_TESTS)
+    add_subdirectory(Tests)
+endif()
 	
 #optional: create IDE groups
 #plugin_create_filters()

--- a/Plugins/RecordControl/Tests/CMakeLists.txt
+++ b/Plugins/RecordControl/Tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+add_sources(${PLUGIN_NAME}_tests
+    RecordControlTests.cpp
+)

--- a/Plugins/RecordControl/Tests/RecordControlTests.cpp
+++ b/Plugins/RecordControl/Tests/RecordControlTests.cpp
@@ -1,0 +1,30 @@
+#include <stdio.h>
+
+#include "gtest/gtest.h"
+
+#include "../RecordControl.h"
+#include <ProcessorHeaders.h>
+#include <ModelProcessors.h>
+#include <ModelApplication.h>
+#include <TestFixtures.h>
+
+class RecordControlTests : public ProcessorTest {
+protected:
+    RecordControlTests() : ProcessorTest(1, 150) {
+    }
+
+    ~RecordControlTests() override {
+    }
+
+    void SetUp() override {
+        ProcessorTest::SetUp();
+    }
+
+    void TearDown() override {
+        ProcessorTest::TearDown();
+
+    }
+
+};
+
+

--- a/Source/AccessClass.cpp
+++ b/Source/AccessClass.cpp
@@ -159,4 +159,15 @@ MidiBuffer* ExternalProcessorAccessor::getMidiBuffer(GenericProcessor* proc)
 	return proc->m_currentMidiBuffer;
 }
 
+
+void ExternalProcessorAccessor::injectNumSamples(GenericProcessor *proc, uint16_t dataStream, uint32_t numSamples) {
+    proc->numSamplesInBlock[dataStream] = numSamples;
+}
+
+//**Set the MessageCenter for testing only**//
+void setMessageCenter(MessageCenter * mc_){
+    if(pg != nullptr) return;
+    mc = mc_;
+}
+
 }

--- a/Source/AccessClass.h
+++ b/Source/AccessClass.h
@@ -24,7 +24,11 @@
 #ifndef __ACCESSCLASS_H_CE1DC2DE__
 #define __ACCESSCLASS_H_CE1DC2DE__
 
+
+
 #include "../JuceLibraryCode/JuceHeader.h"
+#include "TestableExport.h"
+
 
 class UIComponent;
 class EditorViewport;
@@ -94,6 +98,8 @@ PluginManager* getPluginManager();
 /** Retursn a pointer to the */
 ActionBroadcaster* getBroadcaster();
 
+void TESTABLE setMessageCenter(MessageCenter * mc_);
+
 void shutdownBroadcaster();
 
 //Methods to access some private members of GenericProcessors.
@@ -101,11 +107,12 @@ void shutdownBroadcaster();
 //used by various internal parts of the core GUI which need access
 //to those members, while keeping them inaccessible by normal plugins
 
-class ExternalProcessorAccessor
+class TESTABLE ExternalProcessorAccessor
 {
 
 public:
 	static MidiBuffer* getMidiBuffer(GenericProcessor* proc);
+    static void injectNumSamples(GenericProcessor* proc, uint16_t dataStream, uint32_t numSamples);
 };
 
 };

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,7 +1,8 @@
 #Open Ephys GUI directory-specific file
 
 #add files in this folder
-add_sources(open-ephys 
+add_sources(open-ephys
+	TestableExport.h
 	AccessClass.h
 	AccessClass.cpp
 	CoreServices.h

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -101,7 +101,7 @@ MainWindow::MainWindow(const File& fileToLoad, bool isConsoleApp_) :
         MenuBarModel::setMacMainMenu(ui);
         documentWindow->setMenuBar(0);
     #else
-        documentWindow->setMenuBar(this);
+        documentWindow->setMenuBar(ui);
         documentWindow->getMenuBarComponent()->setName("MainMenu");
     #endif
 

--- a/Source/Processors/GenericProcessor/GenericProcessor.cpp
+++ b/Source/Processors/GenericProcessor/GenericProcessor.cpp
@@ -1047,6 +1047,7 @@ void GenericProcessor::update()
               if (param->getType() == Parameter::SELECTED_CHANNELS_PARAM)
               {
                    
+                   
                  SelectedChannelsParameter* p = (SelectedChannelsParameter*) spikeChannel->getParameter(param->getName());
                      
                  p->setChannelCount(channelCount);

--- a/Source/Processors/MessageCenter/MessageCenter.h
+++ b/Source/Processors/MessageCenter/MessageCenter.h
@@ -24,7 +24,7 @@
 #ifndef __MESSAGECENTER_H_2695FC38__
 #define __MESSAGECENTER_H_2695FC38__
 
-
+#include "../../TestableExport.h"
 #include "../../../JuceLibraryCode/JuceHeader.h"
 #include <stdio.h>
 
@@ -44,7 +44,7 @@ class MessageCenterEditor;
 
 */
 
-class MessageCenter : public GenericProcessor,
+class TESTABLE MessageCenter : public GenericProcessor,
     public ActionListener
 
 {

--- a/Source/TestableExport.h
+++ b/Source/TestableExport.h
@@ -1,0 +1,20 @@
+#ifndef TESTABLEEXPORT_H
+#define TESTABLEEXPORT_H
+
+#ifdef BUILD_TESTS
+#ifdef _WIN32
+#ifdef TEST_RUNNER
+#define TESTABLE __declspec(dllimport)
+#else
+#define TESTABLE __declspec(dllexport)
+#endif
+#else
+#define TESTABLE __attribute__((visibility("default")))
+#endif
+#else
+#define TESTABLE
+#endif
+
+
+
+#endif

--- a/Source/UI/DefaultConfig.cpp
+++ b/Source/UI/DefaultConfig.cpp
@@ -54,7 +54,7 @@ void DefaultConfigWindow::launchWindow()
 	configComponent = new DefaultConfigComponent();
 	options.content.setOwned (configComponent);
 
-	Rectangle<int> area (0, 0, 450, 300);
+	juce::Rectangle<int> area (0, 0, 450, 300);
 	options.content->setSize (area.getWidth(), area.getHeight());
 
 	options.componentToCentreAround 	  = parent;

--- a/Source/UI/EditorViewport.cpp
+++ b/Source/UI/EditorViewport.cpp
@@ -848,7 +848,7 @@ void EditorViewport::mouseDown(const MouseEvent& e)
                     
                     File outputFile = picturesDirectory.getChildFile(editorArray[i]->getNameAndId() + ".png");
                     
-                    Rectangle<int> bounds = Rectangle<int>(3, 3, editorArray[i]->getWidth()-6, editorArray[i]->getHeight()-6);
+                    juce::Rectangle<int> bounds = juce::Rectangle<int>(3, 3, editorArray[i]->getWidth()-6, editorArray[i]->getHeight()-6);
                     
                     Image componentImage = editorArray[i]->createComponentSnapshot(
                                                                                    bounds,
@@ -1475,7 +1475,8 @@ std::unique_ptr<XmlElement> EditorViewport::createSettingsXml()
 
 XmlElement* EditorViewport::createNodeXml(GenericProcessor* processor, bool isStartOfSignalChain)
 {
-    AccessClass::getProcessorGraph()->createNodeXml(processor, isStartOfSignalChain);
+    XmlElement* node = AccessClass::getProcessorGraph()->createNodeXml(processor, isStartOfSignalChain);
+    return node;
 }
 
 
@@ -1510,7 +1511,7 @@ const String EditorViewport::loadStateFromXml(XmlElement* xml)
 {
     
     AccessClass::getProcessorGraph()->loadFromXml(xml);
-    
+    return String();
 }
 
 void EditorViewport::deleteSelectedProcessors()

--- a/Source/UI/LookAndFeel/CustomLookAndFeel.h
+++ b/Source/UI/LookAndFeel/CustomLookAndFeel.h
@@ -106,7 +106,7 @@ public:
                        bool isMouseDown);
     
     // ======== custom tooltip methods: ============================
-    Rectangle<int> getTooltipBounds(const String &tipText, Point<int> screenPos, Rectangle<int> parentArea) override;
+    juce::Rectangle<int> getTooltipBounds(const String &tipText, Point<int> screenPos, juce::Rectangle<int> parentArea) override;
     
     void drawTooltip(Graphics &, const String &text, int width, int height) override;
 

--- a/Source/UI/PluginInstaller.cpp
+++ b/Source/UI/PluginInstaller.cpp
@@ -59,7 +59,7 @@ static inline File getSharedDirectory() {
     return std::move(dir);
 }
 
-static String osType;
+static String osType = String("");
 StringArray updatablePlugins;
 
 PluginInstaller::PluginInstaller(MainWindow* mainWindow, bool loadComponents)

--- a/TestHelpers/Application/CMakeLists.txt
+++ b/TestHelpers/Application/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+
+add_sources(test_helpers
+    StubAccessClass.cpp
+    StubAccessClass.h
+)
+

--- a/TestHelpers/Application/StubAccessClass.cpp
+++ b/TestHelpers/Application/StubAccessClass.cpp
@@ -1,0 +1,7 @@
+#include "StubAccessClass.h"
+
+void StubAccessClass::addMessageCenter(){
+    stubMC = std::make_unique<MessageCenter>();
+    stubMC->addSpecialProcessorChannels();
+    AccessClass::setMessageCenter(stubMC.get());
+}

--- a/TestHelpers/Application/StubAccessClass.h
+++ b/TestHelpers/Application/StubAccessClass.h
@@ -1,0 +1,14 @@
+#ifndef STUBACCESSCLASS_H
+#define STUBACCESSCLASS_H
+
+#include <NonAPIHeaders.h>
+
+class TESTABLE StubAccessClass {
+public:
+    void addMessageCenter();
+private:
+    std::unique_ptr<MessageCenter> stubMC;
+};
+
+
+#endif

--- a/TestHelpers/CMakeLists.txt
+++ b/TestHelpers/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.15)
+
+add_library(test_helpers SHARED)
+
+target_compile_features(test_helpers PRIVATE cxx_std_17)
+
+add_dependencies(test_helpers gui_testable_source)
+target_include_directories(test_helpers PRIVATE ${JUCE_DIRECTORY} ${JUCE_DIRECTORY}/modules ${PLUGINS_DIRECTORY}/Headers include)
+target_link_libraries(test_helpers PRIVATE gui_testable_source)
+
+set_property(TARGET test_helpers PROPERTY RUNTIME_OUTPUT_DIRECTORY ${BIN_TESTS_DIR}/common)
+set_property(TARGET test_helpers PROPERTY LIBRARY_OUTPUT_DIRECTORY ${BIN_TESTS_DIR}/common)
+
+add_subdirectory(Processors)
+add_subdirectory(Application)

--- a/TestHelpers/Processors/CMakeLists.txt
+++ b/TestHelpers/Processors/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.15)
+
+add_sources(test_helpers
+    FakeSourceNode.cpp
+    FakeSourceNode.h
+)
+

--- a/TestHelpers/Processors/FakeSourceNode.cpp
+++ b/TestHelpers/Processors/FakeSourceNode.cpp
@@ -1,0 +1,40 @@
+#include "FakeSourceNode.h"
+
+FakeSourceNode::FakeSourceNode(int channels, float sampleRate) : GenericProcessor("Fake Source Node"), channels(channels), sampleRate(sampleRate){}
+
+void FakeSourceNode::addMessageChannel() {
+    
+}
+
+void FakeSourceNode::addTestDataStreams() {
+    DataStream::Settings settings
+    {
+        "FakeSourceNode",
+        "description",
+        "identifier",
+        sampleRate
+    };
+    
+    dataStreams.add(new DataStream(settings));
+    
+    for (int index= 0; index < channels; index++)
+    {
+        
+        ContinuousChannel::Settings settings{
+            ContinuousChannel::Type::ELECTRODE,
+            "CH" + String(index),
+            String(index),
+            "identifier",
+            
+            1.0,
+            
+            dataStreams.getFirst()
+        };
+        
+        continuousChannels.add(new ContinuousChannel(settings));
+    }
+
+}
+
+void FakeSourceNode::process(AudioBuffer<float>& continuousBuffer) {}
+

--- a/TestHelpers/Processors/FakeSourceNode.h
+++ b/TestHelpers/Processors/FakeSourceNode.h
@@ -1,0 +1,22 @@
+#ifndef FAKESOURCENODE_H
+#define FAKESOURCENODE_H
+
+#include <ProcessorHeaders.h>
+#include <NonAPIHeaders.h>
+
+class TESTABLE FakeSourceNode : public GenericProcessor {
+public:
+    FakeSourceNode(int channels = 1, float sampleRate = 20000.0f);
+    
+    void addMessageChannel();
+    void addTestDataStreams();
+    
+    void process(AudioBuffer<float>& continuousBuffer) override;
+    
+private:
+    int channels;
+    float sampleRate;
+};
+
+
+#endif

--- a/TestHelpers/include/ModelApplication.h
+++ b/TestHelpers/include/ModelApplication.h
@@ -1,0 +1,7 @@
+#ifndef FAKEAPPLICATION_H
+#define FAKEAPPLICATION_H
+
+#include "../Application/StubAccessClass.h"
+
+
+#endif

--- a/TestHelpers/include/ModelProcessors.h
+++ b/TestHelpers/include/ModelProcessors.h
@@ -1,0 +1,4 @@
+#ifndef FAKEPROCESSORS_H
+#define FAKEPROCESSORS_H
+#include "../Processors/FakeSourceNode.h"
+#endif

--- a/TestHelpers/include/NonAPIHeaders.h
+++ b/TestHelpers/include/NonAPIHeaders.h
@@ -1,0 +1,13 @@
+#ifndef NONAPIHEADERS_H
+#define NONAPIHEADERS_H
+/*This file includes headers from the main GUI that are not encapsulated by the 
+  Plugin API headers, yet are needed by mocks/fakes/stubs
+*/
+
+#include "../../Source/AccessClass.h"
+#include "../../Source/TestableExport.h"
+
+#include "../../Source/Processors/MessageCenter/MessageCenter.h"
+#include "../../Source/Processors/MessageCenter/MessageCenterEditor.h"
+
+#endif

--- a/TestHelpers/include/TestFixtures.h
+++ b/TestHelpers/include/TestFixtures.h
@@ -1,0 +1,33 @@
+#ifndef TESTFIXTURES_H
+#define TESTFIXTURES_H
+
+#include "gtest/gtest.h"
+
+class ProcessorTest : public ::testing::Test {
+protected:
+    ProcessorTest(int channels, int sampleRate) {
+        sn = std::make_unique<FakeSourceNode>(channels, sampleRate);
+        ac = std::make_unique<StubAccessClass>();
+    }
+
+    ~ProcessorTest() override {
+    }
+
+    void SetUp() override {
+
+        ac->addMessageCenter();
+        sn->addTestDataStreams();
+        sn->update();
+
+    }
+
+    void TearDown() override {
+
+    }
+    std::unique_ptr<FakeSourceNode> sn;
+    std::unique_ptr<StubAccessClass> ac;
+
+};
+
+
+#endif

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+project(open-ephys-components)
+set(CMAKE_SHARED_LIBRARY_PREFIX "")
+
+set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
+			OEPLUGIN
+			"$<$<PLATFORM_ID:Windows>:JUCE_API=__declspec(dllimport)>"
+			)
+
+
+add_subdirectory(Processors)

--- a/Tests/ComponentRules.cmake
+++ b/Tests/ComponentRules.cmake
@@ -1,0 +1,37 @@
+#common options for default plug-ins
+unset(PROJECT_FOLDER)
+unset(COMPONENT_NAME)
+set(INSTALL_GTEST OFF)
+get_filename_component(PROJECT_FOLDER ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
+get_filename_component(COMPONENT_NAME ${PROJECT_FOLDER} NAME)
+
+include(FetchContent)
+FetchContent_Declare(
+		googletest
+		GIT_REPOSITORY    https://github.com/google/googletest.git
+		GIT_TAG           release-1.12.1
+)
+
+FetchContent_MakeAvailable(googletest)
+enable_testing()
+
+add_executable(
+		${COMPONENT_NAME}_tests
+)
+target_compile_features(${COMPONENT_NAME}_tests PRIVATE cxx_std_17)
+
+
+add_dependencies(${COMPONENT_NAME}_tests gui_testable_source)
+target_compile_definitions(${COMPONENT_NAME}_tests PRIVATE -DTEST_RUNNER)
+target_link_libraries(${COMPONENT_NAME}_tests PRIVATE gtest_main gui_testable_source)
+target_include_directories(${COMPONENT_NAME}_tests PRIVATE ${JUCE_DIRECTORY} ${JUCE_DIRECTORY}/modules)
+add_test(NAME ${COMPONENT_NAME}_tests  COMMAND ${COMPONENT_NAME}_tests)
+
+
+set_property(TARGET ${COMPONENT_NAME}_tests PROPERTY RUNTIME_OUTPUT_DIRECTORY ${BIN_TESTS_DIR}/${COMPONENT_NAME})
+
+add_custom_command(TARGET ${COMPONENT_NAME}_tests POST_BUILD
+	COMMAND ${CMAKE_COMMAND} -E copy_directory ${BIN_TESTS_DIR}/common ${BIN_TESTS_DIR}/${COMPONENT_NAME})
+
+get_target_property(PLUGIN_BASES gui_testable_source SOURCES)
+source_group("Plugin Base Classes" FILES ${PLUGIN_BASES})

--- a/Tests/Processors/CMakeLists.txt
+++ b/Tests/Processors/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.15)
+
+include(../ComponentRules.cmake)
+
+target_include_directories(${COMPONENT_NAME}_tests PRIVATE "${SOURCE_DIRECTORY}/Processors/DataThreads/")
+
+add_sources(${COMPONENT_NAME}_tests
+    DataBufferTests.cpp
+)

--- a/Tests/Processors/DataBufferTests.cpp
+++ b/Tests/Processors/DataBufferTests.cpp
@@ -1,0 +1,13 @@
+#include "gtest/gtest.h"
+
+#include <DataBuffer.h>
+
+TEST(DataBuffer, AddToBufferSanityTest) {
+    DataBuffer db(32, 4*32);
+    float data;
+    int64 sampleNumbers;
+    double timestamps;
+    uint64 eventCodes;
+    db.addToBuffer(&data, &sampleNumbers, &timestamps, &eventCodes, 1);
+    ASSERT_EQ(db.getNumSamples(), 1);
+}


### PR DESCRIPTION
  - Add gui_testable_source target to compile all GUI components except main()
  - Add compilation steps to compile tests for Plugins/
  - Add tests_helpers target to compile fake/mock/stub classes for tests
  - Add Tests/ to allow for testing of Source/ components