### PR TITLE
Add Auto Updater to the GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Open Ephys GUI main build file
 cmake_minimum_required(VERSION 3.15)
 
-set(GUI_VERSION 0.6.3)
+set(GUI_VERSION 0.6.4)
 
 string(REGEX MATCHALL "[0-9]+" VERSION_LIST ${GUI_VERSION})
 set(GUI_VERSION_HEX "0x")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Open Ephys GUI main build file
 cmake_minimum_required(VERSION 3.15)
 
-set(GUI_VERSION 0.6.4)
+set(GUI_VERSION 0.6.3)
 
 string(REGEX MATCHALL "[0-9]+" VERSION_LIST ${GUI_VERSION})
 set(GUI_VERSION_HEX "0x")

--- a/Source/AutoUpdater.cpp
+++ b/Source/AutoUpdater.cpp
@@ -503,10 +503,9 @@ void LatestVersionCheckerAndUpdater::downloadAndInstall (const Asset& asset, con
         }
         else
         {
-            msgBoxString = "Please launch the installer file located at: \n" + 
+            msgBoxString = "Please quit the GUI first, then launch the installer file located at: \n" + 
                             targetFile.getFullPathName().quoted() +
-                            "\nafter closing the GUI, "
-                            "and follow the steps to finish updating the GUI.";
+                            "\nand follow the steps to finish updating the GUI.";
         }
         
         

--- a/Source/AutoUpdater.cpp
+++ b/Source/AutoUpdater.cpp
@@ -466,17 +466,20 @@ void LatestVersionCheckerAndUpdater::downloadAndInstall (const Asset& asset, con
     else
 #endif
     {
-        AlertWindow::showMessageBoxAsync (AlertWindow::InfoIcon,
-                                            "Download successful!",
-                                            "Please extract the zip file located at: \n" + 
-                                            targetFile.getFullPathName().quoted() +
-                                            "\nto your desired location and then run the updated version from there. "
-                                            "You can also overwrite the current installation after quitting the current instance.");
+        String msgBoxString = "Please extract the zip file located at: \n" + 
+                               targetFile.getFullPathName().quoted() +
+                               "\nto your desired location and then run the updated version from there. "
+                               "You can also overwrite the current installation after quitting the current instance.";
 
         downloader.reset (new DownloadThread (asset, targetFile,
-                                                [this]
+                                                [this, msgBoxString]
                                                 {
                                                     downloader.reset();
+
+                                                    AlertWindow::showMessageBoxAsync
+                                                        (AlertWindow::InfoIcon,
+                                                         "Download successful!",
+                                                         msgBoxString);
                                 
                                                 }));
     }

--- a/Source/AutoUpdater.cpp
+++ b/Source/AutoUpdater.cpp
@@ -1,0 +1,548 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2023 Open Ephys
+
+    ------------------------------------------------------------------
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    Reference : https://github.com/juce-framework/JUCE/blob/6.0.8/extras/Projucer/Source/Application/jucer_AutoUpdater.cpp
+
+*/
+
+#include "AutoUpdater.h"
+#include "CoreServices.h"
+
+//==============================================================================
+LatestVersionCheckerAndUpdater::LatestVersionCheckerAndUpdater()
+    : Thread ("VersionChecker")
+{
+}
+
+LatestVersionCheckerAndUpdater::~LatestVersionCheckerAndUpdater()
+{
+    stopThread (6000);
+    clearSingletonInstance();
+}
+
+void LatestVersionCheckerAndUpdater::checkForNewVersion (bool background)
+{
+    if (! isThreadRunning())
+    {
+        backgroundCheck = background;
+        startThread (3);
+    }
+}
+
+//==============================================================================
+void LatestVersionCheckerAndUpdater::run()
+{
+    LOGC("Checking for a new version....");
+    URL latestVersionURL ("https://api.github.com/repos/open-ephys/plugin-GUI/releases/latest");
+
+    std::unique_ptr<InputStream> inStream (latestVersionURL.createInputStream (URL::InputStreamOptions (URL::ParameterHandling::inAddress)
+                                                                                 .withConnectionTimeoutMs (5000)));
+    const String commErr = "Failed to communicate with the Open Ephys update server.\n"
+                           "Please try again in a few minutes.\n\n"
+                           "If this problem persists you can download the latest version of Open Ephys GUI from open-ephys.org/gui";
+
+    if (inStream == nullptr)
+    {
+        if (! backgroundCheck)
+            AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
+                                              "Update Server Communication Error",
+                                              commErr);
+
+        return;
+    }
+
+    auto content = inStream->readEntireStreamAsString();
+    auto latestReleaseDetails = JSON::parse (content);
+
+    auto* json = latestReleaseDetails.getDynamicObject();
+
+    if (json == nullptr)
+    {
+        if (! backgroundCheck)
+            AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
+                                              "Update Server Communication Error",
+                                              commErr);
+
+        return;
+    }
+
+    auto versionString = json->getProperty ("tag_name").toString();
+
+    if (versionString.isEmpty())
+        return;
+
+    auto* assets = json->getProperty ("assets").getArray();
+
+    if (assets == nullptr)
+        return;
+
+    auto releaseNotes = json->getProperty ("body").toString();
+
+    std::vector<Asset> parsedAssets;
+
+    for (auto& asset : *assets)
+    {
+        if (auto* assetJson = asset.getDynamicObject())
+        {
+            parsedAssets.push_back ({ assetJson->getProperty ("name").toString(),
+                                      assetJson->getProperty ("url").toString(),
+                                      (int)assetJson->getProperty("size")});
+            jassert (parsedAssets.back().name.isNotEmpty());
+            jassert (parsedAssets.back().url.isNotEmpty());
+            jassert (parsedAssets.back().size != 0);
+
+        }
+        else
+        {
+            jassertfalse;
+        }
+    }
+
+    String latestVer = versionString.substring(1);
+
+
+    if (latestVer.compareNatural(CoreServices::getGUIVersion()) <= 0)
+    {
+        if (! backgroundCheck)
+            AlertWindow::showMessageBoxAsync (AlertWindow::InfoIcon,
+                                              "No New Version Available",
+                                              "Your GUI version is up to date.");
+        return;
+    }
+
+    auto osString = []
+    {
+       #if JUCE_MAC
+        return "mac";
+       #elif JUCE_WINDOWS
+        return "windows";
+       #elif JUCE_LINUX
+        return "linux";
+       #else
+        jassertfalse;
+        return "Unknown";
+       #endif
+    }();
+
+#if JUCE_WINDOWS 
+    String requiredFilename ("open-ephys-" + versionString + "-" + osString + ".zip");
+    File exeDir = File::getSpecialLocation(File::SpecialLocationType::currentExecutableFile).getParentDirectory();
+    if(exeDir.findChildFiles(File::findFiles, false, "unins*").size() > 0)
+    {
+        requiredFilename = "Install-Open-Ephys-GUI-" + versionString + ".exe";
+    }
+#elif
+    String requiredFilename ("open-ephys-" + versionString + "-" + osString + ".zip");
+#endif
+    for (auto& asset : parsedAssets)
+    {
+        if (asset.name == requiredFilename)
+        {
+
+            MessageManager::callAsync ([this, versionString, releaseNotes, asset]
+            {
+                askUserAboutNewVersion (versionString, releaseNotes, asset);
+            });
+
+            return;
+        }
+    }
+
+    if (! backgroundCheck)
+        AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
+                                          "Failed to find any new downloads",
+                                          "Please try again in a few minutes.");
+}
+
+//==============================================================================
+class UpdateDialog  : public Component
+{
+public:
+    UpdateDialog (const String& newVersion, const String& releaseNotes)
+    {
+        titleLabel.setText ("Open Ephys GUI version " + newVersion, dontSendNotification);
+        titleLabel.setFont (Font("Fira Sans", "SemiBold", 18.0f));
+        titleLabel.setJustificationType (Justification::centred);
+        addAndMakeVisible (titleLabel);
+
+        contentLabel.setText ("A new version of Open Ephys GUI is available - would you like to download it?", dontSendNotification);
+        contentLabel.setFont (Font("Fira Sans", "Regular", 16.0f));
+        contentLabel.setJustificationType (Justification::topLeft);
+        contentLabel.setMinimumHorizontalScale(1.0);
+        addAndMakeVisible (contentLabel);
+
+        releaseNotesEditor.setMultiLine (true);
+        releaseNotesEditor.setReadOnly (true);
+        releaseNotesEditor.setText (releaseNotes);
+        addAndMakeVisible (releaseNotesEditor);
+
+        addAndMakeVisible (chooseButton);
+        chooseButton.onClick = [this] { exitModalStateWithResult (1); };
+
+        addAndMakeVisible (cancelButton);
+        cancelButton.onClick = [this]
+        {
+            // ProjucerApplication::getApp().setAutomaticVersionCheckingEnabled (! dontAskAgainButton.getToggleState());
+            exitModalStateWithResult (-1);
+        };
+
+        dontAskAgainButton.setToggleState (false, dontSendNotification);
+        addAndMakeVisible (dontAskAgainButton);
+
+#if JUCE_MAC
+    	File iconDir = File::getSpecialLocation(File::currentApplicationFile).getChildFile("Contents/Resources");
+#else
+		File iconDir = File::getSpecialLocation(File::currentApplicationFile).getParentDirectory();
+#endif
+        juceIcon = Drawable::createFromImageFile(iconDir.getChildFile("icon-small.png"));
+        lookAndFeelChanged();
+
+        setSize (640, 480);
+    }
+
+    void resized() override
+    {
+        auto b = getLocalBounds().reduced (10);
+
+        auto topSlice = b.removeFromTop (juceIconBounds.getHeight())
+                         .withTrimmedLeft (juceIconBounds.getWidth());
+
+        titleLabel.setBounds (topSlice.removeFromTop (25));
+        topSlice.removeFromTop (5);
+        contentLabel.setBounds (topSlice.removeFromTop (25));
+
+        auto buttonBounds = b.removeFromBottom (60);
+        buttonBounds.removeFromBottom (25);
+        chooseButton.setBounds (buttonBounds.removeFromLeft (buttonBounds.getWidth() / 2).reduced (20, 0));
+        cancelButton.setBounds (buttonBounds.reduced (20, 0));
+        dontAskAgainButton.setBounds (cancelButton.getBounds().withY (cancelButton.getBottom() + 5).withHeight (20));
+
+        releaseNotesEditor.setBounds (b.reduced (0, 10));
+    }
+
+    void paint (Graphics& g) override
+    {
+        g.fillAll (Colours::lightgrey);
+
+        if (juceIcon != nullptr)
+            juceIcon->drawWithin (g, juceIconBounds.toFloat(),
+                                  RectanglePlacement::stretchToFit, 1.0f);
+    }
+
+    static std::unique_ptr<DialogWindow> launchDialog (const String& newVersionString,
+                                                       const String& releaseNotes)
+    {
+        DialogWindow::LaunchOptions options;
+
+        options.dialogTitle = "Download Open Ephys GUI version " + newVersionString + "?";
+        options.resizable = false;
+
+        auto* content = new UpdateDialog (newVersionString, releaseNotes);
+        options.content.set (content, true);
+
+        std::unique_ptr<DialogWindow> dialog (options.create());
+
+        content->setParentWindow (dialog.get());
+        dialog->enterModalState (true, nullptr, true);
+
+        return dialog;
+    }
+
+private:
+    void lookAndFeelChanged() override
+    {
+        cancelButton.setColour (TextButton::buttonColourId, Colours::crimson);
+        releaseNotesEditor.applyFontToAllText (Font("Fira Sans", "Regular", 16.0f));
+    }
+
+    void setParentWindow (DialogWindow* parent)
+    {
+        parentWindow = parent;
+    }
+
+    void exitModalStateWithResult (int result)
+    {
+        if (parentWindow != nullptr)
+            parentWindow->exitModalState (result);
+    }
+
+    Label titleLabel, contentLabel, releaseNotesLabel;
+    TextEditor releaseNotesEditor;
+    TextButton chooseButton { "Download" }, cancelButton { "Cancel" };
+    ToggleButton dontAskAgainButton { "Don't ask again" };
+    std::unique_ptr<Drawable> juceIcon;
+    Rectangle<int> juceIconBounds { 10, 10, 64, 64 };
+
+    DialogWindow* parentWindow = nullptr;
+};
+
+void LatestVersionCheckerAndUpdater::askUserForLocationToDownload (const Asset& asset)
+{
+    FileChooser chooser ("Please select the location into which you would like to install the new version",
+                         { File::getSpecialLocation(File::userDesktopDirectory) },
+                         "*.exe;*.zip");
+
+    if (chooser.browseForDirectory())
+    {
+        auto targetFolder = chooser.getResult();
+        if (targetFolder == File{})
+            return;
+
+        downloadAndInstall (asset, targetFolder);
+    }
+}
+
+void LatestVersionCheckerAndUpdater::askUserAboutNewVersion (const String& newVersionString,
+                                                             const String& releaseNotes,
+                                                             const Asset& asset)
+{
+    dialogWindow = UpdateDialog::launchDialog (newVersionString, releaseNotes);
+
+    if (auto* mm = ModalComponentManager::getInstance())
+    {
+        mm->attachCallback (dialogWindow.get(),
+                            ModalCallbackFunction::create ([this, asset] (int result)
+                                                           {
+                                                               if (result == 1)
+                                                                    askUserForLocationToDownload (asset);
+
+                                                                dialogWindow.reset();
+                                                            }));
+    }
+}
+
+//==============================================================================
+class DownloadAndInstallThread   : private ThreadWithProgressWindow
+{
+public:
+    DownloadAndInstallThread  (const LatestVersionCheckerAndUpdater::Asset& a,
+                               const File& t,
+                               std::function<void()>&& cb)
+        : ThreadWithProgressWindow ("Downloading New Version", true, true),
+          asset (a), targetFolder (t), completionCallback (std::move (cb))
+    {
+        launchThread (3);
+    }
+
+private:
+    void run() override
+    {
+        setProgress (0.0);
+
+        File targetFile = targetFolder.getChildFile(asset.name).getNonexistentSibling();
+        auto result = download (targetFile);
+
+        // if (result.wasOk() && ! threadShouldExit())
+        //     result = install (zipData);
+
+        if (result.failed())
+        {
+            MessageManager::callAsync ([result] { AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
+                                                                                    "Downloading Failed",
+                                                                                    result.getErrorMessage()); });
+        }
+        else
+        {
+            AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon,
+                                                "Download finished!",
+                                                "New binaries can be found at: " + 
+                                                targetFile.getFullPathName());
+            MessageManager::callAsync (completionCallback);
+        }
+    }
+
+    Result download (File& dest)
+    {
+        setStatusMessage ("Downloading...");
+
+        int statusCode = 0;
+        URL downloadUrl (asset.url);
+        StringPairArray responseHeaders;
+
+        auto inStream = downloadUrl.createInputStream (URL::InputStreamOptions (URL::ParameterHandling::inAddress)
+                                                        .withExtraHeaders ("Accept: application/octet-stream")
+                                                        .withConnectionTimeoutMs (5000)
+                                                        .withResponseHeaders (&responseHeaders)
+                                                        .withStatusCode (&statusCode)
+                                                        .withNumRedirectsToFollow (1));
+
+        if (inStream != nullptr && statusCode == 200)
+        {
+            int64 total = 0;
+
+            //Use the Url's input stream and write it to a file using output stream
+            std::unique_ptr<FileOutputStream> out = dest.createOutputStream();
+
+            for (;;)
+            {
+                if (threadShouldExit())
+                    return Result::fail ("Cancelled");
+
+
+
+                auto written = out->writeFromInputStream(*inStream, 8192);
+
+                if (written == 0)
+                    break;
+
+                total += written;
+
+                setProgress((double)total / (double)asset.size);
+
+                setStatusMessage ("Downloading... " + File::descriptionOfSizeInBytes (total));
+            }
+
+            out->flush();
+            return Result::ok();
+        }
+
+        return Result::fail ("Failed to download from: " + asset.url);
+    }
+
+    Result install (const File& dest)
+    {
+        setStatusMessage ("Installing...");
+
+        ZipFile zip (dest);
+
+    //     if (zip.getNumEntries() == 0)
+    //         return Result::fail ("The downloaded file was not a valid JUCE file!");
+
+    //     struct ScopedDownloadFolder
+    //     {
+    //         explicit ScopedDownloadFolder (const File& installTargetFolder)
+    //         {
+    //             folder = installTargetFolder.getSiblingFile (installTargetFolder.getFileNameWithoutExtension() + "_download").getNonexistentSibling();
+    //             jassert (folder.createDirectory());
+    //         }
+
+    //         ~ScopedDownloadFolder()   { folder.deleteRecursively(); }
+
+    //         File folder;
+    //     };
+
+    //     ScopedDownloadFolder unzipTarget (targetFolder);
+
+    //     if (! unzipTarget.folder.isDirectory())
+    //         return Result::fail ("Couldn't create a temporary folder to unzip the new version!");
+
+    //     auto r = zip.uncompressTo (unzipTarget.folder);
+
+    //     if (r.failed())
+    //         return r;
+
+    //     if (threadShouldExit())
+    //         return Result::fail ("Cancelled");
+
+    //    #if JUCE_LINUX || JUCE_BSD || JUCE_MAC
+    //     r = setFilePermissions (unzipTarget.folder, zip);
+
+    //     if (r.failed())
+    //         return r;
+
+    //     if (threadShouldExit())
+    //         return Result::fail ("Cancelled");
+    //    #endif
+
+    //     if (targetFolder.exists())
+    //     {
+    //         auto oldFolder = targetFolder.getSiblingFile (targetFolder.getFileNameWithoutExtension() + "_old").getNonexistentSibling();
+
+    //         if (! targetFolder.moveFileTo (oldFolder))
+    //             return Result::fail ("Could not remove the existing folder!\n\n"
+    //                                  "This may happen if you are trying to download into a directory that requires administrator privileges to modify.\n"
+    //                                  "Please select a folder that is writable by the current user.");
+    //     }
+
+    //     if (! unzipTarget.folder.getChildFile ("JUCE").moveFileTo (targetFolder))
+    //         return Result::fail ("Could not overwrite the existing folder!\n\n"
+    //                              "This may happen if you are trying to download into a directory that requires administrator privileges to modify.\n"
+    //                              "Please select a folder that is writable by the current user.");
+
+    //     return Result::ok();
+    }
+
+    Result setFilePermissions (const File& root, const ZipFile& zip)
+    {
+        // constexpr uint32 executableFlag = (1 << 22);
+
+        // for (int i = 0; i < zip.getNumEntries(); ++i)
+        // {
+        //     auto* entry = zip.getEntry (i);
+
+        //     if ((entry->externalFileAttributes & executableFlag) != 0 && entry->filename.getLastCharacter() != '/')
+        //     {
+        //         auto exeFile = root.getChildFile (entry->filename);
+
+        //         if (! exeFile.exists())
+        //             return Result::fail ("Failed to find executable file when setting permissions " + exeFile.getFileName());
+
+        //         if (! exeFile.setExecutePermission (true))
+        //             return Result::fail ("Failed to set executable file permission for " + exeFile.getFileName());
+        //     }
+        // }
+
+        // return Result::ok();
+    }
+
+    const LatestVersionCheckerAndUpdater::Asset asset;
+    File targetFolder;
+    std::function<void()> completionCallback;
+};
+
+static void restartProcess (const File& targetFolder)
+{
+   #if JUCE_MAC || JUCE_LINUX || JUCE_BSD
+    #if JUCE_MAC
+     auto newProcess = targetFolder.getChildFile ("Projucer.app").getChildFile ("Contents").getChildFile ("MacOS").getChildFile ("Projucer");
+    #elif JUCE_LINUX || JUCE_BSD
+     auto newProcess = targetFolder.getChildFile ("Projucer");
+    #endif
+
+    StringArray command ("/bin/sh", "-c", "while killall -0 Projucer; do sleep 5; done; " + newProcess.getFullPathName().quoted());
+   #elif JUCE_WINDOWS
+    auto newProcess = targetFolder.getChildFile ("Projucer.exe");
+
+    auto command = "cmd.exe /c\"@echo off & for /l %a in (0) do ( tasklist | find \"Projucer\" >nul & ( if errorlevel 1 ( "
+                    + targetFolder.getChildFile ("Projucer.exe").getFullPathName().quoted() + " & exit /b ) else ( timeout /t 10 >nul ) ) )\"";
+   #endif
+
+    if (newProcess.existsAsFile())
+    {
+        ChildProcess restartProcess;
+        restartProcess.start (command, 0);
+
+        JUCEApplication::getInstance()->systemRequestedQuit();
+    }
+}
+
+void LatestVersionCheckerAndUpdater::downloadAndInstall (const Asset& asset, const File& targetFolder)
+{
+    installer.reset (new DownloadAndInstallThread (asset, targetFolder,
+                                                   [this, targetFolder]
+                                                   {
+                                                       installer.reset();
+                                
+                                                    //    restartProcess (targetFolder);
+                                                   }));
+}
+
+//==============================================================================
+JUCE_IMPLEMENT_SINGLETON (LatestVersionCheckerAndUpdater)

--- a/Source/AutoUpdater.h
+++ b/Source/AutoUpdater.h
@@ -26,6 +26,7 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 
+class MainWindow;
 class DownloadThread;
 
 class LatestVersionCheckerAndUpdater   : public DeletedAtShutdown,
@@ -42,7 +43,7 @@ public:
         const int size;
     };
 
-    void checkForNewVersion (bool isBackgroundCheck);
+    void checkForNewVersion (bool isBackgroundCheck, MainWindow* mw);
 
     //==============================================================================
     JUCE_DECLARE_SINGLETON_SINGLETHREADED_MINIMAL (LatestVersionCheckerAndUpdater)
@@ -56,6 +57,7 @@ private:
 
     //==============================================================================
     bool backgroundCheck = false;
+    MainWindow* mainWindow;
 
     std::unique_ptr<DownloadThread> downloader;
     std::unique_ptr<Component> dialogWindow;

--- a/Source/AutoUpdater.h
+++ b/Source/AutoUpdater.h
@@ -1,0 +1,62 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2023 Open Ephys
+
+    ------------------------------------------------------------------
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    Reference : https://github.com/juce-framework/JUCE/blob/6.0.8/extras/Projucer/Source/Application/jucer_AutoUpdater.h
+
+*/
+
+#pragma once
+
+#include "../JuceLibraryCode/JuceHeader.h"
+
+class DownloadAndInstallThread;
+
+class LatestVersionCheckerAndUpdater   : public DeletedAtShutdown,
+                                         private Thread
+{
+public:
+    LatestVersionCheckerAndUpdater();
+    ~LatestVersionCheckerAndUpdater() override;
+
+    struct Asset
+    {
+        const String name;
+        const String url;
+        const int size;
+    };
+
+    void checkForNewVersion (bool isBackgroundCheck);
+
+    //==============================================================================
+    JUCE_DECLARE_SINGLETON_SINGLETHREADED_MINIMAL (LatestVersionCheckerAndUpdater)
+
+private:
+    //==============================================================================
+    void run() override;
+    void askUserAboutNewVersion (const String&, const String&, const Asset& asset);
+    void askUserForLocationToDownload (const Asset& asset);
+    void downloadAndInstall (const Asset& asset, const File& targetFolder);
+
+    //==============================================================================
+    bool backgroundCheck = false;
+
+    std::unique_ptr<DownloadAndInstallThread> installer;
+    std::unique_ptr<Component> dialogWindow;
+};

--- a/Source/AutoUpdater.h
+++ b/Source/AutoUpdater.h
@@ -26,7 +26,7 @@
 
 #include "../JuceLibraryCode/JuceHeader.h"
 
-class DownloadAndInstallThread;
+class DownloadThread;
 
 class LatestVersionCheckerAndUpdater   : public DeletedAtShutdown,
                                          private Thread
@@ -52,11 +52,11 @@ private:
     void run() override;
     void askUserAboutNewVersion (const String&, const String&, const Asset& asset);
     void askUserForLocationToDownload (const Asset& asset);
-    void downloadAndInstall (const Asset& asset, const File& targetFolder);
+    void downloadAndInstall (const Asset& asset, const File& targetFile);
 
     //==============================================================================
     bool backgroundCheck = false;
 
-    std::unique_ptr<DownloadAndInstallThread> installer;
+    std::unique_ptr<DownloadThread> downloader;
     std::unique_ptr<Component> dialogWindow;
 };

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -4,6 +4,8 @@
 add_sources(open-ephys 
 	AccessClass.h
 	AccessClass.cpp
+	AutoUpdater.cpp
+	AutoUpdater.h
 	CoreServices.h
 	CoreServices.cpp
 	MainWindow.h

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -25,6 +25,7 @@
 #include "Utils/OpenEphysHttpServer.h"
 #include "UI/UIComponent.h"
 #include "UI/EditorViewport.h"
+#include "AutoUpdater.h"
 #include <stdio.h>
 
 
@@ -59,6 +60,7 @@ MainWindow::MainWindow(const File& fileToLoad)
 	shouldReloadOnStartup = true;
 	shouldEnableHttpServer = true;
 	openDefaultConfigWindow = false;
+	automaticVersionChecking = true;
 
 	// Create ProcessorGraph and AudioComponent, and connect them.
 	// Callbacks will be set by the play button in the control panel
@@ -159,6 +161,9 @@ MainWindow::MainWindow(const File& fileToLoad)
 	else {
 		disableHttpServer();
 	}
+
+	if(automaticVersionChecking)
+		LatestVersionCheckerAndUpdater::getInstance()->checkForNewVersion (true, this);
 
 }
 
@@ -267,6 +272,7 @@ void MainWindow::saveWindowBounds()
 	xml->setAttribute("version", JUCEApplication::getInstance()->getApplicationVersion());
 	xml->setAttribute("shouldReloadOnStartup", shouldReloadOnStartup);
 	xml->setAttribute("shouldEnableHttpServer", shouldEnableHttpServer);
+	xml->setAttribute("automaticVersionChecking", automaticVersionChecking);
 
 	XmlElement* bounds = new XmlElement("BOUNDS");
 	bounds->setAttribute("x",getScreenX());
@@ -330,6 +336,7 @@ void MainWindow::loadWindowBounds()
 
 		shouldReloadOnStartup = xml->getBoolAttribute("shouldReloadOnStartup", false);
 		shouldEnableHttpServer = xml->getBoolAttribute("shouldEnableHttpServer", false);
+		automaticVersionChecking = xml->getBoolAttribute("automaticVersionChecking", true);
 
 		for (auto* e : xml->getChildIterator())
 		{

--- a/Source/MainWindow.cpp
+++ b/Source/MainWindow.cpp
@@ -162,9 +162,10 @@ MainWindow::MainWindow(const File& fileToLoad)
 		disableHttpServer();
 	}
 
+#ifdef NDEBUG
 	if(automaticVersionChecking)
 		LatestVersionCheckerAndUpdater::getInstance()->checkForNewVersion (true, this);
-
+#endif
 }
 
 MainWindow::~MainWindow()

--- a/Source/MainWindow.h
+++ b/Source/MainWindow.h
@@ -68,7 +68,11 @@ public:
     /** Determines whether the ProcessorGraph http server is enabled. */
     bool shouldEnableHttpServer;
 
+    /** Determines whether the default config selection window needs to open on startup. */
     bool openDefaultConfigWindow;
+
+    /** Determines whether the Auto Updater needs to run on startup. */
+    bool automaticVersionChecking;
 
     /** Ends the process() callbacks and disables all processors.*/
 	void shutDownGUI();

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -36,6 +36,7 @@
 #include "../Processors/ProcessorGraph/ProcessorGraph.h"
 #include "../Audio/AudioComponent.h"
 #include "../MainWindow.h"
+#include "../AutoUpdater.h"
 
 	UIComponent::UIComponent(MainWindow* mainWindow_, ProcessorGraph* pgraph, AudioComponent* audio_)
 : mainWindow(mainWindow_), processorGraph(pgraph), audio(audio_), messageCenterIsCollapsed(true)
@@ -476,6 +477,7 @@ PopupMenu UIComponent::getMenuForIndex(int menuIndex, const String& menuName)
 	else if (menuIndex == 3)
 	{
 		menu.addCommandItem(commandManager, showHelp);
+		menu.addCommandItem(commandManager, checkForUpdates);
 	}
 
 	return menu;
@@ -518,6 +520,7 @@ void UIComponent::getAllCommands(Array <CommandID>& commands)
 		setClockModeDefault,
 		setClockModeHHMMSS,
 		showHelp,
+		checkForUpdates,
 		resizeWindow,
 		openPluginInstaller,
 		openDefaultConfigWindow
@@ -648,6 +651,11 @@ void UIComponent::getCommandInfo(CommandID commandID, ApplicationCommandInfo& re
 
 		case showHelp:
 			result.setInfo("Online documentation...", "Launch the GUI's documentation website in a browser.", "General", 0);
+			result.setActive(true);
+			break;
+
+		case checkForUpdates:
+			result.setInfo("Check for updates", "Checks if a newer version of the GUI is available", "General", 0);
 			result.setActive(true);
 			break;
 
@@ -850,6 +858,12 @@ bool UIComponent::perform(const InvocationInfo& info)
 			{
 				URL url = URL("https://open-ephys.github.io/gui-docs/");
 				url.launchInDefaultBrowser();
+				break;
+			}
+		
+		case checkForUpdates:
+			{
+				LatestVersionCheckerAndUpdater::getInstance()->checkForNewVersion (false);
 				break;
 			}
 

--- a/Source/UI/UIComponent.cpp
+++ b/Source/UI/UIComponent.cpp
@@ -863,7 +863,7 @@ bool UIComponent::perform(const InvocationInfo& info)
 		
 		case checkForUpdates:
 			{
-				LatestVersionCheckerAndUpdater::getInstance()->checkForNewVersion (false);
+				LatestVersionCheckerAndUpdater::getInstance()->checkForNewVersion (false, mainWindow);
 				break;
 			}
 

--- a/Source/UI/UIComponent.h
+++ b/Source/UI/UIComponent.h
@@ -206,6 +206,7 @@ private:
 		setClockModeHHMMSS      = 0x2112,
         toggleHttpServer        = 0x4001,
         showHelp				= 0x2011,
+        checkForUpdates         = 0x2022,
         resizeWindow            = 0x2012,
         reloadOnStartup         = 0x2013,
         saveSignalChainAs       = 0x2014,


### PR DESCRIPTION
Adds an automatic update checker and downloader to the GUI.

 - Checks for updates automatically on Launch (in background). Can be disabled in the update notifier pop-up.
 - Manual update checking by clicking on `Help -> Check for updates`
 - Automatically identifies the type of installation and downloads the relevant binaries (installer vs zip). User is asked for the download location
 - On Windows, if installer is being used, launches the installer for the user.
 - Shows state-specific message boxes as well as a download progress bar.