### PR TITLE
Show the channel number in the tooltip, even if it is not shown on the left of the LFP viewer

### DIFF
--- a/Plugins/LfpViewer/LfpChannelDisplayInfo.cpp
+++ b/Plugins/LfpViewer/LfpChannelDisplayInfo.cpp
@@ -325,8 +325,7 @@ bool LfpChannelDisplayInfo::isChannelNumberHidden()
 String LfpChannelDisplayInfo::getTooltip()
 {
     const bool showChannelNumbers = options->getChannelNameState();
-    const String channelString = (isChannelNumberHidden() ? ("--") : showChannelNumbers ? String (getChannelNumber() + 1)
-                                                                                        : getName());
+    const String channelString = showChannelNumbers ? String (getChannelNumber() + 1) : getName();
 
     return channelString;
 }


### PR DESCRIPTION
I noticed that, when the channel height is small, channel numbers are replaced by `--` on the left of the LFP viewer. However, the text of the tooltip is also replaced by `--` which makes it impossible to know what channel one is looking at.

<img width="135" height="163" alt="image" src="https://github.com/user-attachments/assets/7421e0d5-b260-4fb3-b7bf-e064d2ebb071" />

I made a simple change so that the channel number is always shown in the tooltip.
<img width="118" height="154" alt="image" src="https://github.com/user-attachments/assets/47e7c0ea-ee79-495f-915f-39e889619929" />

