### PR TITLE
Fix LoadLibrary not searching the full DLL tree

### DIFF
--- a/Source/Processors/PluginManager/PluginManager.cpp
+++ b/Source/Processors/PluginManager/PluginManager.cpp
@@ -120,6 +120,7 @@ PluginManager::PluginManager()
         }
         AddDllDirectory (installSharedPath.getFullPathName().toWideCharPointer());
     }
+    SetDefaultDllDirectories (LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 #elif __linux__
     File installSharedPath = File::getSpecialLocation (File::userApplicationDataDirectory)


### PR DESCRIPTION
For some reason, changing from `SetDllDirectory()` to `AddDllDirectory()` makes plugins trying dynamic loading through  `LoadLibrary()` not search in the shared directory. 

Adding this line tells the linker to search in all default directories. As per [Microsoft Documentation](https://learn.microsoft.com/en-us/windows/win32/api/LibLoaderAPI/nf-libloaderapi-setdefaultdlldirectories):

> This value is a combination of LOAD_LIBRARY_SEARCH_APPLICATION_DIR, LOAD_LIBRARY_SEARCH_SYSTEM32, and LOAD_LIBRARY_SEARCH_USER_DIRS.
> This value represents the recommended maximum number of directories an application should include in its DLL search path.

An example was the acquisition board plugin with ONI. The plugin was loaded. The plugin could load liboni.dll from shared through the implicit linker, but the call to `LoadLibrary()` failed. This PR fixes this behavior and should not affect others, but please test it if required.
