### PR TITLE
[WIP] Record Node directory - offer permanent link to control panel

### DIFF
--- a/Source/Processors/Parameter/Parameter.cpp
+++ b/Source/Processors/Parameter/Parameter.cpp
@@ -1230,6 +1230,9 @@ void PathParameter::setNextValue (var newValue_, bool undoable)
         else if (isDirectory && File (newValue_.toString()).exists())
         {
             newValue = newValue_;
+        } else if (!isRequired && newValue_.toString() == "None")
+        {
+            newValue = newValue_;
         }
 
         if (! undoable)

--- a/Source/Processors/Parameter/Parameter.h
+++ b/Source/Processors/Parameter/Parameter.h
@@ -962,11 +962,15 @@ public:
     /** Returns true if the path should be a directory */
     bool getIsDirectory() { return isDirectory; }
 
+    /** Returns true if the path is required */
+    bool getIsRequired() { return isRequired; }
+
     /** Returns a list of valid file extensions if applicable */
     StringArray getValidFilePatterns() { return filePatternsAllowed; }
 
     /** Returns true if the current path is valid for this parameter */
     bool isValid() override;
+
 
 private:
     StringArray filePatternsAllowed;

--- a/Source/Processors/Parameter/ParameterEditor.h
+++ b/Source/Processors/Parameter/ParameterEditor.h
@@ -575,8 +575,12 @@ public:
     /** Sets sub-component locations */
     virtual void resized() override;
 
+    void mouseEnter(const juce::MouseEvent&) override;
+    void mouseExit(const juce::MouseEvent&) override;
+
 private:
     std::unique_ptr<TextButton> button;
+    std::unique_ptr<TextButton> clearButton;
 };
 
 class PLUGIN_API TimeParameterEditor : public ParameterEditor,

--- a/Source/Processors/RecordNode/RecordNode.cpp
+++ b/Source/Processors/RecordNode/RecordNode.cpp
@@ -106,7 +106,7 @@ RecordNode::~RecordNode()
 void RecordNode::registerParameters()
 {
     String defaultRecordDirectory = CoreServices::getRecordingParentDirectory().getFullPathName();
-    addPathParameter (Parameter::PROCESSOR_SCOPE, "directory", "Directory", "Select a directory to write data to", defaultRecordDirectory, {}, true, true);
+    addPathParameter (Parameter::PROCESSOR_SCOPE, "directory", "Directory", "Select a directory to write data to", defaultRecordDirectory, {}, true, false);
 
     Array<String> recordEngines;
     std::vector<RecordEngineManager*> engines = getAvailableRecordEngines();


### PR DESCRIPTION
As far as i understand the control panel default path is copied to the record node when it's instantiated. But if the control panel changes after that the record node does not change.  Assuming i've understood that correctly, I do find that confusing.

Here I propose the path parameter on the record node has `isRequired` set to `false`, and the value set to `None` by default. The`None` value is rendered like this:
![Screenshot 2025-04-27 at 23 52 47](https://github.com/user-attachments/assets/82cedddf-73a1-4eb3-957a-edc4d48ddfa8)

When you click that, you get the existing folder picker which lets you pick a custom directory. If you have selected a custom dir, it looks no different to prior to the PR:
![Screenshot 2025-04-27 at 23 54 35](https://github.com/user-attachments/assets/0ce27c73-e39e-4de5-896c-7a0bbc4a6d83)

However, when you mouse over the path you now get the option to clear it:
![Screenshot 2025-04-27 at 23 49 30](https://github.com/user-attachments/assets/79f8cc0e-d74f-4279-bf9b-b2baaf19c146)

(if you click the 'x' it goes back to the `None` state, otherwise if you click the main part of the path it opens the file picker as before).

I think I've implemented the UI aspect of this correctly, but the actual dataDir stuff I don't think I've quite got right as it needs to either listen for changes in the control panel (i haven't checked how to do this), or when the recording starts it should check at that point. I make look myself shortly, but welcome to suggestions on the right way to do that.

I appriciate this is not the most exciting feature, and I have dived straight in with a PR rather than discussing, but I won't be offended if it doesn't quite make sense in terms of UX and/or implementation.