### PR TITLE
Issue: submitting interleaved or sequential data (chunkSize != 1) to DataThread/DataBuffer

### DIFF
--- a/Source/Processors/DataThreads/DataBuffer.h
+++ b/Source/Processors/DataThreads/DataBuffer.h
@@ -46,6 +46,32 @@ public:
     void clear();
 
     /** Add an array of floats to the buffer.
+        The data is laid out as a set of channels with a series of samples per channel.
+        The number of samples (chunkSize) in each sequence can be from 1..numItems.
+
+        Examples:
+        In the following examples, the numbers shown in the data indicate the channel #.
+
+        numItems = 4
+        chunkSize = 1
+        # channels = 3
+
+        Data:
+        1 2 3 1 2 3 1 2 3 1 2 3
+
+        numItems = 4
+        chunkSize = 2
+        # channels = 3
+
+        Data:
+        1 1 2 2 3 3 1 1 2 2 3 3
+
+        numItmes = 4
+        chunkSize = 4
+        # channels = 3
+
+        Data:
+        1 1 1 1 2 2 2 2 3 3 3 3
 
         @param data The data.
         @param sampleNumbers  Array of sample numbers (integers). Same length as numItems.
@@ -53,7 +79,8 @@ public:
         @param eventCodes Array of event codes. Same length as numItems.
         @param numItems Total number of samples per channel.
         @param chunkSize Number of consecutive samples per channel per chunk.
-        1 by default. Typically 1 or numItems.
+        1 by default. Typically, 1 or numItems.
+        Must be a multiple of numItems.
 
         @return The number of items actually written. May be less than numItems if
         the buffer doesn't have space.


### PR DESCRIPTION
Resolution to thread: https://github.com/open-ephys/plugin-GUI/issues/556

The _DataBuffer::addToBuffer_ method, as written, only copies data correctly if _chunkSize_ = 1. 

Fixes included:

1) Allowing _chunkSize_ of any value that is a multiple of _numItems_ (it wouldn't make sense, otherwise).
2) Handling the case where a _chunkSize_ copy is split between end-of-buffer and start-of-buffer for the circular buffer.
3) Optimizations of when contiguous data is copied; in particular with the vectors _timestamps_ _sequenceNumbers_, and _eventCodes_.
4) Added clarity to the functionality of _addToBuffer_, with examples, to the header comment for the method.

Testing was performed using a sin wave as input across multiple channels in a _DataThread::updateBuffer_ method:

```
  static int cntr{0};
  static int index{0};
  static int groups[] = {1, 2, 5, 10};

  std::vector<float> raw_samples;
  raw_samples.reserve(NUMBER_CHANNELS * MAX_SAMPLES_PER_CHANNEL);

  if (cntr++ == mSampleRate * 3) {
    if (++index == 4) {
      index = 0;
    }
    cntr = 0;
  }

  float* buf = raw_samples.data();
  auto grouping{groups[index]};

  for (auto i = 0; i < MAX_SAMPLES_PER_CHANNEL; i += grouping) {

    for (int chan = 0; chan < NUMBER_CHANNELS; ++chan) {
      for (auto j = 0; j < grouping; j++) {
        *buf++ = ::sinf(mSample[chan]) * 40;
        mSample[chan] += static_cast<float>(M_PI) * 2.0f / (mSampleRate * chan+1);
      }

    }
  }

  mDataBuffer->addToBuffer(raw_samples.data(), sample_numbers, timestamps,
    event_codes, MAX_SAMPLES_PER_CHANNEL, grouping);
```

MAX_SAMPLES_PER_CHANNEL was set to 10, the buffer size to 1024. This was done to create a scenario where a _chunkSize_ copy could be split across the circular buffer.

PS - Although I've been developing code for over 30 years, this is my first contribution to open source. If in any of this process, I've made a faux pas, provide grace and allow it to be a teaching moment. Thanks for considering this update to your project.
