### PR TITLE
recordEngine - improve writeTimestampSyncText signature

### DIFF
--- a/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.cpp
+++ b/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.cpp
@@ -672,7 +672,7 @@ void BinaryRecording::writeSpike (int electrodeIndex, const Spike* spike)
     increaseEventCounts (rec);
 }
 
-void BinaryRecording::writeTimestampSyncText (uint64 streamId, int64 sampleNumber, float sourceSampleRate, String text)
+void BinaryRecording::writeTimestampSyncText(DataStream* stream, int64 sampleNumber, double timestamp, String text) 
 {
     if (! m_syncTextFile)
         return;
@@ -680,11 +680,10 @@ void BinaryRecording::writeTimestampSyncText (uint64 streamId, int64 sampleNumbe
     String syncString = text + ": " + String (sampleNumber);
     LOGD (syncString);
 
-    int64 fsn = firstSampleNumber[streamId];
-
-    if(streamId > 0)
+    if(stream != nullptr){
+        int64 fsn = firstSampleNumber[stream->getStreamId()];
         jassert (fsn == sampleNumber);
-
+    }
     m_syncTextFile->writeText (syncString + "\r\n", false, false, nullptr);
     
     m_syncTextFile->flush();

--- a/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.h
+++ b/Source/Processors/RecordNode/BinaryFormat/BinaryRecording.h
@@ -69,7 +69,7 @@ public:
     void writeSpike (int electrodeIndex, const Spike* spike);
 
     /** Writes timestamp sync texts */
-    void writeTimestampSyncText (uint64 streamId, int64 sampleNumber, float sampleRate, String text);
+    void writeTimestampSyncText (DataStream* stream, int64 sampleNumber, double timestamp, String text);
 
     /** Sets an engine parameter (in this case TTL word writing bool) */
     void setParameter (EngineParameter& parameter);

--- a/Source/Processors/RecordNode/RecordEngine.cpp
+++ b/Source/Processors/RecordNode/RecordEngine.cpp
@@ -111,6 +111,11 @@ int RecordEngine::getLocalIndex (int channel) const
     return localChannelMap[channel];
 }
 
+Array<const DataStream*> RecordEngine::getDataStreams() const
+{
+    return recordNode->getDataStreams();
+}
+
 int RecordEngine::getNumRecordedDataStreams() const
 {
     return recordNode->getTotalRecordedStreams();

--- a/Source/Processors/RecordNode/RecordEngine.h
+++ b/Source/Processors/RecordNode/RecordEngine.h
@@ -104,8 +104,8 @@ public:
     /** Write a spike to disk */
     virtual void writeSpike (int electrodeIndex, const Spike* spike) = 0;
 
-    /** Handle the timestamp sync text messages*/
-    virtual void writeTimestampSyncText (uint64 streamId, int64 timestamp, float sourceSampleRate, String text) = 0;
+    /** Handle the timestamp sync text messages. */
+    virtual void writeTimestampSyncText (DataStream* stream, int64 sampleNumber, double timestamp, String text) = 0;
 
     // ------------------------------------------------------------
     //                   VIRTUAL METHODS

--- a/Source/Processors/RecordNode/RecordEngine.h
+++ b/Source/Processors/RecordNode/RecordEngine.h
@@ -145,6 +145,9 @@ protected:
     /** Gets the number of recorded data streams */
     int getNumRecordedDataStreams() const;
 
+    /** Gets all the data streams, regardless of whether they have any recordable channels */
+    Array<const DataStream*> getDataStreams() const;
+
     /** Gets the number of recorded continuous channels */
     int getNumRecordedContinuousChannels() const;
 

--- a/Source/Processors/RecordNode/RecordThread.cpp
+++ b/Source/Processors/RecordNode/RecordThread.cpp
@@ -240,7 +240,19 @@ void RecordThread::writeData (const AudioBuffer<float>& dataBuffer,
         if (SystemEvent::getBaseType (event) == EventBase::Type::SYSTEM_EVENT)
         {
             String syncText = SystemEvent::getSyncText (event);
-            m_engine->writeTimestampSyncText (SystemEvent::getStreamId (event), SystemEvent::getSampleNumber (event), 0.0f, SystemEvent::getSyncText (event));
+            auto streamId = SystemEvent::getStreamId (event);
+            DataStream* stream = recordNode->getDataStream(streamId);
+            int64 sampleNumber = SystemEvent::getSampleNumber (event);
+            
+            double timestamp;
+            if (stream == nullptr){
+                timestamp = 0;
+            } else if(recordNode->synchronizer.streamGeneratesTimestamps (stream->getKey())){
+                timestamp = static_cast<double>(sampleNumber) / stream->getSampleRate();
+            } else {
+                timestamp = recordNode->synchronizer.convertSampleNumberToTimestamp (stream->getKey(), sampleNumber);
+            }   
+            m_engine->writeTimestampSyncText (stream, sampleNumber, timestamp, SystemEvent::getSyncText (event));
         }
         else
         {


### PR DESCRIPTION
The old version had a few quirks:

1. Provides `streamId`, but there is no way to lookup a stream by `streamId` within the record engine, only by index.
2. Provides `0` for the `sourceSampleRate` (this is hardcoded at the one call site), so this param is useless.
3. Despite being called "..Timestamp.." it provides the `sampleNumber` rather than a timestamp. This is also especially painful as the other virtual functions on the record engine recieve timestamps not sample numbers, and I don't think you have access to the synchroniser to do the conversion in either direction.

So to address that, I suggest:

- A. Provide a `DataStream*` rather than a `streamId`, this means you can also get any properties you want from the stream, such as the sample rate.  A `nullptr` can be provided for this arg if needed, and indeed it seems it is (I don't quite understand how/why that is happening, but the `writeTimestampSyncText` function has historically been called with a non-stream first).
 - B. Provide the timestamp as well as the sampleNumber. This timestamp should match up to the timestamps provided to the other vitual functions.
 
 This is of course a breaking change to the plugin api. But it should be pretty trivial to migrate given you can always call `stream == nullptr ? 0 : stream->getStreamId()` to recover the `streamId`, and aside from that we haven't lost anything (given the `sourceSampleRate` was never providing any actual data, and the new `timestamp` arg is an addition.
 
 In terms of thread-saftey considerations, as far as I understand I'm not doing anything especially novel in the `RecordThread`, but worth someone who understands things better checking this.
 
 In terms of the `timestamp` calculation, it would be good for someone to confirm this is right. I adapted the logic from the call to `dataQueue->writeSynchronizedTimestamps(..)` within `RecordNode::process`.
 
 -- 

In addition to the main change here, I've also added a `getDataStreams()` function on the `RecordEngine`, wrapping the function on the underlying `recordNode`. 

Without that there was no way to iterate over the streams safely, as far as I can tell. You might think you can iterate from `0` to `getNumRecordedDataStreams()`, and call `getDataStream(index)` in each case, but that doesn't work because `getNumRecordedDataStreams` can return a number less than the total number of streams, and there's no reason that the recorded stream(s) are guaranteeed to come first in the list (i.e. if you stop iterating too soon you might miss actual recorded streams).
 
**TODO:** 
  - [ ] Update `PLUGIN_API_VER`, presumably.
  
  
 I have posted about this in discord [here](https://discord.com/channels/932637696503971850/1118929476114456648/1410235049969844256).
